### PR TITLE
[Bug fix] Redid the package argument parsing

### DIFF
--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -12,8 +12,6 @@ import sys
 import logging
 import yaml
 import traceback
-import re
-import argparse
 from edk2toollib.uefi.edk2.path_utilities import Edk2Path
 from edk2toollib.log.junit_report_format import JunitTestReport
 from edk2toolext.edk2_invocable import Edk2Invocable

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -112,9 +112,9 @@ class Edk2CiBuild(Edk2Invocable):
         '''  Add command line options to the argparser '''
         # This will parse the packages that we are going to build
         parser.add_argument('-p', '--pkg', '--pkg-dir', dest='packageList', type=str,
-                            help='A package or folder you want to test (abs path or cwd relative).'
-                            'Can list multiple by doing -p <pkg1>,<pkg2> or -p <pkg3> -p <pkg4>. It must end in Pkg.',
-                            action="append")
+                            help='A package or folder you want to test (workspace relative).'
+                            'Can list multiple by doing -p <pkg1>,<pkg2> or -p <pkg3> -p <pkg4>',
+                            action="append", default=[])
 
     def RetrieveCommandLineOptions(self, args):
         '''  Retrieve command line options from the argparser '''

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -115,12 +115,9 @@ class Edk2CiBuild(Edk2Invocable):
         return logging.DEBUG
 
     def AddCommandLineOptions(self, parser):
-        # Make sure the packages passed in match
-        def package_regex_type(s, pat=re.compile(r"[a-zA-Z0-9_]*Pkg(,\s*[a-zA-Z0-9_]*Pkg)*")):
-            if not pat.match(s):
-                raise argparse.ArgumentTypeError
-            return s
-        parser.add_argument('-p', '--pkg', '--pkg-dir', dest='packageList', type=package_regex_type,
+        '''  Add command line options to the argparser '''
+        # This will parse the packages that we are going to build
+        parser.add_argument('-p', '--pkg', '--pkg-dir', dest='packageList', type=str,
                             help='A package or folder you want to test (abs path or cwd relative).'
                             'Can list multiple by doing -p <pkg1>,<pkg2> or -p <pkg3> -p <pkg4>. It must end in Pkg.',
                             action="append")

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -122,7 +122,8 @@ class Edk2CiBuild(Edk2Invocable):
             return s
         parser.add_argument('-p', '--pkg', '--pkg-dir', dest='packageList', type=package_regex_type,
                             help='A package or folder you want to test (abs path or cwd relative).'
-                            'Can list multiple by doing -p <pkg1>,<pkg2> or -p <pkg3> -p <pkg4>. It must end in Pkg.', action="append")
+                            'Can list multiple by doing -p <pkg1>,<pkg2> or -p <pkg3> -p <pkg4>. It must end in Pkg.',
+                            action="append")
 
     def RetrieveCommandLineOptions(self, args):
         '''  Retrieve command line options from the argparser '''


### PR DESCRIPTION
Fixes #15 but basically the argument parsing for -p was using nargs and consuming other arguments. A few solutions were proposed and we elected to use csv and multiple -p arguments