### PR TITLE
[Bug fix] Fix skipped tests 

### DIFF
--- a/edk2toolext/environment/plugin_manager.py
+++ b/edk2toolext/environment/plugin_manager.py
@@ -33,17 +33,12 @@ class PluginManager(object):
     # Pass tuple of Environment Descriptor dictionaries to be loaded as plugins
     #
     def SetListOfEnvironmentDescriptors(self, newlist):
-        env = shell_environment.GetBuildVars()
         failed = []
         if newlist is None:
             return []
         for a in newlist:
             b = PluginDescriptor(a)
             if(self._load(b) == 0):
-                val = env.GetValue(b.Module.upper())
-                if val and val == "skip":
-                    logging.info(f"{b.Module} turned off by environment variable")
-                    continue
                 self.Descriptors.append(b)
             else:
                 failed.append(a)

--- a/edk2toolext/environment/plugin_manager.py
+++ b/edk2toolext/environment/plugin_manager.py
@@ -10,7 +10,6 @@ import sys
 import os
 import imp
 import logging
-from edk2toolext.environment import shell_environment
 
 
 class PluginDescriptor(object):

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -197,7 +197,7 @@ class Edk2CiBuild(Edk2Invocable):
             logging.log(edk2_logging.SECTION, f"Building {pkgToRunOn} Package")
             logging.info(f"Running on Package: {pkgToRunOn}")
             ts = JunitReport.create_new_testsuite(pkgToRunOn,
-                                                  f"Edk2CiBuild.{self.PlatformSettings.GetGroupName}.{pkgToRunOn}")
+                                                  f"Edk2CiBuild.{self.PlatformSettings.GetGroupName()}.{pkgToRunOn}")
             packagebuildlog_path = os.path.join(log_directory, pkgToRunOn)
             _, txthandle = edk2_logging.setup_txt_logger(
                 packagebuildlog_path, f"BUILDLOG_{pkgToRunOn}", logging_level=logging.DEBUG, isVerbose=True)

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -290,7 +290,7 @@ class Edk2CiBuild(Edk2Invocable):
                                 exp), "UNEXPECTED EXCEPTION")
                             rc = 1
 
-                            if tc.Status == JunitTestReport.JunitReportTestCase.SKIPPED:
+                        if tc.Status == JunitTestReport.JunitReportTestCase.SKIPPED:
                             edk2_logging.log_progress("--->Test Skipped by plugin! %s" % Descriptor.Name)
                         elif (rc != 0):
                             failure_num += 1

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -289,8 +289,10 @@ class Edk2CiBuild(Edk2Invocable):
                             tc.SetError("Exception: {0}".format(
                                 exp), "UNEXPECTED EXCEPTION")
                             rc = 1
-
-                        if(rc != 0):
+                        
+                        if tc.Status == JunitTestReport.JunitReportTestCase.SKIPPED:
+                            edk2_logging.log_progress("--->Test Skipped by plugin! %s" % Descriptor.Name)
+                        elif (rc != 0):
                             failure_num += 1
                             if(rc is None):
                                 logging.error(

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -289,8 +289,8 @@ class Edk2CiBuild(Edk2Invocable):
                             tc.SetError("Exception: {0}".format(
                                 exp), "UNEXPECTED EXCEPTION")
                             rc = 1
-                        
-                        if tc.Status == JunitTestReport.JunitReportTestCase.SKIPPED:
+
+                            if tc.Status == JunitTestReport.JunitReportTestCase.SKIPPED:
                             edk2_logging.log_progress("--->Test Skipped by plugin! %s" % Descriptor.Name)
                         elif (rc != 0):
                             failure_num += 1

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -14,6 +14,7 @@ import yaml
 import traceback
 from edk2toollib.uefi.edk2.path_utilities import Edk2Path
 from edk2toollib.log.junit_report_format import JunitTestReport
+from edk2toollib.log.junit_report_format import JunitReportTestCase
 from edk2toolext.edk2_invocable import Edk2Invocable
 from edk2toolext.environment import self_describing_environment
 from edk2toolext.environment.plugintypes.ci_build_plugin import ICiBuildPlugin
@@ -290,7 +291,7 @@ class Edk2CiBuild(Edk2Invocable):
                                 exp), "UNEXPECTED EXCEPTION")
                             rc = 1
 
-                        if tc.Status == JunitTestReport.JunitReportTestCase.SKIPPED:
+                        if tc.Status == JunitReportTestCase.SKIPPED:
                             edk2_logging.log_progress("--->Test Skipped by plugin! %s" % Descriptor.Name)
                         elif (rc != 0):
                             failure_num += 1

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -252,8 +252,17 @@ class Edk2CiBuild(Edk2Invocable):
                     # perhaps we should ask the validator to run on the package for this target
 
                     # Still need to see if the package decided this should be skipped
-                    if pkg_plugin_configuration is None or\
-                            "skip" in pkg_plugin_configuration and pkg_plugin_configuration["skip"]:
+                    should_skip = False
+                    if pkg_plugin_configuration is None:
+                        should_skip = True
+                    elif "skip" in pkg_plugin_configuration and pkg_plugin_configuration["skip"]:
+                        should_skip = True
+
+                    val = env.GetValue(Descriptor.Module.upper())
+                    if val and val == "skip":
+                        should_skip = True
+
+                    if should_skip:
                         tc.SetSkipped()
                         edk2_logging.log_progress("--->Test Skipped by package! %s" % Descriptor.Name)
 


### PR DESCRIPTION
Previously, when a test is meant to be skipped by the CI build it will not load the plugin, which means it doesn't show up in the JUnit XML. This fixes that. Fixes #13 