### PR TITLE
[Bug fix] Fixed Junit output by removing GetGroupName

### DIFF
--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -50,12 +50,8 @@ class CiBuildSettingsManager():
         ''' get WorkspacePath '''
         raise NotImplementedError()
 
-    def GetGroupName(self):
-        '''  '''
-        raise NotImplementedError()
-
     def GetName(self):
-        '''  '''
+        ''' Get the name of the repo, platform, or product being build by CI '''
         raise NotImplementedError()
 
     def AddCommandLineOptions(self, parserObj):
@@ -197,7 +193,7 @@ class Edk2CiBuild(Edk2Invocable):
             logging.log(edk2_logging.SECTION, f"Building {pkgToRunOn} Package")
             logging.info(f"Running on Package: {pkgToRunOn}")
             ts = JunitReport.create_new_testsuite(pkgToRunOn,
-                                                  f"Edk2CiBuild.{self.PlatformSettings.GetGroupName()}.{pkgToRunOn}")
+                                                  f"Edk2CiBuild.{self.PlatformSettings.GetName()}.{pkgToRunOn}")
             packagebuildlog_path = os.path.join(log_directory, pkgToRunOn)
             _, txthandle = edk2_logging.setup_txt_logger(
                 packagebuildlog_path, f"BUILDLOG_{pkgToRunOn}", logging_level=logging.DEBUG, isVerbose=True)

--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,11 @@ NOTE: It is strongly recommended that you use python virtual environments.  Virt
 
 ## Release Version History
 
+### Version 0.9.4
+
+* Bugs
+  * Issue 14 - XML log created by Stuart_ci_build has incorrect fields
+
 ### Version 0.9.3
 
 * Bugs


### PR DESCRIPTION
Previously, we were using GetGroupName in Junit and instead switched to GetName, which is a bit more standard across CI implementations.