### PR TITLE
Add API to VarDict to alllow override

### DIFF
--- a/edk2toolext/environment/var_dict.py
+++ b/edk2toolext/environment/var_dict.py
@@ -29,7 +29,7 @@ class EnvEntry(object):
     #
 
     def SetValue(self, value, comment, overridable=False):
-        if (value == self.Value):
+        if (value == self.Value) and (overridable == self.Overrideable):
             return True
 
         if(not self.Overrideable):
@@ -40,6 +40,10 @@ class EnvEntry(object):
         self.Value = value
         self.Comment = comment
         self.Overrideable = overridable
+        return True
+
+    def AllowOverride(self):
+        self.Overrideable = True
         return True
 
     def GetValue(self):
@@ -94,6 +98,15 @@ class VarDict(object):
             return True
 
         return en.SetValue(value, comment, overridable)
+
+    def AllowOverride(self, k):
+        key = k.upper()
+        en = self.GetEntry(key)
+        if(en is not None):
+            self.Logger.warn("Allowing Override for key %s" % k)
+            en.AllowOverride()
+            return True
+        return False
 
     #
     # function used to get a build var value for given key and buildtype

--- a/edk2toolext/tests/test_var_dict.py
+++ b/edk2toolext/tests/test_var_dict.py
@@ -61,6 +61,23 @@ class TestVarDict(unittest.TestCase):
         vv = v.GetValue("test1")
         self.assertEqual("value2", vv)
 
+    def test_var_dict_can_change_override_state_with_same_set(self):
+        v = var_dict.VarDict()
+        v.SetValue("test1", "value1", "test 1 comment", True)
+        v.SetValue("test1", "value1", "Change override to false", False)
+        v.SetValue("test1", "value2", "this should fail", False)
+        self.assertNotEqual(v.GetValue("test1"), "value2")
+
+    def test_var_dict_can_change_override_state_with_allow_override(self):
+        v = var_dict.VarDict()
+        v.SetValue("test1", "value1", "test 1 comment", False)
+        v.AllowOverride("test1")
+        v.SetValue("test1", "value2", "this should be allowed", False)
+        self.assertEqual(v.GetValue("test1"), "value2")
+        ## since override was set to False should not change again
+        v.SetValue("test1", "value3", "this should not be allowed", False)
+        self.assertEqual(v.GetValue("test1"), "value2")
+
     def test_var_dict_key_not_case_sensitive(self):
         v = var_dict.VarDict()
         v.SetValue("test1", "value1", "test 1 comment")


### PR DESCRIPTION
VarDict has a unique feature in that it can block override of a value.  This is heavily used in the tool and build flow to make sure that settings with high priority are not overridden later in the process by something with lower priority.  Also it is critical for stability that once a value is set and used that it doesn't change.  

But in some cases for specific usage models it might be needed.  The API makes it possible.  
One such example case is in adapting support for Host Based Unit tests and wanted to only compile Host Tests that will run on the host afterwards.  