### PR TITLE
Fix functionality break in Force Setup.

### DIFF
--- a/edk2toolext/invocables/edk2_setup.py
+++ b/edk2toolext/invocables/edk2_setup.py
@@ -98,7 +98,9 @@ class Edk2PlatformSetup(Edk2Invocable):
                 edk2_logging.log_progress("## Cleaning the root repo...")
                 RunCmd("git", "reset --hard", workingdir=workspace_path,
                        logging_level=logging.DEBUG, raise_exception_on_nonzero=True)
-                RunCmd("git", "clean -xffd", workingdir=workspace_path,
+                # Because logging is running right now, we have to skip the files that are open.
+                ignore_files = "-e Build/%s.txt -e Build/%s.md" % (self.GetLoggingFileName('txt'), self.GetLoggingFileName('md'))
+                RunCmd("git", "clean -xffd %s" % ignore_files, workingdir=workspace_path,
                        logging_level=logging.DEBUG, raise_exception_on_nonzero=True)
                 edk2_logging.log_progress("Done.\n")
 
@@ -107,9 +109,9 @@ class Edk2PlatformSetup(Edk2Invocable):
                     for required_repo in required_repos:
                         edk2_logging.log_progress("## Cleaning Git repository: %s..." % required_repo)
                         required_repo_path = os.path.normpath(os.path.join(workspace_path, required_repo))
-                        RunCmd("git", "reset --hard", workingdir=workspace_path,
+                        RunCmd("git", "reset --hard", workingdir=required_repo_path,
                                logging_level=logging.DEBUG, raise_exception_on_nonzero=True)
-                        RunCmd("git", "clean -xffd", workingdir=workspace_path,
+                        RunCmd("git", "clean -xffd", workingdir=required_repo_path,
                                logging_level=logging.DEBUG, raise_exception_on_nonzero=True)
 
                         edk2_logging.log_progress("Done.\n")

--- a/edk2toolext/invocables/edk2_setup.py
+++ b/edk2toolext/invocables/edk2_setup.py
@@ -99,7 +99,8 @@ class Edk2PlatformSetup(Edk2Invocable):
                 RunCmd("git", "reset --hard", workingdir=workspace_path,
                        logging_level=logging.DEBUG, raise_exception_on_nonzero=True)
                 # Because logging is running right now, we have to skip the files that are open.
-                ignore_files = "-e Build/%s.txt -e Build/%s.md" % (self.GetLoggingFileName('txt'), self.GetLoggingFileName('md'))
+                ignore_files = "-e Build/%s.txt -e Build/%s.md" % (self.GetLoggingFileName('txt'),
+                                                                   self.GetLoggingFileName('md'))
                 RunCmd("git", "clean -xffd %s" % ignore_files, workingdir=workspace_path,
                        logging_level=logging.DEBUG, raise_exception_on_nonzero=True)
                 edk2_logging.log_progress("Done.\n")


### PR DESCRIPTION
Force setup was failing because Git was trying to remove an open log file.

Add exceptions for the log files and fix a couple of bad working_dir paths that were the copy-pasted wrong.