### PR TITLE
[Feature] Reconfiguration of compiler scanning code

### DIFF
--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -217,30 +217,41 @@ def remove_output_stream(handler, logging_namespace=''):
 
 def scan_compiler_output(output_stream):
     # seek to the start of the output stream
+    def output_compiler_error(match, line, start_txt="Compiler"):
+        start, end = match.span()
+        source = line[:start]
+        error = line[end:]
+        num = match.group(1)
+        return  f"{start_txt} #{num} from {source} {error}"
     problems = []
     output_stream.seek(0, 0)
-    error_exp = re.compile(r"error C(\d+):")
+    error_exp = re.compile(r"error [A-EG-Z]?(\d+):")
     edk2_error_exp = re.compile(r"error F(\d+):")
     buildpy_error_exp = re.compile(r"error (\d+)E:")
     linker_error_exp = re.compile(r"error LNK(\d+):")
-    warning_exp = re.compile(r"warning C(\d+):")
+    warning_exp = re.compile(r"warning [A-Z]?(\d+):")
     for raw_line in output_stream.readlines():
         line = raw_line.strip("\n").strip()
         match = error_exp.search(line)
         if match is not None:
-            problems.append((logging.ERROR, "Compile: Error: {0}".format(line)))
+            error = output_compiler_error(match, line, "Compiler")
+            problems.append((logging.ERROR, error))
         match = warning_exp.search(line)
         if match is not None:
-            problems.append((logging.WARNING, "Compile: Warning: {0}".format(line)))
+            error = output_compiler_error(match, line, "Compiler")
+            problems.append((logging.WARNING, error))
         match = linker_error_exp.search(line)
         if match is not None:
-            problems.append((logging.ERROR, "Linker: Error: {0}".format(line)))
+            error = output_compiler_error(match, line, "Linker")
+            problems.append((logging.ERROR, error))
         match = edk2_error_exp.search(line)
         if match is not None:
-            problems.append((logging.ERROR, "EDK2: Error: {0}".format(line)))
+            error = output_compiler_error(match, line, "EDK2")
+            problems.append((logging.ERROR, error))
         match = buildpy_error_exp.search(line)
         if match is not None:
-            problems.append((logging.ERROR, "Build.py: Error: {0}".format(line)))
+            error = output_compiler_error(match, line, "Build.py")
+            problems.append((logging.ERROR, error))
     return problems
 
 

--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -222,7 +222,7 @@ def scan_compiler_output(output_stream):
         source = line[:start]
         error = line[end:]
         num = match.group(1)
-        return  f"{start_txt} #{num} from {source} {error}"
+        return f"{start_txt} #{num} from {source} {error}"
     problems = []
     output_stream.seek(0, 0)
     error_exp = re.compile(r"error [A-EG-Z]?(\d+):")


### PR DESCRIPTION
This will catch more things in the compiler output and standardizes it a bit. In the future, this will need to be retooled to catch more types of bugs as it is current very MSVC/EDK2 specific.

Fixes #34