### PR TITLE
[Bug] misspelling and non-empty path on VsWhere

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-minimal

--- a/edk2toolext/environment/conf_mgmt.py
+++ b/edk2toolext/environment/conf_mgmt.py
@@ -194,7 +194,7 @@ class ConfMgmt():
             if(path is None):
                 # Not specified...find latest
                 (rc, path) = FindWithVsWhere(vs_version=vsversion)
-                if rc == 0 and path is not None:
+                if rc == 0 and path is not None and len(path) > 0:
                     self.Logger.debug("Found VS instance for %s", vsversion)
                     shell_environment.GetEnvironment().set_shell_var(varname, path)
                 else:
@@ -231,5 +231,5 @@ class ConfMgmt():
             return (ipath is not None) and (iver is not None)
 
         else:
-            logging.warning("No dynameic support for this VS toolchain")
+            logging.warning("No dynamic support for this VS toolchain")
             return False

--- a/edk2toolext/environment/conf_mgmt.py
+++ b/edk2toolext/environment/conf_mgmt.py
@@ -194,7 +194,7 @@ class ConfMgmt():
             if(path is None):
                 # Not specified...find latest
                 (rc, path) = FindWithVsWhere(vs_version=vsversion)
-                if rc == 0 and path is not None and len(path) > 0:
+                if rc == 0 and path is not None and os.path.exists(path):
                     self.Logger.debug("Found VS instance for %s", vsversion)
                     shell_environment.GetEnvironment().set_shell_var(varname, path)
                 else:


### PR DESCRIPTION
Check to make sure we actually have a path when we get a result back from VsWhere