### PR TITLE
Fix a small error in the NugetDependency test.

### DIFF
--- a/edk2toolext/tests/test_nuget_dependency.py
+++ b/edk2toolext/tests/test_nuget_dependency.py
@@ -110,7 +110,7 @@ class TestNugetDependency(unittest.TestCase):
 
         ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
         ext_dep = NugetDependency(ext_dep_descriptor)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(ValueError):
             # we should throw an exception because we don't know how to parse the version
             ext_dep.fetch()
         self.assertFalse(ext_dep.verify())


### PR DESCRIPTION
I think that an update in PyTest made this sensitive in a way it didn't used to be.