### PR TITLE
Fix an issue with inconsistent application of normalization.

### DIFF
--- a/edk2toolext/capsule/capsule_helper.py
+++ b/edk2toolext/capsule/capsule_helper.py
@@ -116,6 +116,9 @@ def save_capsule(uefi_capsule_header, capsule_options, save_path):
     will use get_capsule_file_name() to determine the final filename
     will create all intermediate directories if save_path does not already exist
     '''
+    # Expand the version string prior to creating the payload file.
+    capsule_options['fw_version_string'] = get_normalized_version_string(capsule_options['fw_version_string'])
+
     # First, create the entire save path.
     os.makedirs(save_path, exist_ok=True)
 

--- a/edk2toolext/tests/capsule/capsule_helper_test.py
+++ b/edk2toolext/tests/capsule/capsule_helper_test.py
@@ -23,7 +23,7 @@ DUMMY_OPTIONS = {
         'lsv_version': '0xFEEDF00D',
         'esrt_guid': '00112233-4455-6677-8899-aabbccddeeff',
         'fw_name': 'TEST_FW',
-        'fw_version_string': '1.2.3.4',
+        'fw_version_string': '1.2.3',  # deliberately use 3-part version to exercise version normalization.
         'provider_name': 'TESTER',
         'fw_description': 'TEST FW'
     },


### PR DESCRIPTION
Fix an issue where normalization is applied to create_inf_file, but not in save_capsule, resulting in inconsistent payload filename, which causes create_cat_file to fail.