### PR TITLE
Adding a command-line tool for the Windows Firmware Policy Library

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -107,6 +107,8 @@
         "pyopenssl",
         "esrt",
         "noqa",
-        "pymodule"
+        "pymodule",
+        "smbios",
+        "Contoso"
     ]
 }

--- a/docs/usability/using_firmware_policy_tool.md
+++ b/docs/usability/using_firmware_policy_tool.md
@@ -1,0 +1,51 @@
+# Windows Firmware Policy Command-Line Tool
+
+A simple command-line interface to the Windows Firmware Policy Library.
+
+## Usage info
+
+General:
+
+``` cmd
+firmware_policy_tool.py <action> <positional_parameter1> ... [-optional_parameter1] ...
+```
+
+Enumerating the supported actions and parameters for those actions:
+
+``` cmd
+firmware_policy_tool.py -h
+
+firmware_policy_tool.py <action> -h
+
+firmware_policy_tool.py create -h
+usage: firmware_policy_tool.py create [-h] [--OEM1 OEM1] [--OEM2 OEM2]
+                                      PolicyFilename Manufacturer Product
+                                      SerialNumber NonceHex DevicePolicyHex
+
+positional arguments:
+  PolicyFilename   The name of the binary policy file to create
+  Manufacturer     Manufacturer Name, for example, "Contoso Computers, LLC".
+                   Should match the EV Certificate Subject CN="Manufacturer"
+  Product          Product Name, for example, "Laptop Foo"
+  SerialNumber     Serial Number, for example "F0013-000243546-X02". Should
+                   match SmbiosSystemSerialNumber, SMBIOS System Information
+                   (Type 1 Table) -> Serial Number
+  NonceHex         The nonce in hexadecimal, for example "0x0123456789abcdef"
+  DevicePolicyHex  The device policy in hexadecimal, for example to clear the
+                   TPM and delete Secure Boot keys: 0x3
+
+optional arguments:
+  -h, --help       show this help message and exit
+  --OEM1 OEM1      Optional OEM Field 1, an arbitrary length string, for
+                   example "ODM foo"
+  --OEM2 OEM2      Optional OEM Field 2, an arbitrary length string
+```
+
+Examples of ```create``` to create an unsigned Windows Firmware Policy binary blob,
+and ```parse``` to parse an unsigned Windows Firmware Policy binary blob and print it in human understandable form.
+
+``` cmd
+firmware_policy_tool.py create .\test.bin "Contoso LLC." "Laptop Pro" "000-0012345-00S" 0x1a2b3c4d5e6f7890 0x3 --OEM1 "ODM Number One"
+
+firmware_policy_tool.py parse .\test.bin
+```

--- a/edk2toolext/windows/policy/firmware_policy_tool.py
+++ b/edk2toolext/windows/policy/firmware_policy_tool.py
@@ -11,7 +11,8 @@ from edk2toollib.windows.policy.firmware_policy import FirmwarePolicy
 import argparse
 
 
-def PrintPolicy(filename):
+def PrintPolicy(filename: str) -> None:
+    """Attempts to parse filename as a Windows Firmware Policy and print it"""
     try:
         with open(filename, 'rb') as f:
             policy = FirmwarePolicy(fs=f)
@@ -22,7 +23,12 @@ def PrintPolicy(filename):
 
 
 def CreatePolicyFromParameters(filename: str, manufacturer: str, product: str,
-                               sn: str, nonce: int, oem1: str, oem2: str, devicePolicy: int):
+                               sn: str, nonce: int, oem1: str, oem2: str, devicePolicy: int) -> None:
+    """
+    Populates a Windows FirmwarePolicy object with the provided parameters and serializes it to filename
+    
+    Filename must be a new file, will not overwrite existing files.
+    """
     with open(filename, 'xb') as f:
         policy = FirmwarePolicy()
         TargetInfo = {'Manufacturer': manufacturer,
@@ -38,11 +44,13 @@ def CreatePolicyFromParameters(filename: str, manufacturer: str, product: str,
 
 
 def main():
+    """Parses command-line parameters using ArgumentParser, passing them to helper functions to perform the requests"""
     parser = argparse.ArgumentParser(description='Firmware Policy Tool')
     subparsers = parser.add_subparsers(required=True, dest='action')
 
     parser_create = subparsers.add_parser('create', help='Create a firmware policy')
-    parser_create.add_argument('PolicyFilename', type=str, help='The name of the binary policy file to create')
+    parser_create.add_argument('PolicyFilename', type=str, help='The name of the new binary policy file to create '
+                               '- will not overwrite existing files')
     parser_create.add_argument(
         'Manufacturer', type=str, help='Manufacturer Name, for example, "Contoso Computers, LLC".  '
         'Should match the EV Certificate Subject CN="Manufacturer"')

--- a/edk2toolext/windows/policy/firmware_policy_tool.py
+++ b/edk2toolext/windows/policy/firmware_policy_tool.py
@@ -26,7 +26,7 @@ def CreatePolicyFromParameters(filename: str, manufacturer: str, product: str,
                                sn: str, nonce: int, oem1: str, oem2: str, devicePolicy: int) -> None:
     """
     Populates a Windows FirmwarePolicy object with the provided parameters and serializes it to filename
-    
+
     Filename must be a new file, will not overwrite existing files.
     """
     with open(filename, 'xb') as f:

--- a/edk2toolext/windows/policy/firmware_policy_tool.py
+++ b/edk2toolext/windows/policy/firmware_policy_tool.py
@@ -1,0 +1,79 @@
+# @file
+# Basic command-line interface for creating
+# and decoding Windows Firmware Policy blobs
+#
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+from edk2toollib.windows.policy.firmware_policy import FirmwarePolicy
+import argparse
+
+
+def PrintPolicy(filename):
+    try:
+        with open(filename, 'rb') as f:
+            policy = FirmwarePolicy(fs=f)
+            policy.Print()
+
+    except FileNotFoundError:
+        print('ERROR:  File not found: "{0}"'.format(filename))
+
+
+def CreatePolicyFromParameters(filename: str, manufacturer: str, product: str,
+                               sn: str, nonce: int, oem1: str, oem2: str, devicePolicy: int):
+    with open(filename, 'xb') as f:
+        policy = FirmwarePolicy()
+        TargetInfo = {'Manufacturer': manufacturer,
+                      'Product': product,
+                      'SerialNumber': sn,
+                      'OEM_01': oem1,
+                      'OEM_02': oem2,
+                      'Nonce': nonce}
+        policy.SetDeviceTarget(TargetInfo)
+        policy.SetDevicePolicy(devicePolicy)
+        policy.SerializeToStream(stream=f)
+        policy.Print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Firmware Policy Tool')
+    subparsers = parser.add_subparsers(required=True, dest='action')
+
+    parser_create = subparsers.add_parser('create', help='Create a firmware policy')
+    parser_create.add_argument('PolicyFilename', type=str, help='The name of the binary policy file to create')
+    parser_create.add_argument(
+        'Manufacturer', type=str, help='Manufacturer Name, for example, "Contoso Computers, LLC".  '
+        'Should match the EV Certificate Subject CN="Manufacturer"')
+    parser_create.add_argument('Product', type=str, help='Product Name, for example, "Laptop Foo"')
+    parser_create.add_argument(
+        'SerialNumber', type=str, help='Serial Number, for example "F0013-000243546-X02".  Should match '
+        'SmbiosSystemSerialNumber, SMBIOS System Information (Type 1 Table) -> Serial Number')
+    parser_create.add_argument('NonceHex', type=str, help='The nonce in hexadecimal, for example "0x0123456789abcdef"')
+    parser_create.add_argument('--OEM1', type=str, default='',
+                               help='Optional OEM Field 1, an arbitrary length string, for example "ODM foo"')
+    parser_create.add_argument('--OEM2', type=str, default='', help='Optional OEM Field 2, an arbitrary length string')
+    parser_create.add_argument('DevicePolicyHex', type=str, help='The device policy in hexadecimal,'
+                               ' for example to clear the TPM and delete Secure Boot keys: 0x3')
+
+    parser_print = subparsers.add_parser('parse', help='Parse a firmware policy and print in human readable form')
+    parser_print.add_argument('filename', help='Filename to parse and print')
+
+    options = parser.parse_args()
+
+    print('Options: ', options)
+
+    if options.action == 'create':
+        nonceInt = int(options.NonceHex, 16)
+        devicePolicy = int(options.DevicePolicyHex, 16)
+        CreatePolicyFromParameters(options.PolicyFilename, options.Manufacturer,
+                                   options.Product, options.SerialNumber, nonceInt,
+                                   options.OEM1, options.OEM2, devicePolicy)
+
+    elif options.action == 'parse':
+        PrintPolicy(options.filename)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This enables easy creation of policy binaries from the command-line, and
also decoding binary policy files into something understandable