### PR TITLE
Add support for _embedded_ PKCS7 signing to signtool_signer sign()

### DIFF
--- a/azure-pipelines/templates/spell-test-steps.yml
+++ b/azure-pipelines/templates/spell-test-steps.yml
@@ -3,7 +3,7 @@
 # template file used to install spell checking prerequisites
 # and run spell test
 #
-# Copyright (c) 2019, Microsoft Corporation
+# Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
@@ -13,7 +13,7 @@ parameters:
 steps:
 - task: NodeTool@0
   inputs:
-    versionSpec: '10.x'
+    versionSpec: '12.x'
 
 - script: npm install -g cspell
   displayName: 'Install cspell npm'

--- a/edk2toolext/capsule/pyopenssl_signer.py
+++ b/edk2toolext/capsule/pyopenssl_signer.py
@@ -16,7 +16,7 @@ import warnings
 from OpenSSL import crypto
 
 
-def sign(data, signature_options, signer_options):
+def sign(data: bytes, signature_options: dict, signer_options: dict) -> bytes:
     '''
     primary signing interface. Takes n the signature_options and signer_options
     dictionaries that are used by capsule_tool and capsule_helper
@@ -35,7 +35,7 @@ def sign(data, signature_options, signer_options):
         else:
             raise ValueError(f"Unsupported signature algorithm: {signature_options['sign_alg']}!")
 
-    ''' signature type 'bare' is just a signed digest, no headers/footers or ASN '''
+    ''' signature type 'bare' is just a binary signed digest, no PEM headers/footers or ASN '''
     if signature_options['type'] != 'bare':
         raise ValueError(f"Unsupported signature type: {signature_options['type']}")
     if 'type_options' in signature_options:

--- a/edk2toolext/capsule/pyopenssl_signer.py
+++ b/edk2toolext/capsule/pyopenssl_signer.py
@@ -11,6 +11,7 @@
 
 
 import logging
+import warnings
 
 from OpenSSL import crypto
 

--- a/edk2toolext/capsule/pyopenssl_signer.py
+++ b/edk2toolext/capsule/pyopenssl_signer.py
@@ -21,10 +21,30 @@ def sign(data, signature_options, signer_options):
     dictionaries that are used by capsule_tool and capsule_helper
     '''
     # NOTE: Currently, we only support the necessary algorithms for capsules.
-    if signature_options['sign_alg'] != 'pkcs12':
-        raise ValueError(f"Unsupported signature algorithm: {signature_options['sign_alg']}")
+
+    # The following _if_ clause handles the deprecated signature_option 'sign_alg' for backwards compatibility
+    # when the deprecated option is supplied, this code adds the new, required options based on prior code behavior
+    if 'sign_alg' in signature_options:
+        warnings.warn('Signature_option "sign_alg" is deprecated, use "type"', DeprecationWarning)
+        if signature_options['sign_alg'] == 'pkcs12':
+            # map legacy behavior to new options and backwards-compatible values
+            signature_options['type'] = 'bare'
+            signature_options['encoding'] = 'binary'
+            signer_options['key_file_format'] = 'pkcs12'
+        else:
+            raise ValueError(f"Unsupported signature algorithm: {signature_options['sign_alg']}!")
+
+    ''' signature type 'bare' is just a signed digest, no headers/footers or ASN '''
+    if signature_options['type'] != 'bare':
+        raise ValueError(f"Unsupported signature type: {signature_options['type']}")
+    if 'type_options' in signature_options:
+        raise ValueError(f"Signature type options not supported")
+    if signature_options['encoding'] != 'binary':
+        raise ValueError(f"Unsupported signature encoding: {signature_options['encoding']}")
     if signature_options['hash_alg'] != 'sha256':
         raise ValueError(f"Unsupported hashing algorithm: {signature_options['hash_alg']}")
+    if signer_options['key_file_format'] != 'pkcs12':
+        raise ValueError(f"Unsupported signer key file format: {signer_options['key_file_format']}")
 
     logging.debug("Executing PKCS1 Signing")
 

--- a/edk2toolext/capsule/signtool_signer.py
+++ b/edk2toolext/capsule/signtool_signer.py
@@ -20,6 +20,10 @@ from edk2toollib.windows import locate_tools
 from edk2toollib.utility_functions import RunCmd
 
 GLOBAL_SIGNTOOL_PATH = None
+SUPPORTED_SIGNTOOL_FORMAT_OPTIONS = {
+    'detachedSignedData',
+    'embedded'
+}
 
 
 def get_signtool_path():
@@ -36,18 +40,40 @@ def get_signtool_path():
     return GLOBAL_SIGNTOOL_PATH
 
 
-def sign(data, signature_options, signer_options):
+def sign(data: bytes, signature_options: dict, signer_options: dict) -> bytes:
     '''
     primary signing interface. Takes n the signature_options and signer_options
     dictionaries that are used by capsule_tool and capsule_helper
     '''
-    # NOTE: Currently, we only support the necessary algorithms for capsules.
-    if signature_options['sign_alg'] != 'pkcs12':
-        raise ValueError(f"Unsupported signature algorithm: {signature_options['sign_alg']}!")
+
+    # NOTE: Currently, we only support the necessary options for capsules & Windows Firmware Policies
+
+    # The following _if_ clause handles the deprecated signature_option 'sign_alg' for backwards compatibility
+    # when the deprecated option is supplied, this code adds the new, required options based on prior code behavior
+    if 'sign_alg' in signature_options:
+        print('!!! WARNING: signature_option "sign_alg" is deprecated, use "format" instead')
+        if signature_options['sign_alg'] == 'pkcs12':
+            print('assuming "signature_option" "format" of "pkcs7" with "format_options" of "detached"')
+            signature_options['format'] = 'pkcs7'
+            signature_options['format_options'] = 'DetachedSignedData'
+            print('assuming "signer_option" "key_file_format" of "pkcs12"')
+            signer_options['key_file_format'] = 'pkcs12'
+        else:
+            raise ValueError(f"Unsupported signature algorithm: {signature_options['sign_alg']}!")
+    if signature_options['format'] != 'pkcs7':
+        raise ValueError(f"Unsupported signature format: {signature_options['format']}!")
+    for opt in signature_options['format_options']:
+        if opt not in SUPPORTED_SIGNTOOL_FORMAT_OPTIONS:
+            raise ValueError(f"Unsupported format option: {opt}!  Ensure you have provied a set")
+    if 'embedded' in signature_options['format_options']:
+        if 'detachedSignedData' in signature_options['format_options']:
+            raise ValueError(f"format_options 'detachedSignedData' and 'embedded' are mutually exclusive")
     if signature_options['hash_alg'] != 'sha256':
         raise ValueError(f"Unsupported hashing algorithm: {signature_options['hash_alg']}!")
     if 'key_file' not in signer_options:
         raise ValueError("Must supply a key_file in signer_options for Signtool!")
+    if signer_options['key_file_format'] != 'pkcs12':
+        raise ValueError(f"Unsupported key file format: {signer_options['key_file_format']}!")
 
     # Set up a temp directory to hold input and output files.
     temp_folder = tempfile.mkdtemp()
@@ -61,7 +87,11 @@ def sign(data, signature_options, signer_options):
     # Start building the parameters for the call.
     signtool_params = ['sign']
     signtool_params += ['/fd', signature_options['hash_alg']]
-    signtool_params += ['/p7ce', 'DetachedSignedData']
+    if 'format_options' in signature_options:
+        if 'detachedSignedData' in signature_options['format_options']:
+            signtool_params += ['/p7ce', 'DetachedSignedData']
+        else:
+            signtool_params += ['/p7ce', 'Embedded']
     signtool_params += ['/p7', f'"{temp_folder}"']
     signtool_params += ['/f', f"\"{signer_options['key_file']}\""]
     if 'oid' in signer_options:

--- a/edk2toolext/capsule/signtool_signer.py
+++ b/edk2toolext/capsule/signtool_signer.py
@@ -90,14 +90,12 @@ def sign(data: bytes, signature_options: dict, signer_options: dict) -> bytes:
     # Start building the parameters for the call.
     signtool_params = ['sign']
     signtool_params += ['/fd', signature_options['hash_alg']]
-    if 'type_options' in signature_options:
-        if 'detachedSignedData' in signature_options['type_options']:
-            signtool_params += ['/p7ce', 'DetachedSignedData']
-        elif 'embedded' in signature_options['type_options']:
-            signtool_params += ['/p7ce', 'Embedded']
-        else:
-            raise ValueError(f"For pkcs7, type_options must include either embedded or detachedSignedData")
-
+    if 'detachedSignedData' in signature_options['type_options']:
+        signtool_params += ['/p7ce', 'DetachedSignedData']
+    elif 'embedded' in signature_options['type_options']:
+        signtool_params += ['/p7ce', 'Embedded']
+    else:
+        raise ValueError(f"For pkcs7, type_options must include either embedded or detachedSignedData")
     signtool_params += ['/p7', f'"{temp_folder}"']
     signtool_params += ['/f', f"\"{signer_options['key_file']}\""]
     if 'oid' in signer_options:


### PR DESCRIPTION
To the sign() function:
* added type hints
* In parameter dict "signature_options", the key "sign_alg" is
deprecated and replaced with "format".  Its prior value "pkcs12" was
NOT a signature format, it was the format of the signer's
key file. Moving it to a new signer_option key "key_file_format"
* New "signature_option" key "format" supports 1 value of "pkcs7" which
is the true signature format being produced
* Added "format_options" key to parameter dict "signature_options". Values
"embedded" and "detachedSignatureData" are added to distinguish the
different PKCS7 flavors supported.  Note that these format_options
are mutually exclusive
* To ensure compatibility with existing code that passes
"signature_options" with key "pkcs12", sign() detects this and
fills the new parameters with values the provide backwards compatible
behavior