### PR TITLE
Added extra information to extdep names when present

### DIFF
--- a/edk2toolext/environment/external_dependency.py
+++ b/edk2toolext/environment/external_dependency.py
@@ -43,8 +43,12 @@ class ExternalDependency(object):
         self.source = descriptor['source']
         self.version = descriptor['version']
         self.flags = descriptor.get('flags', None)
+        self.id = descriptor.get('id', None)
         self.var_name = descriptor.get('var_name', None)
         self.error_msg = descriptor.get('error_msg', None)
+
+        if self.id is not None:
+            self.name = f"{self.name}_{self.id}"
 
         self.descriptor_location = os.path.dirname(
             descriptor['descriptor_file'])
@@ -145,6 +149,7 @@ class ExternalDependency(object):
         return result
 
     def report_version(self):
+
         version_aggregator.GetVersionAggregator().ReportVersion(self.name,
                                                                 self.version,
                                                                 version_aggregator.VersionTypes.INFO,

--- a/edk2toolext/environment/external_dependency.py
+++ b/edk2toolext/environment/external_dependency.py
@@ -47,9 +47,6 @@ class ExternalDependency(object):
         self.var_name = descriptor.get('var_name', None)
         self.error_msg = descriptor.get('error_msg', None)
 
-        if self.id is not None:
-            self.name = f"{self.name}_{self.id}"
-
         self.descriptor_location = os.path.dirname(
             descriptor['descriptor_file'])
         self.contents_dir = os.path.join(
@@ -150,7 +147,7 @@ class ExternalDependency(object):
 
     def report_version(self):
 
-        version_aggregator.GetVersionAggregator().ReportVersion(self.name,
+        version_aggregator.GetVersionAggregator().ReportVersion(self.name if self.id is None else f"{self.name}_{self.id}",
                                                                 self.version,
                                                                 version_aggregator.VersionTypes.INFO,
                                                                 self.descriptor_location)

--- a/edk2toolext/environment/external_dependency.py
+++ b/edk2toolext/environment/external_dependency.py
@@ -146,8 +146,8 @@ class ExternalDependency(object):
         return result
 
     def report_version(self):
-
-        version_aggregator.GetVersionAggregator().ReportVersion(self.name if self.id is None else f"{self.name}_{self.id}",
+        calc_name = self.name if self.id is None else f"{self.name}_{self.id}"
+        version_aggregator.GetVersionAggregator().ReportVersion(calc_name,
                                                                 self.version,
                                                                 version_aggregator.VersionTypes.INFO,
                                                                 self.descriptor_location)


### PR DESCRIPTION
Currently, there isn't a good way to add ext_deps that point to the same resource at different versions. This adds the ID to the name if present to prevent version aggregator from exploding