### PR TITLE
Add basic test to confirm packages and module names

### DIFF
--- a/BasicDevTests.py
+++ b/BasicDevTests.py
@@ -51,6 +51,7 @@ def TestLineEndingsOk(apath, Windows: bool):
             return False
         return True
 
+
 def TestFilenameLowercase(apath):
     if apath != apath.lower():
         logging.critical(f"Lowercase failure: file {apath} not lower case path")
@@ -58,12 +59,14 @@ def TestFilenameLowercase(apath):
         return False
     return True
 
+
 def PackageAndModuleValidCharacters(apath):
     ''' check pep8 recommendations for package and module names'''
 
     match = re.match('^[a-z0-9_/.]+$', apath.replace("\\", "/"))
-    if  match is None:
-        logging.critical(f"PackageAndModuleValidCharacters failure: package or module name {apath} has something invalid")
+    if match is None:
+        logging.critical(
+            f"PackageAndModuleValidCharacters failure: package or module name {apath} has something invalid")
         return False
     return True
 
@@ -108,7 +111,7 @@ for a in py_files:
         error += 1
     if(not TestRequiredLicense(a)):
         error += 1
-    if(not PackageAndModuleValidCharacters(aRelativePath)): #use relative path so only test within package
+    if(not PackageAndModuleValidCharacters(aRelativePath)):  # use relative path so only test within package
         error += 1
 
     # Don't check EOL.  Use .gitattributes

--- a/BasicDevTests.py
+++ b/BasicDevTests.py
@@ -28,30 +28,6 @@ def TestEncodingOk(apath, encodingValue):
     return True
 
 
-def TestLineEndingsOk(apath, Windows: bool):
-    WIN_EOL = b'\r\n'
-    UNIX_EOL = b'\n'
-
-    with open(apath, "rb") as f_obj:
-        content_uni = f_obj.read()
-
-    if(not Windows):
-        if(WIN_EOL in content_uni):
-            logging.critical("Windows EOL in use file: {0}".format(apath))
-            return False
-        return True
-
-    else:
-        # windows
-        # since UNIX EOL is substring of WIN EOL replace WIN with something
-        # else and then look for UNIX
-        content_no_nl = content_uni.replace(WIN_EOL, b"  ")
-        if UNIX_EOL in content_no_nl:
-            logging.critical("UNIX EOL in use file: {0}".format(apath))
-            return False
-        return True
-
-
 def TestFilenameLowercase(apath):
     if apath != apath.lower():
         logging.critical(f"Lowercase failure: file {apath} not lower case path")
@@ -113,10 +89,6 @@ for a in py_files:
         error += 1
     if(not PackageAndModuleValidCharacters(aRelativePath)):  # use relative path so only test within package
         error += 1
-
-    # Don't check EOL.  Use .gitattributes
-    # if(not TestLineEndingsOk(a, True)):
-    #    error += 1
 
 logging.critical(f"Found {error} error(s) in {len(py_files)} file(s)")
 sys.exit(error)

--- a/BasicDevTests.py
+++ b/BasicDevTests.py
@@ -14,6 +14,7 @@ import glob
 import os
 import sys
 import logging
+import re
 
 
 def TestEncodingOk(apath, encodingValue):
@@ -50,11 +51,19 @@ def TestLineEndingsOk(apath, Windows: bool):
             return False
         return True
 
-
 def TestFilenameLowercase(apath):
     if apath != apath.lower():
         logging.critical(f"Lowercase failure: file {apath} not lower case path")
         logging.error(f"\n\tLOWERCASE: {apath.lower()}\n\tINPUTPATH: {apath}")
+        return False
+    return True
+
+def PackageAndModuleValidCharacters(apath):
+    ''' check pep8 recommendations for package and module names'''
+
+    match = re.match('^[a-z0-9_/.]+$', apath.replace("\\", "/"))
+    if  match is None:
+        logging.critical(f"PackageAndModuleValidCharacters failure: package or module name {apath} has something invalid")
         return False
     return True
 
@@ -98,6 +107,8 @@ for a in py_files:
     if(not TestNoSpaces(aRelativePath)):
         error += 1
     if(not TestRequiredLicense(a)):
+        error += 1
+    if(not PackageAndModuleValidCharacters(aRelativePath)): #use relative path so only test within package
         error += 1
 
     # Don't check EOL.  Use .gitattributes


### PR DESCRIPTION
Only allow lowercase a-z, 0-9, _, /, . in the package and module names.
Some python tools have issues when a "-" is in the package or module name.