### PR TITLE
nuget_dependency: Warn on malformed cache

### DIFF
--- a/edk2toolext/environment/extdeptypes/nuget_dependency.py
+++ b/edk2toolext/environment/extdeptypes/nuget_dependency.py
@@ -122,14 +122,22 @@ class NugetDependency(ExternalDependency):
         #
         # Now, try to locate our actual cache path
         nuget_version = NugetDependency.normalize_version(self.version)
+
         cache_search_path = os.path.join(
-            self.global_cache_path, package_name.lower(), nuget_version, package_name)
+            self.global_cache_path, package_name.lower(), nuget_version)
+        inner_cache_search_path = os.path.join(cache_search_path, package_name)
         if os.path.isdir(cache_search_path):
-            logging.info(
-                "Local Cache found for Nuget package '%s'. Skipping fetch.", package_name)
-            shutil.copytree(cache_search_path, self.contents_dir)
-            self.update_state_file()
-            result = True
+            # If we found a cache for this version, let's use it.
+            if os.path.isdir(inner_cache_search_path):
+                logging.info(
+                    "Local Cache found for Nuget package '%s'. Skipping fetch.", package_name)
+                shutil.copytree(inner_cache_search_path, self.contents_dir)
+                self.update_state_file()
+                result = True
+            # If this cache doesn't match our heuristic, let's warn the user.
+            else:
+                logging.warning(
+                    "Local Cache found for Nuget package '%s', but could not find contents. Malformed?", package_name)
 
         return result
 

--- a/edk2toolext/tests/test_nuget_dependency.py
+++ b/edk2toolext/tests/test_nuget_dependency.py
@@ -230,6 +230,5 @@ class TestNugetDependency(unittest.TestCase):
         self.assertTrue(ext_dep.verify())
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/edk2toolext/tests/test_nuget_dependency.py
+++ b/edk2toolext/tests/test_nuget_dependency.py
@@ -190,7 +190,7 @@ class TestNugetDependency(unittest.TestCase):
         os.mkdir(cache_dir)
         ext_dep.global_cache_path = cache_dir
         # Then create the directories inside the cache that should hold the contents.
-        package_cache_dir = os.path.join(cache_dir, hw_package_name, good_version)
+        package_cache_dir = os.path.join(cache_dir, hw_package_name.lower(), good_version)
         os.makedirs(package_cache_dir)
         # There are no package directories inside the cache.
         self.assertFalse(ext_dep._fetch_from_cache(hw_package_name))
@@ -216,7 +216,7 @@ class TestNugetDependency(unittest.TestCase):
         os.mkdir(cache_dir)
         ext_dep.global_cache_path = cache_dir
         # Then create the directories inside the cache that should hold the contents.
-        package_cache_dir = os.path.join(cache_dir, hw_package_name, good_version)
+        package_cache_dir = os.path.join(cache_dir, hw_package_name.lower(), good_version)
         os.makedirs(package_cache_dir)
 
         # Create a directory that doesn't match the heuristic.

--- a/integration_test/azure-pipelines/windows-robot-integration-test.yml
+++ b/integration_test/azure-pipelines/windows-robot-integration-test.yml
@@ -44,7 +44,7 @@ jobs:
   - script: pip install -e .
     displayName: 'Install from Source'
 
-  - powershell: choco install qemu; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
+  - powershell: choco install qemu --version=2020.08.14; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
     displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI
     condition: and(contains(variables.Tag, 'AndQemu'), succeeded())
 


### PR DESCRIPTION
If the Nuget Dependency code finds a cache but cannot
heuristically match the package contents (so that they may
be copied directly) produce a warning to the user that they
may be using a malformed package..

Issue #228 