### PR TITLE
integration_test/azure-pipelines: Pin to a specific QEMU version

### DIFF
--- a/integration_test/azure-pipelines/windows-robot-integration-test.yml
+++ b/integration_test/azure-pipelines/windows-robot-integration-test.yml
@@ -44,7 +44,7 @@ jobs:
   - script: pip install -e .
     displayName: 'Install from Source'
 
-  - powershell: choco install qemu; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
+  - powershell: choco install qemu --version=2020.08.14; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
     displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI
     condition: and(contains(variables.Tag, 'AndQemu'), succeeded())
 


### PR DESCRIPTION
QEMU fails in the latest builds. This commit pins the QEMU version to a known-good installation.