### PR TITLE
Pytools: Add the customization invocable and builder

### DIFF
--- a/edk2toolext/environment/customizable_builder.py
+++ b/edk2toolext/environment/customizable_builder.py
@@ -1,0 +1,33 @@
+# @file customizable_builder.py
+#  
+##
+# Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+from edk2toolext.environment.multiple_workspace import MultipleWorkspace
+from edk2toolext.environment import shell_environment
+
+class CustomizableBuilder():
+    
+    def AddPlatformCommandLineOptions(self, parserObj):
+        pass
+
+    def RetrievePlatformCommandLineOptions(self, args):
+        pass
+
+    def execute(self):
+        raise NotImplementedError
+
+    def Go(self, WorkSpace, PackagesPath, PInHelper, PInManager):
+        self.env = shell_environment.GetBuildVars()
+        self.mws = MultipleWorkspace()
+        self.mws.setWs(WorkSpace, PackagesPath)
+        self.ws = WorkSpace
+        self.pp = PackagesPath  # string using os.pathsep
+        self.Helper = PInHelper
+        self.pm = PInManager
+        
+        self.execute()
+        return 0
+

--- a/edk2toolext/environment/customizable_builder.py
+++ b/edk2toolext/environment/customizable_builder.py
@@ -7,17 +7,45 @@
 ##
 from edk2toolext.environment.multiple_workspace import MultipleWorkspace
 from edk2toolext.environment import shell_environment
+import logging
+from edk2toolext import edk2_logging
+from edk2toolext.environment.plugintypes.uefi_build_plugin import IUefiBuildPlugin
 
 class CustomizableBuilder():
-    
+
     def AddPlatformCommandLineOptions(self, parserObj):
-        pass
+        ''' adds command line options to the argparser '''
+        parserObj.add_argument("--SKIPBUILD", "--skipbuild", "--SkipBuild", dest="SKIPBUILD",
+                               action='store_true', default=False, help="Skip the build process")
+        parserObj.add_argument("--SKIPPREBUILD", "--skipprebuild", "--SkipPrebuild", dest="SKIPPREBUILD",
+                               action='store_true', default=False, help="Skip prebuild process")
+        parserObj.add_argument("--SKIPPOSTBUILD", "--skippostbuild", "--SkipPostBuild", dest="SKIPPOSTBUILD",
+                               action='store_true', default=False, help="Skip postbuild process")
 
     def RetrievePlatformCommandLineOptions(self, args):
-        pass
 
-    def execute(self):
+        self.SkipBuild = False
+        self.SkipPreBuild = False
+        self.SkipPostBuild = False
+
+        if(args.SKIPBUILD):
+            self.SkipBuild = True
+        elif(args.SKIPPREBUILD):
+            self.SkipPreBuild = True
+        elif(args.SKIPPOSTBUILD):
+            self.SkipPostBuild = True
+
+    def Build(self):
         raise NotImplementedError
+
+    @classmethod
+    def SetPlatformEnv(self):
+        return 0
+
+    def SetEnv(self):
+        # process platform parameters defined in platform build file
+        ret = self.SetPlatformEnv()
+        return ret
 
     def Go(self, WorkSpace, PackagesPath, PInHelper, PInManager):
         self.env = shell_environment.GetBuildVars()
@@ -27,7 +55,98 @@ class CustomizableBuilder():
         self.pp = PackagesPath  # string using os.pathsep
         self.Helper = PInHelper
         self.pm = PInManager
-        
-        self.execute()
+
+        ret = self.SetEnv()
+
+        if(self.SkipPreBuild):
+            edk2_logging.log_progress("Skipping Pre Build")
+        else:
+            ret = self.PreBuild()
+            if(ret != 0):
+                logging.critical("Pre Build failed")
+                return ret
+        if(self.SkipBuild):
+            edk2_logging.log_progress("Skipping Build")
+        else:
+            ret = self.Build()
+
+            if(ret != 0):
+                logging.critical("Build failed")
+                return ret
+
+        # postbuild
+        if(self.SkipPostBuild):
+            edk2_logging.log_progress("Skipping Post Build")
+        else:
+            ret = self.PostBuild()
+            if(ret != 0):
+                logging.critical("Post Build failed")
+                return ret
+
+        return 0
+    def PreBuild(self):
+        edk2_logging.log_progress("Running Pre Build")
+        #
+        # Run the platform pre-build steps.
+        #
+        ret = self.PlatformPreBuild()
+
+        if(ret != 0):
+            logging.critical("PlatformPreBuild failed %d" % ret)
+            return ret
+        #
+        # run all loaded UefiBuild Plugins
+        #
+        for Descriptor in self.pm.GetPluginsOfClass(IUefiBuildPlugin):
+            rc = Descriptor.Obj.do_pre_build(self)
+            if(rc != 0):
+                if(rc is None):
+                    logging.error(
+                        "Plugin Failed: %s returned NoneType" % Descriptor.Name)
+                    ret = -1
+                else:
+                    logging.error("Plugin Failed: %s returned %d" %
+                                  (Descriptor.Name, rc))
+                    ret = rc
+                break  # fail on plugin error
+            else:
+                logging.debug("Plugin Success: %s" % Descriptor.Name)
+        return ret
+    def PostBuild(self):
+        edk2_logging.log_progress("Running Post Build")
+        #
+        # Run the platform post-build steps.
+        #
+        ret = self.PlatformPostBuild()
+
+        if(ret != 0):
+            logging.critical("PlatformPostBuild failed %d" % ret)
+            return ret
+
+        #
+        # run all loaded UefiBuild Plugins
+        #
+        for Descriptor in self.pm.GetPluginsOfClass(IUefiBuildPlugin):
+            rc = Descriptor.Obj.do_post_build(self)
+            if(rc != 0):
+                if(rc is None):
+                    logging.error(
+                        "Plugin Failed: %s returned NoneType" % Descriptor.Name)
+                    ret = -1
+                else:
+                    logging.error("Plugin Failed: %s returned %d" %
+                                  (Descriptor.Name, rc))
+                    ret = rc
+                break  # fail on plugin error
+            else:
+                logging.debug("Plugin Success: %s" % Descriptor.Name)
+
+        return ret
+
+    @classmethod
+    def PlatformPreBuild(self):
         return 0
 
+    @classmethod
+    def PlatformPostBuild(self):
+        return 0

--- a/edk2toolext/invocables/customizable_build.py
+++ b/edk2toolext/invocables/customizable_build.py
@@ -1,0 +1,101 @@
+# @file customizable_build
+# Invocable class that does a customized build.
+# Needs a child of CustomizableBuilder for pre/post build steps.
+##
+# Copyright (c) 2021, Intel Corporation. All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+import os
+import sys
+import logging
+
+from edk2toolext import edk2_logging
+from edk2toolext.environment import plugin_manager
+from edk2toolext.environment.plugintypes.uefi_helper_plugin import HelperFunctions
+from edk2toolext.environment import self_describing_environment
+from edk2toolext.environment.customizable_builder import CustomizableBuilder
+from edk2toolext.edk2_invocable import Edk2Invocable,Edk2InvocableSettingsInterface
+from edk2toollib.utility_functions import locate_class_in_module
+from edk2toollib.uefi.edk2.path_utilities import Edk2Path
+
+
+class BuildSettingsManager(Edk2InvocableSettingsInterface):
+    ''' Platform settings will be accessed through this implementation. '''
+
+    def GetName(self):
+        ''' Get the name of the repo, platform, or product being build '''
+        return None
+
+class CustomizableBuild(Edk2Invocable):
+    ''' Imports UefiBuilder and calls go '''
+
+    def AddCommandLineOptions(self, parserObj):
+        ''' adds command line options to the argparser '''
+
+        # PlatformSettings could also be a subclass of UefiBuilder, who knows!
+        if isinstance(self.PlatformSettings, CustomizableBuilder):
+            self.PlatformBuilder = self.PlatformSettings
+        else:
+            try:
+                # if it's not, we will try to find it in the module that was originally provided.
+                self.PlatformBuilder = locate_class_in_module(self.PlatformModule, CustomizableBuilder)()
+            except (TypeError):
+                raise RuntimeError(f"UefiBuild not found in module:\n{dir(self.PlatformModule)}")
+
+        self.PlatformBuilder.AddPlatformCommandLineOptions(parserObj)
+    def RetrieveCommandLineOptions(self, args):
+        '''  Retrieve command line options from the argparser '''
+        self.PlatformBuilder.RetrievePlatformCommandLineOptions(args)
+        
+    def GetSettingsClass(self):
+        '''  Providing BuildSettingsManager  '''
+        return BuildSettingsManager
+
+    def GetLoggingFileName(self, loggerType):
+        name = self.PlatformSettings.GetName()
+        if name is not None:
+            return f"BUILDLOG_{name}"
+        return "BUILDLOG"
+
+    def Go(self):
+        logging.info("Running Python version: " + str(sys.version_info))
+
+        CustomizableBuild.collect_python_pip_info()
+
+        (build_env, shell_env) = self_describing_environment.BootstrapEnvironment(
+            self.GetWorkspaceRoot(), self.GetActiveScopes())
+
+        # Load plugins
+        logging.log(edk2_logging.SECTION, "Loading Plugins")
+        pm = plugin_manager.PluginManager()
+        failedPlugins = pm.SetListOfEnvironmentDescriptors(
+            build_env.plugins)
+        if failedPlugins:
+            logging.critical("One or more plugins failed to load. Halting build.")
+            for a in failedPlugins:
+                logging.error("Failed Plugin: {0}".format(a["name"]))
+            raise Exception("One or more plugins failed to load.")
+
+        helper = HelperFunctions()
+        if(helper.LoadFromPluginManager(pm) > 0):
+            raise Exception("One or more helper plugins failed to load.")
+
+        # Make a pathobj so we can normalize and validate the workspace
+        # and packages path.  The Settings Manager can return absolute or
+        # relative paths
+        pathobj = Edk2Path(self.GetWorkspaceRoot(), self.GetPackagesPath())
+        #
+        # Now we can actually kick off a build.
+        #
+        logging.log(edk2_logging.SECTION, "Kicking off build")
+        ret = self.PlatformBuilder.Go(pathobj.WorkspacePath,
+                                      os.pathsep.join(pathobj.PackagePathList),
+                                      helper, pm)
+        logging.log(edk2_logging.SECTION, f"Log file is located at: {self.log_filename}")
+        return ret
+
+
+def main():
+    CustomizableBuild().Invoke()
+

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ setuptools.setup(
                             'sig_db_tool=edk2toolext.uefi.sig_db_tool:main',
                             'firmware_policy_tool=edk2toolext.windows.policy.firmware_policy_tool:main',
                             'edk2_capsule_tool=edk2toolext.capsule.capsule_tool:main',
-                            'versioninfo_tool=edk2toolext.versioninfo.versioninfo_tool:main']
+                            'versioninfo_tool=edk2toolext.versioninfo.versioninfo_tool:main',
+                            'stuart_customization_build=edk2toolext.invocables.customizable_build:main']
     },
     install_requires=[
         'pyyaml>=5.3.1',


### PR DESCRIPTION
The CustomizableBuild class is similar to Edk2PlatformBuild, but it consumes CustomizableBuilder.

The CustomizableBuilder class is the base class, its child class do the real implementation.

Signed-off-by: Bob Feng <bob.c.feng@intel.com>