### PR TITLE
Added logic to support nuget versions suffix with numbers

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -122,6 +122,7 @@
         "Boothole",
         "dbxupdate",
         "FileFlagsMask",
-        "markdownlint"
+        "markdownlint",
+        "xffd"
     ]
 }

--- a/edk2toolext/environment/extdeptypes/nuget_dependency.py
+++ b/edk2toolext/environment/extdeptypes/nuget_dependency.py
@@ -72,7 +72,17 @@ class NugetDependency(ExternalDependency):
 
         int_parts = tuple([0 if a == "" else int(a) for a in parts])
 
-        if tag not in [None, "beta", "alpha", "rc"]:
+        if tag is not None:
+            # It might start with "beta*", "alpha*" or "rc*"
+            legit_tag = False
+            for rv in ["beta", "alpha", "rc"]:
+                if tag.startswith(rv):
+                    legit_tag = True
+        else:
+            # Otherwise, it is legit
+            legit_tag = True
+
+        if not legit_tag:
             raise ValueError(f"Unparsable version tag: {tag}")
 
         if len(int_parts) > 4:

--- a/edk2toolext/tests/test_nuget_dependency.py
+++ b/edk2toolext/tests/test_nuget_dependency.py
@@ -132,6 +132,9 @@ class TestNugetDependency(unittest.TestCase):
         version5 = "3.2.1.-alpha"
         proper_version5 = "3.2.1-alpha"
         self.assertEqual(proper_version5, NugetDependency.normalize_version(version5))
+        version6 = "3.2.1.0-rc1"
+        proper_version6 = "3.2.1-rc1"
+        self.assertEqual(proper_version6, NugetDependency.normalize_version(version6))
         # try some bad cases
         with self.assertRaises(ValueError):
             NugetDependency.normalize_version("not a number")


### PR DESCRIPTION
As exemplified in nuget versioning site: https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#version-basics, the current nuget package supports versioning suffixes such as "alpha2", "beta1", etc.

This change added extra logic to support nuget versions suffix with numbers instead of failing to update with "Unparsable version tag".