### PR TITLE
Add a builder's base class so that the user

### DIFF
--- a/edk2toolext/environment/abs_builder.py
+++ b/edk2toolext/environment/abs_builder.py
@@ -1,0 +1,22 @@
+# @file abs_build.py
+# This module contains code that supports the Tianocore Edk2 build system
+# This class is designed to be subclassed by a platform to allow
+# more extensive and custom behavior.
+##
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+class AbsBuilder(object):
+
+    # TODO: this initiablize block should go to pipeline builder
+
+    def AddPlatformCommandLineOptions(self, parserObj):
+        pass
+
+    def RetrievePlatformCommandLineOptions(self, args):
+        pass
+
+    def Go(self, WorkSpace, PackagesPath, PInHelper, PInManager):
+        raise NotImplementedError

--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -23,10 +23,11 @@ from edk2toollib.uefi.edk2.parsers.fdf_parser import FdfParser
 from edk2toollib.utility_functions import RunCmd
 from edk2toolext import edk2_logging
 from edk2toolext.environment.plugintypes.uefi_build_plugin import IUefiBuildPlugin
+from edk2toolext.environment.abs_builder import AbsBuilder
 import datetime
 
 
-class UefiBuilder(object):
+class UefiBuilder(AbsBuilder):
 
     def __init__(self):
         self.SkipBuild = False

--- a/edk2toolext/invocables/edk2_platform_build.py
+++ b/edk2toolext/invocables/edk2_platform_build.py
@@ -39,7 +39,7 @@ class Edk2PlatformBuild(Edk2Invocable):
         else:
             try:
                 # if it's not, we will try to find it in the module that was originally provided.
-                self.PlatformBuilder = locate_class_in_module(self.PlatformModule, UefiBuilder)()
+                self.PlatformBuilder = locate_class_in_module(self.PlatformModule, AbsBuilder)()
             except (TypeError):
                 raise RuntimeError(f"UefiBuild not found in module:\n{dir(self.PlatformModule)}")
 


### PR DESCRIPTION
can create customized builder and make it be consumed by
edk2PlatformBuild. That is to be consumed by stuart_build.exe

Signed-off-by: Bob Feng <bob.c.feng@intel.com>