### PR TITLE
Add support for user overriding NuGet.exe from package using NUGET_PATH system environment variable.  Remove broken code that tried to find NuGet.exe on path.

### DIFF
--- a/docs/usability/using_extdep.md
+++ b/docs/usability/using_extdep.md
@@ -69,6 +69,9 @@ either unauthenticated or authenticated. Support is done by using the nuget
 command line tool. When the ext_dep type is set to **_nuget_** the descriptor
 will be interpreted as a nuget dependency. Nuget has a few nice features such as
 caching, authentication, versioning, and is platform and language agnostic.
+This package has a version of the NuGet.exe binary or a user can configure their
+environment to use a defined version by setting `NUGET_PATH` to the folder containing
+the NuGet.exe that should be used.
 
 ### Web Dependency
 

--- a/edk2toolext/environment/extdeptypes/nuget_dependency.py
+++ b/edk2toolext/environment/extdeptypes/nuget_dependency.py
@@ -46,7 +46,7 @@ class NugetDependency(ExternalDependency):
             cmd += ["mono"]
 
         nuget_path = os.getenv(cls.NUGET_ENV_VAR_NAME)
-        if  nuget_path is None:
+        if nuget_path is None:
             # No env variable found.  Get it from our package
             requirement = pkg_resources.Requirement.parse("edk2-pytool-extensions")
             nuget_file_path = os.path.join("edk2toolext", "bin")

--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -68,23 +68,18 @@ class UefiBuilder(object):
         '''  Retrieve command line options from the argparser'''
         self.OutputConfig = os.path.abspath(args.OutputConfig) if args.OutputConfig else None
 
-        if(args.SKIPBUILD):
-            self.SkipBuild = True
-        elif(args.SKIPPREBUILD):
-            self.SkipPreBuild = True
-        elif(args.SKIPPOSTBUILD):
-            self.SkipPostBuild = True
-        elif(args.FLASHONLY):
+        self.SkipBuild = args.SKIPBUILD
+        self.SkipPreBuild = args.SKIPPREBUILD
+        self.SkipPostBuild = args.SKIPPOSTBUILD
+        self.Clean = args.CLEAN
+        self.FlashImage = args.FLASHROM
+        self.UpdateConf = args.UPDATECONF
+
+        if(args.FLASHONLY):
             self.SkipPostBuild = True
             self.SkipBuild = True
             self.SkipPreBuild = True
             self.FlashImage = True
-        elif(args.FLASHROM):
-            self.FlashImage = True
-        elif(args.UPDATECONF):
-            self.UpdateConf = True
-        elif(args.CLEAN):
-            self.Clean = True
         elif(args.CLEANONLY):
             self.Clean = True
             self.SkipBuild = True

--- a/edk2toolext/tests/test_nuget_dependency.py
+++ b/edk2toolext/tests/test_nuget_dependency.py
@@ -70,6 +70,7 @@ def clean_workspace():
 class TestNugetDependency(unittest.TestCase):
     def setUp(self):
         prep_workspace()
+        self.saved_nuget_path = os.getenv(NugetDependency.NUGET_ENV_VAR_NAME)
 
     @classmethod
     def setUpClass(cls):
@@ -85,6 +86,9 @@ class TestNugetDependency(unittest.TestCase):
         # we need to reset the version aggregator each time
         version_aggregator.GetVersionAggregator().Reset()
 
+        if self.saved_nuget_path is not None:
+            os.environ[NugetDependency.NUGET_ENV_VAR_NAME] = self.saved_nuget_path
+
         # Fix the nuget.exe is missing....download again
         requirement = pkg_resources.Requirement.parse("edk2-pytool-extensions")
         nuget_file_path = os.path.join("edk2toolext", "bin", "NuGet.exe")
@@ -99,17 +103,49 @@ class TestNugetDependency(unittest.TestCase):
         ret = RunCmd(nuget_cmd[0], ' '.join(nuget_cmd[1:]), outstream=sys.stdout)
         self.assertEqual(ret, 0)  # make sure we have a zero return code
 
-    def test_nuget_exe_on_path(self):
+    def test_missing_nuget(self):
 
+        if NugetDependency.NUGET_ENV_VAR_NAME in os.environ:
+            del os.environ[NugetDependency.NUGET_ENV_VAR_NAME]
+
+        #delete the package file
         original = NugetDependency.GetNugetCmd()[-1]  # get last item which will be exe path
         os.remove(original)
         path = NugetDependency.GetNugetCmd()
         self.assertIsNone(path)  #Should not be found
 
-        os.environ["PATH"] = os.environ["PATH"] + os.pathsep + os.path.dirname(test_dir)
+    def test_nuget_env_var(self):
+        if NugetDependency.NUGET_ENV_VAR_NAME in os.environ:
+            del os.environ[NugetDependency.NUGET_ENV_VAR_NAME]
+
+        # set the env var to our path
+        os.environ[NugetDependency.NUGET_ENV_VAR_NAME] = test_dir
         nuget.DownloadNuget(test_dir)  #download to test dir
-        path = NugetDependency.GetNugetCmd()
-        self.assertIsNotNone(path)
+        found_path = NugetDependency.GetNugetCmd()[-1]
+
+        ## done with env testing.  clean up
+        del os.environ[NugetDependency.NUGET_ENV_VAR_NAME]
+        self.assertIsNotNone(found_path)
+        path_should_be = os.path.join(test_dir, "nuget.exe")
+        self.assertTrue(os.path.samefile(found_path, path_should_be))
+
+    def test_nuget_env_var_with_space(self):
+        if NugetDependency.NUGET_ENV_VAR_NAME in os.environ:
+            del os.environ[NugetDependency.NUGET_ENV_VAR_NAME]
+
+        # set the env var to our path
+        my_test_dir = os.path.join(test_dir, "my folder")
+        os.makedirs(my_test_dir)
+        os.environ[NugetDependency.NUGET_ENV_VAR_NAME] = my_test_dir
+        nuget.DownloadNuget(my_test_dir)  #download to test dir
+        found_path = NugetDependency.GetNugetCmd()[-1]
+
+        ## done with env testing.  clean up
+        del os.environ[NugetDependency.NUGET_ENV_VAR_NAME]
+
+        self.assertIsNotNone(found_path)
+        path_should_be = os.path.join(my_test_dir, "nuget.exe")
+        self.assertTrue(os.path.samefile(found_path.strip('"'), path_should_be))
 
     # good case
     def test_download_good_nuget(self):

--- a/edk2toolext/tests/test_nuget_dependency.py
+++ b/edk2toolext/tests/test_nuget_dependency.py
@@ -108,11 +108,11 @@ class TestNugetDependency(unittest.TestCase):
         if NugetDependency.NUGET_ENV_VAR_NAME in os.environ:
             del os.environ[NugetDependency.NUGET_ENV_VAR_NAME]
 
-        #delete the package file
+        # delete the package file
         original = NugetDependency.GetNugetCmd()[-1]  # get last item which will be exe path
         os.remove(original)
         path = NugetDependency.GetNugetCmd()
-        self.assertIsNone(path)  #Should not be found
+        self.assertIsNone(path)  # Should not be found
 
     def test_nuget_env_var(self):
         if NugetDependency.NUGET_ENV_VAR_NAME in os.environ:
@@ -120,10 +120,10 @@ class TestNugetDependency(unittest.TestCase):
 
         # set the env var to our path
         os.environ[NugetDependency.NUGET_ENV_VAR_NAME] = test_dir
-        nuget.DownloadNuget(test_dir)  #download to test dir
+        nuget.DownloadNuget(test_dir)  # download to test dir
         found_path = NugetDependency.GetNugetCmd()[-1]
 
-        ## done with env testing.  clean up
+        # done with env testing.  clean up
         del os.environ[NugetDependency.NUGET_ENV_VAR_NAME]
         self.assertIsNotNone(found_path)
         path_should_be = os.path.join(test_dir, "nuget.exe")
@@ -137,10 +137,10 @@ class TestNugetDependency(unittest.TestCase):
         my_test_dir = os.path.join(test_dir, "my folder")
         os.makedirs(my_test_dir)
         os.environ[NugetDependency.NUGET_ENV_VAR_NAME] = my_test_dir
-        nuget.DownloadNuget(my_test_dir)  #download to test dir
+        nuget.DownloadNuget(my_test_dir)  # download to test dir
         found_path = NugetDependency.GetNugetCmd()[-1]
 
-        ## done with env testing.  clean up
+        # done with env testing.  clean up
         del os.environ[NugetDependency.NUGET_ENV_VAR_NAME]
 
         self.assertIsNotNone(found_path)

--- a/edk2toolext/tests/test_nuget_dependency.py
+++ b/edk2toolext/tests/test_nuget_dependency.py
@@ -126,7 +126,7 @@ class TestNugetDependency(unittest.TestCase):
         # done with env testing.  clean up
         del os.environ[NugetDependency.NUGET_ENV_VAR_NAME]
         self.assertIsNotNone(found_path)
-        path_should_be = os.path.join(test_dir, "nuget.exe")
+        path_should_be = os.path.join(test_dir, "NuGet.exe")
         self.assertTrue(os.path.samefile(found_path, path_should_be))
 
     def test_nuget_env_var_with_space(self):
@@ -144,7 +144,7 @@ class TestNugetDependency(unittest.TestCase):
         del os.environ[NugetDependency.NUGET_ENV_VAR_NAME]
 
         self.assertIsNotNone(found_path)
-        path_should_be = os.path.join(my_test_dir, "nuget.exe")
+        path_should_be = os.path.join(my_test_dir, "NuGet.exe")
         self.assertTrue(os.path.samefile(found_path.strip('"'), path_should_be))
 
     # good case


### PR DESCRIPTION
Quoted string fails os.path.isfile and thus a nuget.exe found on the path never works