### PR TITLE
Update NuGet.exe to 5.10.0

### DIFF
--- a/edk2toolext/bin/nuget.py
+++ b/edk2toolext/bin/nuget.py
@@ -11,9 +11,9 @@ import urllib.request
 import logging
 
 # Update this when you want a new version of NuGet
-VERSION = "5.7.0"
+VERSION = "5.10.0"
 URL = "https://dist.nuget.org/win-x86-commandline/v{}/nuget.exe".format(VERSION)
-SHA256 = "AE3BB02517B52A744833A4777E99D647CD80B29A62FD360E9AABAA34F09AF59C"
+SHA256 = "852b71cc8c8c2d40d09ea49d321ff56fd2397b9d6ea9f96e532530307bbbafd3"
 
 
 def DownloadNuget(unpack_folder: str = None) -> list:


### PR DESCRIPTION
Just keeping current given the security sensitive nature of downloading external dependencies.