### PR TITLE
Update scripts to programmatically find default branch from remote.

### DIFF
--- a/integration_test/Shared_Keywords.robot
+++ b/integration_test/Shared_Keywords.robot
@@ -44,11 +44,11 @@ Clone the git repo
     Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
     Should Be Equal As Integers  ${result.rc}  0
 
-Reset git repo to main branch
-    [Arguments]     ${ws}  ${main_branch_name}
+Reset git repo to default branch
+    [Arguments]     ${ws}  ${default_branch_name}
 
-    # checkout remote tag for origin/master
-    ${result}=  Run Process  git  checkout  origin/${main_branch_name}
+    # checkout remote tag for origin/<default branch>
+    ${result}=  Run Process  git  checkout  origin/${default_branch_name}
     ...  cwd=${ws}  stdout=stdout.txt  stderr=stderr.txt
     Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
     Should Be Equal As Integers  ${result.rc}  0
@@ -63,6 +63,27 @@ Reset git repo to main branch
     ...  cwd=${ws}  stdout=stdout.txt  stderr=stderr.txt
     Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
     Should Be Equal As Integers  ${result.rc}  0
+
+Get default branch from remote
+    [Arguments]     ${ws}
+
+    # Set origin head to auto
+    ${result}=  Run Process  git  remote  set-head  origin  --auto
+    ...  cwd=${ws}
+    Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+    # get the head
+    ${result}=  Run Process  git  rev-parse  --abbrev-ref  origin/HEAD
+    ...  cwd=${ws}
+    Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+    # Strip off origin/ from the branch because all other commands
+    # add the remote name.
+    ${branch}=  Get Substring  ${result.stdout}  7
+
+    [Return]  ${branch}
 
 Make new branch
     [Arguments]    ${name}  ${ws}

--- a/integration_test/edk2_core_ci.robot
+++ b/integration_test/edk2_core_ci.robot
@@ -16,7 +16,7 @@ Suite Setup  One time setup  ${repo_url}  ${ws_dir}
 
 *** Variables ***
 ${repo_url}           https://github.com/tianocore/edk2.git
-${master_branch}      master
+${default_branch}     not_yet_set
 ${ws_dir}             edk2
 ${ci_file}            .pytool/CISettings.py
 ${ws_root}            ${TEST_OUTPUT}${/}${ws_dir}
@@ -36,6 +36,10 @@ One time setup
     ## Clone repo
     Run Keyword  Clone the git repo  ${url}  ${folder}
 
+    ## Figure out default branch
+    ${branch}=  Get default branch from remote  ${ws_root}
+    Set Suite Variable  ${default_branch}  ${branch}
+
 
 *** Test Cases ***
 
@@ -47,8 +51,8 @@ Run Edk2 MdePkg CoreCI Debug
     ${targets}=          Set Variable    DEBUG
     ${packages}=         Set Variable    MdePkg
 
-    # make sure on master
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Stuart update          ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
@@ -63,8 +67,8 @@ Run Edk2 SecurityPkg CoreCI Release
     ${targets}=          Set Variable    RELEASE
     ${packages}=         Set Variable    SecurityPkg
 
-    # make sure on master
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Stuart update          ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
@@ -79,8 +83,8 @@ Run Edk2 UefiCpuPkg CoreCI for No-Target
     ${targets}=          Set Variable    NO-TARGET
     ${packages}=         Set Variable    UefiCpuPkg
 
-    # make sure on master
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Stuart update          ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
@@ -95,8 +99,8 @@ Run Edk2 MdeModulePkg CoreCI for NOOPT and HostTest
     ${targets}=          Set Variable    NOOPT
     ${packages}=         Set Variable    MdeModulePkg
 
-    # make sure on master
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Stuart update          ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}

--- a/integration_test/edk2_platform_ci.robot
+++ b/integration_test/edk2_platform_ci.robot
@@ -16,7 +16,7 @@ Suite Setup  One time setup  ${repo_url}  ${ws_dir}
 
 *** Variables ***
 ${repo_url}           https://github.com/tianocore/edk2.git
-${master_branch}      master
+${default_branch}     not_yet_set
 ${ws_dir}             edk2
 ${ws_root}            ${TEST_OUTPUT}${/}${ws_dir}
 ${tool_chain}         VS2019
@@ -35,6 +35,10 @@ One time setup
     ## Clone repo
     Run Keyword  Clone the git repo  ${url}  ${folder}
 
+    ## Figure out default branch
+    ${branch}=  Get default branch from remote  ${ws_root}
+    Set Suite Variable  ${default_branch}  ${branch}
+
 *** Test Cases ***
 Run Edk2 Ovmf PlatformCI
     [Documentation]  This Test will run Platform CI on the OvmfPkg X64
@@ -44,8 +48,8 @@ Run Edk2 Ovmf PlatformCI
     ${package}=          Set Variable    OvmfPkg
     ${ci_file}=          Set Variable    ${package}${/}PlatformCI${/}PlatformBuild.py
 
-    # make sure on master
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
     Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
@@ -61,8 +65,8 @@ Run Edk2 EmulatorPkg PlatformCI
     ${package}=          Set Variable    EmulatorPkg
     ${ci_file}=          Set Variable    ${package}${/}PlatformCI${/}PlatformBuild.py
 
-    # make sure on master
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}
     Stuart update          ${ci_file}  ${arch}  ${target}  ${package}  ${tool_chain}  ${ws_root}

--- a/integration_test/edk2_stuart_pr_eval.robot
+++ b/integration_test/edk2_stuart_pr_eval.robot
@@ -16,7 +16,7 @@ Suite Setup  One time setup  ${repo_url}  ${ws_dir}
 
 *** Variables ***
 ${repo_url}           https://github.com/tianocore/edk2.git
-${master_branch}      master
+${default_branch}     not_yet_set
 ${ws_dir}             edk2
 ${core_ci_file}       .pytool/CISettings.py
 ${platform_ci_file}   OvmfPkg${/}PlatformCI${/}PlatformBuild.py
@@ -37,6 +37,10 @@ One time setup
     ## Clone repo
     Run Keyword  Clone the git repo  ${url}  ${folder}
 
+    ## Figure out default branch
+    ${branch}=  Get default branch from remote  ${ws_root}
+    Set Suite Variable  ${default_branch}  ${branch}
+
 *** Test Cases ***
 
 Test Stuart PR for Policy 1 special files in PrEvalSettingsManager
@@ -45,7 +49,7 @@ Test Stuart PR for Policy 1 special files in PrEvalSettingsManager
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    BaseTools${/}Source${/}C${/}GenFv${/}GenFv.c
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -55,10 +59,10 @@ Test Stuart PR for Policy 1 special files in PrEvalSettingsManager
     Commit changes  "Changes"  ${ws_root}
 
     # Core CI test  package dependency # Policy 3
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,ArmVirtPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,ArmVirtPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Confirm same contents  ${pkgs}  MdePkg,MdeModulePkg,ArmVirtPkg
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR for Policy 2 in package change of private inf file
     [Tags]           PrEval  Edk2
@@ -66,7 +70,7 @@ Test Stuart PR for Policy 2 in package change of private inf file
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    MdePkg${/}Library${/}BaseLib${/}BaseLib.inf
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -76,14 +80,14 @@ Test Stuart PR for Policy 2 in package change of private inf file
     Commit changes  "Changes"  ${ws_root}
 
     # Core CI test same package  # policy 2
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Confirm same contents  ${pkgs}  MdePkg
 
     # Core CI test another package and make sure a it doesn't need to build
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdeModulePkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdeModulePkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 
 Test Stuart PR for Policy 3 for package dependency on change of public header file
@@ -92,7 +96,7 @@ Test Stuart PR for Policy 3 for package dependency on change of public header fi
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    MdePkg${/}Include${/}Protocol${/}DevicePath.h
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -102,10 +106,10 @@ Test Stuart PR for Policy 3 for package dependency on change of public header fi
     Commit changes  "Changes"  ${ws_root}
 
     # Core CI test  package dependency # Policy 3
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdeModulePkg,UefiCpuPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdeModulePkg,UefiCpuPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Confirm same contents  ${pkgs}  MdeModulePkg,UefiCpuPkg
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR for Policy 3 for package dependency on change of public header file not dependent
     [Tags]           PrEval  Edk2
@@ -113,7 +117,7 @@ Test Stuart PR for Policy 3 for package dependency on change of public header fi
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    CryptoPkg${/}Include${/}Library${/}TlsLib.h
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -123,10 +127,10 @@ Test Stuart PR for Policy 3 for package dependency on change of public header fi
     Commit changes  "Changes"  ${ws_root}
 
     # Core CI test  package dependency # Policy 3
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,UefiCpuPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,UefiCpuPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR for Policy 3 for package dependency on change of package dec file
     [Tags]           PrEval  Edk2
@@ -134,7 +138,7 @@ Test Stuart PR for Policy 3 for package dependency on change of package dec file
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    SecurityPkg${/}SecurityPkg.dec
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -144,10 +148,10 @@ Test Stuart PR for Policy 3 for package dependency on change of package dec file
     Commit changes  "Changes"  ${ws_root}
 
     # Core CI test  package dependency # Policy 3
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,ArmVirtPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,ArmVirtPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Confirm same contents  ${pkgs}  ArmVirtPkg
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR for Policy 4 module c file changed that platform dsc depends on
     [Tags]           PrEval  Edk2
@@ -155,7 +159,7 @@ Test Stuart PR for Policy 4 module c file changed that platform dsc depends on
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    MdeModulePkg${/}Core${/}Dxe${/}DxeMain.h
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -165,10 +169,10 @@ Test Stuart PR for Policy 4 module c file changed that platform dsc depends on
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Confirm same contents  ${pkgs}  OvmfPkg
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR for Policy 4 module c file changed that platform dsc does not depend on
     [Tags]           PrEval  Edk2
@@ -176,7 +180,7 @@ Test Stuart PR for Policy 4 module c file changed that platform dsc does not dep
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    MdeModulePkg${/}Application${/}HelloWorld${/}HelloWorld.c
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -186,10 +190,10 @@ Test Stuart PR for Policy 4 module c file changed that platform dsc does not dep
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR for all policies when a PR contains a deleted file
     [Tags]           PrEval  Delete  Edk2
@@ -197,7 +201,7 @@ Test Stuart PR for all policies when a PR contains a deleted file
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    MdeModulePkg${/}Application${/}HelloWorld${/}HelloWorld.c
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Remove File  ${ws_root}${/}${file_to_modify}
@@ -206,10 +210,10 @@ Test Stuart PR for all policies when a PR contains a deleted file
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR for all policies when a PR contains a deleted folder
     [Tags]           PrEval  Delete  Edk2
@@ -217,7 +221,7 @@ Test Stuart PR for all policies when a PR contains a deleted folder
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    MdeModulePkg${/}Application${/}HelloWorld
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Remove Directory  ${ws_root}${/}${file_to_modify}  True
@@ -226,10 +230,10 @@ Test Stuart PR for all policies when a PR contains a deleted folder
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR for all policies when a PR contains multiple levels of deleted folders
     [Tags]           PrEval  Delete  Edk2
@@ -237,7 +241,7 @@ Test Stuart PR for all policies when a PR contains multiple levels of deleted fo
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    UefiCpuPkg${/}CpuDxe
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Remove Directory  ${ws_root}${/}${file_to_modify}  True
@@ -246,10 +250,10 @@ Test Stuart PR for all policies when a PR contains multiple levels of deleted fo
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Confirm same contents  ${pkgs}  OvmfPkg
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR for all policies when a PR contains file added
     [Tags]           PrEval  Add  Edk2
@@ -258,7 +262,7 @@ Test Stuart PR for all policies when a PR contains file added
     ${file_to_move}=      Set Variable    MdePkg${/}Library${/}BaseS3StallLib${/}S3StallLib.c
     ${location_to_move}=  Set Variable    MdePkg${/}Library${/}BaseLib
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Move File  ${ws_root}${/}${file_to_move}  ${ws_root}${/}${location_to_move}
@@ -267,10 +271,10 @@ Test Stuart PR for all policies when a PR contains file added
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Confirm same contents  ${pkgs}  OvmfPkg
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR for all policies when a PR contains directory added
     [Tags]           PrEval  Add  Edk2
@@ -279,7 +283,7 @@ Test Stuart PR for all policies when a PR contains directory added
     ${file_to_move}=      Set Variable    MdePkg${/}Library${/}BaseS3StallLib
     ${location_to_move}=  Set Variable    MdeModulePkg${/}Library
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Move Directory  ${ws_root}${/}${file_to_move}  ${ws_root}${/}${location_to_move}
@@ -288,10 +292,10 @@ Test Stuart PR for all policies when a PR contains directory added
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR for changing a file at the root of repo
     [Tags]           PrEval  Edk2
@@ -299,7 +303,7 @@ Test Stuart PR for changing a file at the root of repo
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    edksetup.bat
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -309,7 +313,7 @@ Test Stuart PR for changing a file at the root of repo
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}

--- a/integration_test/mu_core_ci.robot
+++ b/integration_test/mu_core_ci.robot
@@ -16,7 +16,7 @@ Suite Setup  One time setup  ${repo_url}  ${ws_dir}
 
 *** Variables ***
 ${repo_url}           https://github.com/microsoft/mu_basecore
-${master_branch}      release/202002
+${default_branch}     not_yet_set
 ${ws_dir}             mu_basecore
 ${ci_file}            .pytool/CISettings.py
 ${ws_root}            ${TEST_OUTPUT}${/}${ws_dir}
@@ -36,6 +36,9 @@ One time setup
     ## Clone repo
     Run Keyword  Clone the git repo  ${url}  ${folder}
 
+    ## Figure out default branch
+    ${branch}=  Get default branch from remote  ${ws_root}
+    Set Suite Variable  ${default_branch}  ${branch}
 
 *** Test Cases ***
 
@@ -47,8 +50,8 @@ Run ProjectMu MdePkg CoreCI Debug
     ${targets}=          Set Variable    DEBUG
     ${packages}=         Set Variable    MdePkg
 
-    # make sure on master
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Stuart ci setup        ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
@@ -64,8 +67,8 @@ Run ProjectMu SecurityPkg CoreCI Release
     ${targets}=          Set Variable    RELEASE
     ${packages}=         Set Variable    SecurityPkg
 
-    # make sure on master
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Stuart ci setup        ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
@@ -81,8 +84,8 @@ Run ProjectMu UefiCpuPkg CoreCI for No-Target
     ${targets}=          Set Variable    NO-TARGET
     ${packages}=         Set Variable    UefiCpuPkg
 
-    # make sure on master
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Stuart ci setup        ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
@@ -98,8 +101,8 @@ Run ProjectMu MdeModulePkg CoreCI for NOOPT and HostTest
     ${targets}=          Set Variable    NOOPT
     ${packages}=         Set Variable    MdeModulePkg
 
-    # make sure on master
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    # make sure on default branch
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Stuart ci setup        ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}

--- a/integration_test/mu_stuart_pr_eval.robot
+++ b/integration_test/mu_stuart_pr_eval.robot
@@ -16,7 +16,7 @@ Suite Setup  One time setup  ${repo_url}  ${ws_dir}
 
 *** Variables ***
 ${repo_url}           https://github.com/microsoft/mu_basecore
-${master_branch}      release/202002
+${default_branch}     not_yet_set
 ${ws_dir}             mu_basecore
 ${core_ci_file}       .pytool/CISettings.py
 
@@ -36,6 +36,10 @@ One time setup
     ## Clone repo
     Run Keyword  Clone the git repo  ${url}  ${folder}
 
+    ## Figure out default branch
+    ${branch}=  Get default branch from remote  ${ws_root}
+    Set Suite Variable  ${default_branch}  ${branch}
+
     ## clean the repo of all dependencies including additional repos
     ## Project Mu test cases are most useful for multi-repository testing
     ## but for that to be useful the other repositories must not be
@@ -54,7 +58,7 @@ Test Stuart PR using ProjectMu for Policy 1 special files in PrEvalSettingsManag
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    BaseTools${/}Source${/}C${/}GenFv${/}GenFv.c
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -64,10 +68,10 @@ Test Stuart PR using ProjectMu for Policy 1 special files in PrEvalSettingsManag
     Commit changes  "Changes"  ${ws_root}
 
     # Core CI test  package dependency # Policy 3
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,UefiCpuPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,UefiCpuPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Confirm same contents  ${pkgs}  MdePkg,MdeModulePkg,UefiCpuPkg
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR using ProjectMu for Policy 2 in package change of private inf file
     [Tags]           PrEval  ProjectMu
@@ -75,7 +79,7 @@ Test Stuart PR using ProjectMu for Policy 2 in package change of private inf fil
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    MdePkg${/}Library${/}BaseLib${/}BaseLib.inf
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -85,14 +89,14 @@ Test Stuart PR using ProjectMu for Policy 2 in package change of private inf fil
     Commit changes  "Changes"  ${ws_root}
 
     # Core CI test same package  # policy 2
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Confirm same contents  ${pkgs}  MdePkg
 
     # Core CI test another package and make sure a it doesn't need to build
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdeModulePkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdeModulePkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 
 Test Stuart PR using ProjectMu for Policy 3 for package dependency on change of public header file
@@ -101,7 +105,7 @@ Test Stuart PR using ProjectMu for Policy 3 for package dependency on change of 
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    MdePkg${/}Include${/}Protocol${/}DevicePath.h
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -111,10 +115,10 @@ Test Stuart PR using ProjectMu for Policy 3 for package dependency on change of 
     Commit changes  "Changes"  ${ws_root}
 
     # Core CI test  package dependency # Policy 3
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdeModulePkg,UefiCpuPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdeModulePkg,UefiCpuPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Confirm same contents  ${pkgs}  MdeModulePkg,UefiCpuPkg
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR using ProjectMu for Policy 3 for package dependency on change of public header file not dependent
     [Tags]           PrEval  ProjectMu
@@ -122,7 +126,7 @@ Test Stuart PR using ProjectMu for Policy 3 for package dependency on change of 
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    PcAtChipsetPkg${/}Include${/}Guid${/}PcAtChipsetTokenSpace.h
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -132,10 +136,10 @@ Test Stuart PR using ProjectMu for Policy 3 for package dependency on change of 
     Commit changes  "Changes"  ${ws_root}
 
     # Core CI test  package dependency # Policy 3
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,UefiCpuPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,UefiCpuPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR using ProjectMu for Policy 3 for package dependency on change of package dec file
     [Tags]           PrEval  ProjectMu
@@ -143,7 +147,7 @@ Test Stuart PR using ProjectMu for Policy 3 for package dependency on change of 
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    UefiCpuPkg${/}UefiCpuPkg.dec
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -153,10 +157,10 @@ Test Stuart PR using ProjectMu for Policy 3 for package dependency on change of 
     Commit changes  "Changes"  ${ws_root}
 
     # Core CI test  package dependency # Policy 3
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,PcAtChipsetPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,PcAtChipsetPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Confirm same contents  ${pkgs}  PcAtChipsetPkg
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR using ProjectMu for all policies when a PR contains a deleted file
     [Tags]           PrEval  Delete  ProjectMu
@@ -164,7 +168,7 @@ Test Stuart PR using ProjectMu for all policies when a PR contains a deleted fil
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    MdeModulePkg${/}Application${/}HelloWorld${/}HelloWorld.c
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Remove File  ${ws_root}${/}${file_to_modify}
@@ -172,10 +176,10 @@ Test Stuart PR using ProjectMu for all policies when a PR contains a deleted fil
     Stage changed file  ${file_to_modify}  ${ws_root}
     Commit changes  "Changes"  ${ws_root}
 
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR using ProjectMu for all policies when a PR contains a deleted folder
     [Tags]           PrEval  Delete  ProjectMu
@@ -183,7 +187,7 @@ Test Stuart PR using ProjectMu for all policies when a PR contains a deleted fol
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    MdeModulePkg${/}Application${/}HelloWorld
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Remove Directory  ${ws_root}${/}${file_to_modify}  True
@@ -192,10 +196,10 @@ Test Stuart PR using ProjectMu for all policies when a PR contains a deleted fol
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  SecurityPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  SecurityPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR using ProjectMu for all policies when a PR contains multiple levels of deleted folders
     [Tags]           PrEval  Delete  ProjectMu
@@ -203,7 +207,7 @@ Test Stuart PR using ProjectMu for all policies when a PR contains multiple leve
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    UefiCpuPkg${/}CpuDxe
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Remove Directory  ${ws_root}${/}${file_to_modify}  True
@@ -212,10 +216,10 @@ Test Stuart PR using ProjectMu for all policies when a PR contains multiple leve
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  SecurityPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  SecurityPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR using ProjectMu for all policies when a PR contains file added
     [Tags]           PrEval  Add  ProjectMu
@@ -224,7 +228,7 @@ Test Stuart PR using ProjectMu for all policies when a PR contains file added
     ${file_to_move}=      Set Variable    MdePkg${/}Library${/}BaseS3StallLib${/}S3StallLib.c
     ${location_to_move}=  Set Variable    MdePkg${/}Library${/}BaseLib
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Move File  ${ws_root}${/}${file_to_move}  ${ws_root}${/}${location_to_move}
@@ -233,10 +237,10 @@ Test Stuart PR using ProjectMu for all policies when a PR contains file added
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdeModulePkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdeModulePkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR for all policies when a PR contains directory added
     [Tags]           PrEval  Add
@@ -245,7 +249,7 @@ Test Stuart PR for all policies when a PR contains directory added
     ${file_to_move}=      Set Variable    MdePkg${/}Library${/}BaseS3StallLib
     ${location_to_move}=  Set Variable    MdeModulePkg${/}Library
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Move Directory  ${ws_root}${/}${file_to_move}  ${ws_root}${/}${location_to_move}
@@ -254,10 +258,10 @@ Test Stuart PR for all policies when a PR contains directory added
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  UefiCpuPkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  UefiCpuPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR for changing a file at the root of repo
     [Tags]           PrEval
@@ -265,7 +269,7 @@ Test Stuart PR for changing a file at the root of repo
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
     ${file_to_modify}=   Set Variable    edksetup.bat
 
-    Reset git repo to main branch  ${ws_root}  ${master_branch}
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
 
     Append To File  ${ws_root}${/}${file_to_modify}
@@ -275,7 +279,7 @@ Test Stuart PR for changing a file at the root of repo
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg  ${master_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${master_branch}  ${ws_root}
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}


### PR DESCRIPTION
This will avoid having to update these tests each time a remote repo changes their default branch.  For Project Mu this happens a lot based on the release process.  For edk2 usage this currently isn't a problem but this change should make it more resiliant to future changes.

Rename "master" and "main" to more correct "default" branch.