### PR TITLE
Allow referencing branch in git external dependency

### DIFF
--- a/edk2toolext/environment/extdeptypes/git_dependency.py
+++ b/edk2toolext/environment/extdeptypes/git_dependency.py
@@ -98,8 +98,9 @@ class GitDependency(ExternalDependency):
                 self.logger.error("Git Dependency: dirty")
                 result = False
 
-            if(r.head.commit != self.version):
-                self.logger.error(f"Git Dependency: head is {r.head.commit} and version is {self.version}")
+            if (r.head.commit != self.version) and (r.active_branch != self.version):
+                self.logger.error(f"Git Dependency: head is {r.head.commit} (branch:{r.active_branch}) "
+                                  f"and version is {self.version}")
                 result = False
 
         self.logger.debug("Verify '%s' returning '%s'." % (self.name, result))


### PR DESCRIPTION
Git external dependencies can be checkout at a specific a commit hash.
Referencing a branch is not possible. Add this functionnality.

Signed-off-by: Pierre Gondois <Pierre.Gondois@arm.com>