### PR TITLE
Fix failures in Mu Integration tests due to basecore restructure

### DIFF
--- a/integration_test/Shared_Keywords.robot
+++ b/integration_test/Shared_Keywords.robot
@@ -49,7 +49,7 @@ Setup git user_email
     # check if user.email is set
     ${result}=  Run Process  git  config  user.email  cwd=${ws}
     Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
-    Return From Keyword If    '${result.rc}' == 0
+    Return From Keyword If    '${result.rc}' == '0'
 
     # no email set.  Set a default
     ${result}=  Run Process  git  config  user.email  'ci_test@fake.com'  cwd=${ws}
@@ -66,7 +66,7 @@ Setup git user_name
     # check if user.name is set
     ${result}=  Run Process  git  config  user.name  cwd=${ws}
     Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
-    Return From Keyword If    '${result.rc}' == 0
+    Return From Keyword If    '${result.rc}' == '0'
 
     # no name set.  Set a default
     ${result}=  Run Process  git  config  user.name  'ci_test'  cwd=${ws}

--- a/integration_test/Shared_Keywords.robot
+++ b/integration_test/Shared_Keywords.robot
@@ -78,7 +78,7 @@ Setup git user_name
     Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
     Should Be Equal As Integers  ${result.rc}  0
 
-Confirm or setup git so automation can commit
+Confirm or setup git so automation can can commit
     [Arguments]     ${ws}
 
     Run Keyword  Setup git user_email  ${ws}
@@ -156,7 +156,7 @@ Stage changed file
 
 Commit changes
     [Arguments]    ${msg}  ${ws}
-    Run Keyword  Confirm or setup git so automation can commit  ${ws}
+    Run Keyword  Confirm or setup git so automation can can commit  ${ws}
     ${result}=   Run Process    git  commit  -m  ${msg}
     ...  cwd=${ws}  shell=True
     Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}

--- a/integration_test/Shared_Keywords.robot
+++ b/integration_test/Shared_Keywords.robot
@@ -78,7 +78,7 @@ Setup git user_name
     Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
     Should Be Equal As Integers  ${result.rc}  0
 
-Confirm or setup git so automation can can commit
+Confirm or setup git so automation can commit
     [Arguments]     ${ws}
 
     Run Keyword  Setup git user_email  ${ws}
@@ -156,7 +156,7 @@ Stage changed file
 
 Commit changes
     [Arguments]    ${msg}  ${ws}
-    Run Keyword  Confirm or setup git so automation can can commit  ${ws}
+    Run Keyword  Confirm or setup git so automation can commit  ${ws}
     ${result}=   Run Process    git  commit  -m  ${msg}
     ...  cwd=${ws}  shell=True
     Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}

--- a/integration_test/Shared_Keywords.robot
+++ b/integration_test/Shared_Keywords.robot
@@ -44,6 +44,46 @@ Clone the git repo
     Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
     Should Be Equal As Integers  ${result.rc}  0
 
+Setup git user_email
+    [Arguments]     ${ws}
+    # check if user.email is set
+    ${result}=  Run Process  git  config  user.email  cwd=${ws}
+    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
+    Return From Keyword If    '${result.rc}' == 0
+
+    # no email set.  Set a default
+    ${result}=  Run Process  git  config  user.email  'ci_test@fake.com'  cwd=${ws}
+    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+    # verify
+    ${result}=  Run Process  git  config  user.email  cwd=${ws}
+    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+Setup git user_name
+    [Arguments]     ${ws}
+    # check if user.name is set
+    ${result}=  Run Process  git  config  user.name  cwd=${ws}
+    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
+    Return From Keyword If    '${result.rc}' == 0
+
+    # no name set.  Set a default
+    ${result}=  Run Process  git  config  user.name  'ci_test'  cwd=${ws}
+    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+    # verify
+    ${result}=  Run Process  git  config  user.name  cwd=${ws}
+    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
+    Should Be Equal As Integers  ${result.rc}  0
+
+Confirm or setup git so automation can can commit
+    [Arguments]     ${ws}
+
+    Run Keyword  Setup git user_email  ${ws}
+    Run Keyword  Setup git user_name  ${ws}
+
 Reset git repo to default branch
     [Arguments]     ${ws}  ${default_branch_name}
 
@@ -116,6 +156,7 @@ Stage changed file
 
 Commit changes
     [Arguments]    ${msg}  ${ws}
+    Run Keyword  Confirm or setup git so automation can can commit  ${ws}
     ${result}=   Run Process    git  commit  -m  ${msg}
     ...  cwd=${ws}  shell=True
     Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}

--- a/integration_test/Shared_Keywords.robot
+++ b/integration_test/Shared_Keywords.robot
@@ -44,46 +44,6 @@ Clone the git repo
     Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
     Should Be Equal As Integers  ${result.rc}  0
 
-Setup git user_email
-    [Arguments]     ${ws}
-    # check if user.email is set
-    ${result}=  Run Process  git  config  user.email  cwd=${ws}
-    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
-    Return From Keyword If    '${result.rc}' == '0'
-
-    # no email set.  Set a default
-    ${result}=  Run Process  git  config  user.email  'ci_test@fake.com'  cwd=${ws}
-    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
-    Should Be Equal As Integers  ${result.rc}  0
-
-    # verify
-    ${result}=  Run Process  git  config  user.email  cwd=${ws}
-    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
-    Should Be Equal As Integers  ${result.rc}  0
-
-Setup git user_name
-    [Arguments]     ${ws}
-    # check if user.name is set
-    ${result}=  Run Process  git  config  user.name  cwd=${ws}
-    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
-    Return From Keyword If    '${result.rc}' == '0'
-
-    # no name set.  Set a default
-    ${result}=  Run Process  git  config  user.name  'ci_test'  cwd=${ws}
-    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
-    Should Be Equal As Integers  ${result.rc}  0
-
-    # verify
-    ${result}=  Run Process  git  config  user.name  cwd=${ws}
-    Log Many  stdout: ${result.stdout}  stderr: ${result.stderr}
-    Should Be Equal As Integers  ${result.rc}  0
-
-Confirm or setup git so automation can can commit
-    [Arguments]     ${ws}
-
-    Run Keyword  Setup git user_email  ${ws}
-    Run Keyword  Setup git user_name  ${ws}
-
 Reset git repo to default branch
     [Arguments]     ${ws}  ${default_branch_name}
 
@@ -156,7 +116,6 @@ Stage changed file
 
 Commit changes
     [Arguments]    ${msg}  ${ws}
-    Run Keyword  Confirm or setup git so automation can can commit  ${ws}
     ${result}=   Run Process    git  commit  -m  ${msg}
     ...  cwd=${ws}  shell=True
     Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}

--- a/integration_test/mu_core_ci.robot
+++ b/integration_test/mu_core_ci.robot
@@ -54,24 +54,22 @@ Run ProjectMu MdePkg CoreCI Debug
     Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
-    Stuart ci setup        ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Stuart update          ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Build BaseTools        ${tool_chain}  ${ws_root}
     Stuart CI build        ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
 
-Run ProjectMu SecurityPkg CoreCI Release
-    [Documentation]  This Test will run IA32 RELEASE build of Core CI on the SecurityPkg
+Run ProjectMu MdeModulePkg CoreCI Release
+    [Documentation]  This Test will run IA32 RELEASE build of Core CI on the MdeModulePkg
     [Tags]           CoreCI  Windows  VS2019  Compile  ProjectMu
 
     ${archs}=            Set Variable    IA32
     ${targets}=          Set Variable    RELEASE
-    ${packages}=         Set Variable    SecurityPkg
+    ${packages}=         Set Variable    MdeModulePkg
 
     # make sure on default branch
     Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
-    Stuart ci setup        ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Stuart update          ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Build BaseTools        ${tool_chain}  ${ws_root}
     Stuart CI build        ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
@@ -88,7 +86,6 @@ Run ProjectMu UefiCpuPkg CoreCI for No-Target
     Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
-    Stuart ci setup        ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Stuart update          ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Build BaseTools        ${tool_chain}  ${ws_root}
     Stuart CI build        ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
@@ -105,7 +102,6 @@ Run ProjectMu MdeModulePkg CoreCI for NOOPT and HostTest
     Reset git repo to default branch  ${ws_root}  ${default_branch}
 
     Stuart setup           ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
-    Stuart ci setup        ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Stuart update          ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}
     Build BaseTools        ${tool_chain}  ${ws_root}
     Stuart CI build        ${ci_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws_root}

--- a/integration_test/mu_stuart_pr_eval.robot
+++ b/integration_test/mu_stuart_pr_eval.robot
@@ -185,7 +185,7 @@ Test Stuart PR using ProjectMu for all policies when a PR contains a deleted fol
     [Tags]           PrEval  Delete  ProjectMu
 
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
-    ${file_to_modify}=   Set Variable    MdeModulePkg${/}Application${/}HelloWorld
+    ${file_to_modify}=   Set Variable    MdePkg${/}Library${/}BasePrintLib
 
     Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
@@ -196,7 +196,7 @@ Test Stuart PR using ProjectMu for all policies when a PR contains a deleted fol
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  SecurityPkg  ${default_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  PcAtChipsetPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
     [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
@@ -205,7 +205,7 @@ Test Stuart PR using ProjectMu for all policies when a PR contains multiple leve
     [Tags]           PrEval  Delete  ProjectMu
 
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
-    ${file_to_modify}=   Set Variable    UefiCpuPkg${/}CpuDxe
+    ${file_to_modify}=   Set Variable    MdeModulePkg${/}Library
 
     Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
@@ -216,7 +216,7 @@ Test Stuart PR using ProjectMu for all policies when a PR contains multiple leve
     Commit changes  "Changes"  ${ws_root}
 
     # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  SecurityPkg  ${default_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  PcAtChipsetPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
     [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}

--- a/integration_test/mu_stuart_pr_eval.robot
+++ b/integration_test/mu_stuart_pr_eval.robot
@@ -201,25 +201,29 @@ Test Stuart PR using ProjectMu for all policies when a PR contains a deleted fol
 
     [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
-Test Stuart PR using ProjectMu for all policies when a PR contains multiple levels of deleted folders
-    [Tags]           PrEval  Delete  ProjectMu
+#
+# Given the restructure in MU Basecore there is no longer a small easy multi folder dependency
+#  This test is redundant and will skip for now
+#
+#Test Stuart PR using ProjectMu for all policies when a PR contains multiple levels of deleted folders
+    # [Tags]           PrEval  Delete  ProjectMu
 
-    ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
-    ${file_to_modify}=   Set Variable    MdeModulePkg${/}Library
+    # ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
+    # ${file_to_modify}=   Set Variable    UefiCpuPkg${/}CpuDxe
 
-    Reset git repo to default branch  ${ws_root}  ${default_branch}
-    Make new branch  ${branch_name}  ${ws_root}
+    # Reset git repo to default branch  ${ws_root}  ${default_branch}
+    # Make new branch  ${branch_name}  ${ws_root}
 
-    Remove Directory  ${ws_root}${/}${file_to_modify}  True
+    # Remove Directory  ${ws_root}${/}${file_to_modify}  True
 
-    Stage changed file  ${file_to_modify}  ${ws_root}
-    Commit changes  "Changes"  ${ws_root}
+    # Stage changed file  ${file_to_modify}  ${ws_root}
+    # Commit changes  "Changes"  ${ws_root}
 
-    # Platform CI test DSC dependnency on implementation file # Policy 4
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  PcAtChipsetPkg  ${default_branch}  ${EMPTY}  ${ws_root}
-    Should Be Empty    ${pkgs}
+    # # Platform CI test DSC dependnency on implementation file # Policy 4
+    # ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  SecurityPkg  ${default_branch}  ${EMPTY}  ${ws_root}
+    # Should Be Empty    ${pkgs}
 
-    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
+    # [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
 Test Stuart PR using ProjectMu for all policies when a PR contains file added
     [Tags]           PrEval  Add  ProjectMu


### PR DESCRIPTION
Integration CI is failing due to agent changes around git configuration.  
Add support for checking the git config and setting user.name and user.email if they are not set.  