### PR TITLE
Add ability to skip directories

### DIFF
--- a/edk2toolext/base_abstract_invocable.py
+++ b/edk2toolext/base_abstract_invocable.py
@@ -33,6 +33,10 @@ class BaseAbstractInvocable(object):
         ''' return tuple containing scopes that should be active for this process '''
         raise NotImplementedError()
 
+    def GetSkippedDirectories(self):
+        ''' return tuple containing workspace-relative directory paths that should be skipped for processing'''
+        return ()
+
     def GetLoggingLevel(self, loggerType):
         ''' Get the logging level for a given type (return Logging.Level)
         base == lowest logging level supported
@@ -114,11 +118,11 @@ class BaseAbstractInvocable(object):
         # Next, get the environment set up.
         #
         (build_env, shell_env) = self_describing_environment.BootstrapEnvironment(
-            self.GetWorkspaceRoot(), self.GetActiveScopes())
+            self.GetWorkspaceRoot(), self.GetActiveScopes(), self.GetSkippedDirectories())
 
         # Make sure the environment verifies IF it is required for this invocation
         if self.GetVerifyCheckRequired() and not self_describing_environment.VerifyEnvironment(
-                self.GetWorkspaceRoot(), self.GetActiveScopes()):
+                self.GetWorkspaceRoot(), self.GetActiveScopes(), self.GetSkippedDirectories()):
             raise RuntimeError("SDE is not current.  Please update your env before running this tool.")
 
         # Load plugins

--- a/edk2toolext/base_abstract_invocable.py
+++ b/edk2toolext/base_abstract_invocable.py
@@ -34,7 +34,8 @@ class BaseAbstractInvocable(object):
         raise NotImplementedError()
 
     def GetSkippedDirectories(self):
-        ''' return tuple containing workspace-relative directory paths that should be skipped for processing'''
+        ''' Return tuple containing workspace-relative directory paths that should be skipped for processing.
+        Absolute paths are not supported. '''
         return ()
 
     def GetLoggingLevel(self, loggerType):

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -62,7 +62,8 @@ class Edk2InvocableSettingsInterface():
         pass
 
     def GetSkippedDirectories(self) -> Tuple[str]:
-        ''' Implement in subclass to return a Tuple containing workspace-relative directories that should be skipped '''
+        ''' Implement in subclass to return a Tuple containing workspace-relative directories that should be skipped.
+        Absolute paths are not supported. '''
         return ()
 
 
@@ -148,7 +149,8 @@ class Edk2Invocable(BaseAbstractInvocable):
         pass
 
     def GetSkippedDirectories(self):
-        ''' Implement in subclass to return a Tuple containing workspace-relative directories that should be skipped '''
+        ''' Implement in subclass to return a Tuple containing workspace-relative directories that should be skipped.
+        Absolute paths are not supported. '''
         try:
             return self.PlatformSettings.GetSkippedDirectories()
         except AttributeError:

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -65,6 +65,7 @@ class Edk2InvocableSettingsInterface():
         ''' Implement in subclass to return a Tuple containing workspace-relative directories that should be skipped '''
         return ()
 
+
 class Edk2Invocable(BaseAbstractInvocable):
     ''' Base class for Edk2 based invocables.
 

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -61,6 +61,10 @@ class Edk2InvocableSettingsInterface():
         '''  Implement in subclass to retrieve command line options from the argparser namespace '''
         pass
 
+    def GetSkippedDirectories(self) -> Tuple[str]:
+        ''' Implement in subclass to return a Tuple containing workspace-relative directories that should be skipped '''
+        return ()
+
 
 class Edk2Invocable(BaseAbstractInvocable):
     ''' Base class for Edk2 based invocables.

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -61,10 +61,6 @@ class Edk2InvocableSettingsInterface():
         '''  Implement in subclass to retrieve command line options from the argparser namespace '''
         pass
 
-    def GetSkippedDirectories(self) -> Tuple[str]:
-        ''' Implement in subclass to return a Tuple containing workspace-relative directories that should be skipped '''
-        return ()
-
 
 class Edk2Invocable(BaseAbstractInvocable):
     ''' Base class for Edk2 based invocables.

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -61,6 +61,9 @@ class Edk2InvocableSettingsInterface():
         '''  Implement in subclass to retrieve command line options from the argparser namespace '''
         pass
 
+    def GetSkippedDirectories(self) -> Tuple[str]:
+        ''' Implement in subclass to return a Tuple containing workspace-relative directories that should be skipped '''
+        return ()
 
 class Edk2Invocable(BaseAbstractInvocable):
     ''' Base class for Edk2 based invocables.
@@ -97,7 +100,7 @@ class Edk2Invocable(BaseAbstractInvocable):
     def GetPackagesPath(self) -> Iterable[os.PathLike]:
         ''' Use the SettingsManager to an iterable of paths to be used as Edk2 Packages Path'''
         try:
-            return self.PlatformSettings.GetPackagesPath()
+            return list(set(self.PlatformSettings.GetPackagesPath()) - set(self.GetSkippedDirectories()))
         except AttributeError:
             raise RuntimeError("Can't call this before PlatformSettings has been set up!")
 
@@ -142,6 +145,13 @@ class Edk2Invocable(BaseAbstractInvocable):
     def RetrieveCommandLineOptions(self, args):
         '''  Implement in subclass to retrieve command line options from the argparser '''
         pass
+
+    def GetSkippedDirectories(self):
+        ''' Implement in subclass to return a Tuple containing workspace-relative directories that should be skipped '''
+        try:
+            return self.PlatformSettings.GetSkippedDirectories()
+        except AttributeError:
+            raise RuntimeError("Can't call this before PlatformSettings has been set up!")
 
     def GetSettingsClass(self):
         '''  Child class should provide the class that contains their required settings '''

--- a/edk2toolext/environment/self_describing_environment.py
+++ b/edk2toolext/environment/self_describing_environment.py
@@ -360,7 +360,7 @@ def UpdateDependencies(workspace, scopes=(), skipped_dirs=()):
 
 def VerifyEnvironment(workspace, scopes=(), skipped_dirs=()):
     # Bootstrap the environment.
-    (build_env, shell_env) = BootstrapEnvironment(workspace, scopes,  skipped_dirs)
+    (build_env, shell_env) = BootstrapEnvironment(workspace, scopes, skipped_dirs)
 
     # Clean all the dependencies.
     return build_env.verify_extdeps(shell_env)

--- a/edk2toolext/environment/self_describing_environment.py
+++ b/edk2toolext/environment/self_describing_environment.py
@@ -24,7 +24,7 @@ ENV_STATE = None
 class self_describing_environment(object):
     def __init__(self, workspace_path, scopes=(), skipped_dirs=()):
         logging.debug("--- self_describing_environment.__init__()")
-        logging.debug(f"skipped_dirs = {skipped_dirs}")
+        logging.debug(f"Skipped directories specified = {skipped_dirs}")
         super(self_describing_environment, self).__init__()
 
         self.workspace = workspace_path
@@ -45,6 +45,7 @@ class self_describing_environment(object):
         self.plugins = None
 
     def _gather_env_files(self, ext_strings, base_path):
+        logging.debug("--- self_describing_environment._gather_env_files()")
         # Make sure that the search extension matches easily.
         search_files = tuple(ext_string.lower() for ext_string in ext_strings)
 
@@ -53,9 +54,10 @@ class self_describing_environment(object):
         matches = {}
         for root, dirs, files in os.walk(base_path, topdown=True):
             # Check to see whether any of these directories should be skipped..
-            dirs[:] = [d for d in dirs if pathlib.Path(root, d) not in self.skipped_dirs]
             for index, dir in enumerate(dirs):
-                if dir == '.git':
+                dir_path = pathlib.Path(root, dir)
+                if dir_path in self.skipped_dirs or dir_path.name == '.git':
+                    logging.debug(f"Skipping: {dir_path.resolve()}")
                     del dirs[index]
 
             # Check for any files that match the extensions we're looking for.

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -64,7 +64,7 @@ class Edk2CiBuild(Edk2MultiPkgAwareInvocable):
         # Bring up the common minimum environment.
         logging.log(edk2_logging.SECTION, "Getting Environment")
         (build_env, shell_env) = self_describing_environment.BootstrapEnvironment(
-            self.GetWorkspaceRoot(), self.GetActiveScopes())
+            self.GetWorkspaceRoot(), self.GetActiveScopes(), self.GetSkippedDirectories())
         env = shell_environment.GetBuildVars()
 
         # Bind our current execution environment into the shell vars.

--- a/edk2toolext/invocables/edk2_platform_build.py
+++ b/edk2toolext/invocables/edk2_platform_build.py
@@ -65,7 +65,7 @@ class Edk2PlatformBuild(Edk2Invocable):
         Edk2PlatformBuild.collect_python_pip_info()
 
         (build_env, shell_env) = self_describing_environment.BootstrapEnvironment(
-            self.GetWorkspaceRoot(), self.GetActiveScopes())
+            self.GetWorkspaceRoot(), self.GetActiveScopes(), self.GetSkippedDirectories())
 
         # Bind our current execution environment into the shell vars.
         ph = os.path.dirname(sys.executable)

--- a/edk2toolext/invocables/edk2_update.py
+++ b/edk2toolext/invocables/edk2_update.py
@@ -62,10 +62,6 @@ class Edk2Update(Edk2MultiPkgAwareInvocable):
         '''  Retrieve command line options from the argparser '''
         super().RetrieveCommandLineOptions(args)
 
-    def GetSkippedDirectories(self):
-        '''  Retrieve skipped directories from the settings manager '''
-        return super().GetSkippedDirectories()
-
     def Go(self):
         # Get the environment set up.
         RetryCount = 0

--- a/edk2toolext/invocables/edk2_update.py
+++ b/edk2toolext/invocables/edk2_update.py
@@ -36,8 +36,9 @@ class Edk2Update(Edk2MultiPkgAwareInvocable):
     def PerformUpdate(self):
         ws_root = self.GetWorkspaceRoot()
         scopes = self.GetActiveScopes()
-        (build_env, shell_env) = self_describing_environment.BootstrapEnvironment(ws_root, scopes)
-        (success, failure) = self_describing_environment.UpdateDependencies(ws_root, scopes)
+        skipped_dirs = self.GetSkippedDirectories()
+        (build_env, shell_env) = self_describing_environment.BootstrapEnvironment(ws_root, scopes, skipped_dirs)
+        (success, failure) = self_describing_environment.UpdateDependencies(ws_root, scopes, skipped_dirs)
         if success != 0:
             logging.log(edk2_logging.SECTION, f"\tUpdated/Verified {success} dependencies")
         return (build_env, shell_env, failure)
@@ -60,6 +61,10 @@ class Edk2Update(Edk2MultiPkgAwareInvocable):
     def RetrieveCommandLineOptions(self, args):
         '''  Retrieve command line options from the argparser '''
         super().RetrieveCommandLineOptions(args)
+
+    def GetSkippedDirectories(self):
+        '''  Retrieve skipped directories from the settings manager '''
+        return super().GetSkippedDirectories()
 
     def Go(self):
         # Get the environment set up.

--- a/edk2toolext/tests/test_edk2_update.py
+++ b/edk2toolext/tests/test_edk2_update.py
@@ -110,6 +110,48 @@ class TestEdk2Update(unittest.TestCase):
         # we should have found two ext deps
         self.assertEqual(len(build_env.extdeps), num_of_ext_deps)
 
+    def test_duplicate_ext_deps(self):
+        ''' verifies redundant ext_deps fail '''
+        WORKSPACE = self.get_temp_folder()
+        tree = uefi_tree(WORKSPACE)
+
+        logging.getLogger().setLevel(logging.WARNING)
+
+        tree.create_ext_dep(dep_type="nuget", name="NuGet.CommandLine", version="5.2.0", dir_path="1", extra_data={"id:": "CmdLine1"})
+        tree.create_ext_dep(dep_type="nuget", name="NuGet.CommandLine", version="5.2.0", dir_path="2", extra_data={"id:": "CmdLine1"})
+
+        # Do the update. Expect a ValueError from the version aggregator.
+        with self.assertRaises(ValueError):
+            updater = self.invoke_update(tree.get_settings_provider_path(), failure_expected=True)
+
+    def test_duplicate_ext_deps_skip_dir(self):
+        ''' verifies redundant ext_deps pass if one is skipped '''
+        WORKSPACE = self.get_temp_folder()
+        tree = uefi_tree(WORKSPACE)
+        num_of_ext_deps = 1
+
+        logging.getLogger().setLevel(logging.WARNING)
+
+        tree.create_ext_dep(dep_type="nuget", name="NuGet.CommandLine", version="5.2.0", dir_path="1", extra_data={"id:": "CmdLine1"})
+        tree.create_ext_dep(dep_type="nuget", name="NuGet.CommandLine", version="5.2.0", dir_path="2", extra_data={"id:": "CmdLine1"})
+
+        # Update GetSkippedDirectories() implementation
+        with open(tree.get_settings_provider_path(), 'r') as s:
+            settings_text = s.read()
+
+        settings_text = settings_text.replace('def GetSkippedDirectories(self):\n        return ()', 'def GetSkippedDirectories(self):\n        return (\"2\",)')
+
+        with open(tree.get_settings_provider_path(), 'w') as s:
+            s.write(settings_text)
+
+        # Do the update
+        updater = self.invoke_update(tree.get_settings_provider_path())
+        build_env, shell_env, failure = updater.PerformUpdate()
+        # we should have found one ext dep
+        self.assertEqual(len(build_env.extdeps), num_of_ext_deps)
+        # the one ext_dep should be valid
+        self.assertEqual(failure, 0)
+
     def test_bad_ext_dep(self):
         ''' makes sure we can do an update that will fail '''
         WORKSPACE = self.get_temp_folder()

--- a/edk2toolext/tests/test_edk2_update.py
+++ b/edk2toolext/tests/test_edk2_update.py
@@ -117,12 +117,20 @@ class TestEdk2Update(unittest.TestCase):
 
         logging.getLogger().setLevel(logging.WARNING)
 
-        tree.create_ext_dep(dep_type="nuget", name="NuGet.CommandLine", version="5.2.0", dir_path="1", extra_data={"id:": "CmdLine1"})
-        tree.create_ext_dep(dep_type="nuget", name="NuGet.CommandLine", version="5.2.0", dir_path="2", extra_data={"id:": "CmdLine1"})
+        tree.create_ext_dep(dep_type="nuget",
+                            name="NuGet.CommandLine",
+                            version="5.2.0",
+                            dir_path="1",
+                            extra_data={"id:": "CmdLine1"})
+        tree.create_ext_dep(dep_type="nuget",
+                            name="NuGet.CommandLine",
+                            version="5.2.0",
+                            dir_path="2",
+                            extra_data={"id:": "CmdLine1"})
 
         # Do the update. Expect a ValueError from the version aggregator.
         with self.assertRaises(ValueError):
-            updater = self.invoke_update(tree.get_settings_provider_path(), failure_expected=True)
+            self.invoke_update(tree.get_settings_provider_path(), failure_expected=True)
 
     def test_duplicate_ext_deps_skip_dir(self):
         ''' verifies redundant ext_deps pass if one is skipped '''
@@ -132,14 +140,24 @@ class TestEdk2Update(unittest.TestCase):
 
         logging.getLogger().setLevel(logging.WARNING)
 
-        tree.create_ext_dep(dep_type="nuget", name="NuGet.CommandLine", version="5.2.0", dir_path="1", extra_data={"id:": "CmdLine1"})
-        tree.create_ext_dep(dep_type="nuget", name="NuGet.CommandLine", version="5.2.0", dir_path="2", extra_data={"id:": "CmdLine1"})
+        tree.create_ext_dep(dep_type="nuget",
+                            name="NuGet.CommandLine",
+                            version="5.2.0",
+                            dir_path="1",
+                            extra_data={"id:": "CmdLine1"})
+        tree.create_ext_dep(dep_type="nuget",
+                            name="NuGet.CommandLine",
+                            version="5.2.0",
+                            dir_path="2",
+                            extra_data={"id:": "CmdLine1"})
 
         # Update GetSkippedDirectories() implementation
         with open(tree.get_settings_provider_path(), 'r') as s:
             settings_text = s.read()
 
-        settings_text = settings_text.replace('def GetSkippedDirectories(self):\n        return ()', 'def GetSkippedDirectories(self):\n        return (\"2\",)')
+        settings_text = settings_text.replace(
+            'def GetSkippedDirectories(self):\n        return ()',
+            'def GetSkippedDirectories(self):\n        return (\"2\",)')
 
         with open(tree.get_settings_provider_path(), 'w') as s:
             s.write(settings_text)

--- a/edk2toolext/tests/uefi_tree.py
+++ b/edk2toolext/tests/uefi_tree.py
@@ -173,6 +173,8 @@ class TestSettingsManager(BuildSettingsManager, SetupSettingsManager, Edk2CiBuil
     def GetTargetsSupported(self):
         return []
 
+    def GetSkippedDirectories(self):
+        return ()
 
 class TestBuilder(UefiBuilder):
     def SetPlatformEnv(self):


### PR DESCRIPTION
Adds a GetSkippedDirectories() method that allows a SettingsManager
to specify a tuple of workspace-relative directories that should be
skipped.

This allows subdirectories (such as submodules) that might contain duplicate
resources that would normally cause build errors (such as external dependency
descriptors) to be ignored if only one directory is actually being used for
the current build.