### PR TITLE
PE/COFF Image Validation Tool

### DIFF
--- a/docs/usability/using_image_validation_tool.md
+++ b/docs/usability/using_image_validation_tool.md
@@ -1,13 +1,13 @@
 # PE/COFF Image Validation
 
-The PE/COFF image validation tool is a command line tool used to verify tha
+The PE/COFF image validation tool is a command line tool used to verify that
 memory protection requirements such as section alignment and write / execute
 settings are applied correctly. This tool also provides the ability to check,
 set, and clear the NX_COMPAT flag found in OPTIONAL_HEADER.DllCharacteristics.
 
 ## Synopsis
 
-image_validation.py [-h] -i FILE [-d] [-s MODULE] [--set-nx-compat SET_NX_COMPAT] [--clear-nx-compat CLEAR_NX_COMPAT] [--get-nx-compat]
+image_validation.py [-h] -i FILE [-d] [-p PROFILE] [--set-nx-compat] [--clear-nx-compat] [--get-nx-compat]
 
 ## Options
 
@@ -23,6 +23,10 @@ image_validation.py [-h] -i FILE [-d] [-s MODULE] [--set-nx-compat SET_NX_COMPAT
 
     [Optional] The profile config to be verified against. Will use the default, if not provided
 
+### -d, --debug
+
+    [Optional] Sets the logging mode to debug
+    
 ### --set-nx-compat
 
     [Optional] Sets the NX_COMPAT flag. returns <file>_nx_set.<filetype>

--- a/docs/usability/using_image_validation_tool.md
+++ b/docs/usability/using_image_validation_tool.md
@@ -1,0 +1,169 @@
+# PE/COFF Image Validation
+
+The PE/COFF image validation tool is a command line tool used to verify tha
+memory protection requirements such as section alignment and write / execute
+settings are applied correctly. This tool also provides the ability to check,
+set, and clear the NX_COMPAT flag found in OPTIONAL_HEADER.DllCharacteristics.
+
+## Synopsis
+
+image_validation.py [-h] -i FILE [-d] [-s MODULE] [--set-nx-compat SET_NX_COMPAT] [--clear-nx-compat CLEAR_NX_COMPAT] [--get-nx-compat]
+
+## Options
+
+### -h, --help
+
+    [Optional] Provides information on flags
+
+### -i --file
+
+    [Required] The input PE/COFF file to be verified
+
+### -p, --profile
+
+    [Optional] The profile config to be verified against. Will use the default, if not provided
+
+### --set-nx-compat
+
+    [Optional] Sets the NX_COMPAT flag. returns <file>_nx_set.<filetype>
+
+### --clear-nx-compat
+
+    [Optional] Clears the NX_COMPAT flag. returns <file>_nx_clear.<filetype>
+
+### --get-nx-compat
+
+    [Optional] Returns the value of the NX_COMPAT flag
+
+### Status codes returned
+
+    0 - All tests returned pass or warn
+    1 - One ore more tests returned fail, or an error has occurred
+
+## Tests
+
+### 1. Section Data / Code Separation Verification
+
+Description:
+
+- This test ensures that each section of the binary is not both write-able and
+execute-able. Sections can only be one or the other (or neither). This test is
+done by iterating over each section and checking the characteristics label for
+the Write Mask (0x80000000) and Execute Mask (0x20000000).
+
+Output:
+
+- @Pass: Only one (or neither) of the two masks (Write, Execute) are present
+- @Skip: Test Skipped per profile configuration
+- @Fail: Both of the two masks (Write, Execute) are set on at least one section
+
+### 2. Section Alignment Verification
+
+Description:
+
+- This test checks the section alignment value found in the optional header.
+It must meet the requirements specified in the profile configuration.
+
+Output:
+
+- @Pass: The Image alignment passes all requirements specified in the profile configuration
+- @Warn: The Image alignment is not found in the optional header
+- @Skip: No image alignment requirements are specified in the profile configuration
+- @Fail: The Image alignment does not meet at least one of the requirements
+specified in the profile configuration
+
+### 3. Subsystem Type Verification
+
+Description:
+
+- This check verifies the subsystem value found in the optional header.
+It must be one of the subsystem types specified in the profile configuration
+
+Output:
+
+- @Pass: The subsystem is one of the types specified in the profile configuration
+- @Warn: The subsystem is not found in the optional header
+- @Skip: There are no subsystem restrictions in the profile configuration
+- @Fail: The subsystem is not one of the types specified in the profile configuration
+
+## Profile Configurations
+
+Configurations are first split by the target architecture, which is determined
+from parsing the PE/COFF file. The profile must be specified by the user, or
+the default, most restrictive, profile will automatically be used.
+
+### X64 Profiles
+
+- DEFAULT
+  - Write / Execute Separation = Required
+  - Alignment = 4096
+  - Subsystem = Boot Service Driver, ROM
+- APP
+  - Write / Execute Separation = Required
+  - Alignment = 4096
+  - Subsystem = Application
+- DRIVER
+  - Write / Execute Separation = Required
+  - Alignment = 4096
+  - Subsystem = Boot Service Driver, Runtime Driver, ROM
+- PEI
+  - Write / Execute Separation = Required
+  - Alignment = 4096
+  - Subsystem = Boot Service Driver, ROM
+
+### IA32 Profiles
+
+- DEFAULT
+  - Write / Execute Separation = Required
+  - Alignment = 4096
+  - Subsystem = Boot Service Driver, ROM
+- APP
+  - Write / Execute Separation = Required
+  - Alignment = 4096
+  - Subsystem = Application
+- DRIVER
+  - Write / Execute Separation = Required
+  - Alignment = 4096
+  - Subsystem = Boot Service Driver, Runtime Driver, ROM
+- PEI
+  - Write / Execute Separation = Required
+  - Alignment = 4096
+  - Subsystem = Boot Service Driver, ROM
+
+### AARCH64 Profiles
+
+- DEFAULT
+  - Write / Execute Separation = Required
+  - Alignment = 32, 64
+  - Subsystem = Boot Service Driver, ROM
+- APP
+  - Write / Execute Separation = Required
+  - Alignment = 64
+  - Subsystem = Application
+- DRIVER
+  - Write / Execute Separation = Required
+  - Alignment = 64
+  - Subsystem = Boot Service Driver, Runtime Driver, ROM
+- PEI
+  - Write / Execute Separation = Required
+  - Alignment = 32
+  - Subsystem = Boot Service Driver, ROM
+
+### ARM Profiles
+
+- DEFAULT
+  - Write / Execute Separation = Required
+  - Alignment = 32, 64
+  - Subsystem = Boot Service Driver, ROM
+- APP
+  - Write / Execute Separation = Required
+  - Alignment = 64
+  - Subsystem = Application
+- DRIVER
+  - Write / Execute Separation = Required
+  - Alignment = 64
+  - Subsystem = Boot Service Driver, Runtime Driver, ROM
+- PEI
+  - Write / Execute Separation = Required
+  - Alignment = 32
+  - Subsystem = Boot Service Driver, ROM

--- a/docs/usability/using_image_validation_tool.md
+++ b/docs/usability/using_image_validation_tool.md
@@ -38,7 +38,7 @@ image_validation.py [-h] -i FILE [-d] [-s MODULE] [--set-nx-compat SET_NX_COMPAT
 ### Status codes returned
 
     0 - All tests returned pass or warn
-    1 - One ore more tests returned fail, or an error has occurred
+    1 - One or more tests returned fail, or an error has occurred
 
 ## Tests
 

--- a/docs/usability/using_image_validation_tool.md
+++ b/docs/usability/using_image_validation_tool.md
@@ -26,7 +26,7 @@ image_validation.py [-h] -i FILE [-d] [-p PROFILE] [--set-nx-compat] [--clear-nx
 ### -d, --debug
 
     [Optional] Sets the logging mode to debug
-    
+
 ### --set-nx-compat
 
     [Optional] Sets the NX_COMPAT flag. returns <file>_nx_set.<filetype>
@@ -110,10 +110,6 @@ the default, most restrictive, profile will automatically be used.
   - Write / Execute Separation = Required
   - Alignment = 4096
   - Subsystem = Boot Service Driver, Runtime Driver, ROM
-- PEI
-  - Write / Execute Separation = Required
-  - Alignment = 4096
-  - Subsystem = Boot Service Driver, ROM
 
 ### IA32 Profiles
 

--- a/docs/usability/using_image_validation_tool.md
+++ b/docs/usability/using_image_validation_tool.md
@@ -7,7 +7,7 @@ set, and clear the NX_COMPAT flag found in OPTIONAL_HEADER.DllCharacteristics.
 
 ## Synopsis
 
-image_validation.py [-h] -i FILE [-d] [-p PROFILE] [--set-nx-compat] [--clear-nx-compat] [--get-nx-compat]
+image_validation.py [-h] -i FILE [-d] [-p PROFILE] [--set-nx-compat | --clear-nx-compat | --get-nx-compat]
 
 ## Options
 

--- a/docs/usability/using_image_validation_tool.md
+++ b/docs/usability/using_image_validation_tool.md
@@ -15,7 +15,7 @@ image_validation.py [-h] -i FILE [-d] [-s MODULE] [--set-nx-compat SET_NX_COMPAT
 
     [Optional] Provides information on flags
 
-### -i --file
+### -i, --file
 
     [Required] The input PE/COFF file to be verified
 

--- a/edk2toolext/image_validation.py
+++ b/edk2toolext/image_validation.py
@@ -33,6 +33,13 @@ def clear_bit(data, bit):
     return data & ~(1 << bit)
 
 
+def fill_missing_requirements(default, target):
+    for key in default:
+        if key not in target:
+            target[key] = default[key]
+    return target
+
+
 class Result:
     PASS = '[PASS]'
     WARN = '[WARNING]'
@@ -265,18 +272,16 @@ class TestManager(object):
         @return Result.ERROR: At least one test failed. Error messages can be found in the log
         """
 
+        # Catch any invalid profiles
         machine_type = MACHINE_TYPE[pe.FILE_HEADER.Machine]
         if not self.config_data[machine_type].get(profile):
             profile = "DEFAULT"
 
         # Fill any missing configurations for the specific module type with the default
-        target_requirements = self.config_data[machine_type][profile]
-        if profile != "DEFAULT":
-            for key in self.config_data[machine_type]["DEFAULT"]:
-                if key not in target_requirements:
-                    target_requirements[key] = self.config_data[machine_type]["DEFAULT"][key]
+        default = self.config_data[machine_type]["DEFAULT"]
+        target = self.config_data[machine_type][profile]
+        target_requirements = fill_missing_requirements(default, target)
 
-        target_requirements = self.config_data[machine_type][profile]
         target_info = {
             "MACHINE_TYPE": machine_type,
             "PROFILE": profile

--- a/edk2toolext/image_validation.py
+++ b/edk2toolext/image_validation.py
@@ -1,0 +1,590 @@
+# @file image_validation.py
+# This tool allows a user validate an PE/COFF file
+# against specific requirements
+##
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+
+from datetime import datetime
+import os
+from pefile import PE, SECTION_CHARACTERISTICS, MACHINE_TYPE, SUBSYSTEM_TYPE
+import logging
+import argparse
+import sys
+
+from edk2toolext import edk2_logging
+
+########################
+#    Helper Functions  #
+########################
+
+
+def has_characteristic(data, mask):
+    return ((data & mask) == mask)
+
+
+def set_bit(data, bit):
+    return data | (1 << bit)
+
+
+def clear_bit(data, bit):
+    return data & ~(1 << bit)
+
+
+class Result:
+    PASS = '[PASS]'
+    WARN = '[WARNING]'
+    SKIP = '[SKIP]'
+    FAIL = '[FAIL]'
+
+
+class TestInterface:
+
+    def name(self):
+        """Returns the name of the test"""
+        raise NotImplementedError("Must Override Test Interface")
+
+    def execute(self, pe, config_data):
+        """
+        Executes the test
+
+        @param pe: The parser pefile
+        @param config_data: Configuration data for the specific target machine
+            and profile
+        """
+        raise NotImplementedError("Must Override Test Interface")
+
+
+class TestManager(object):
+    def __init__(self, config_data=None):
+        self.tests = []
+        if config_data:
+            self.config_data = config_data
+        else:
+            self.config_data = {
+                "TARGET_ARCH": {
+                    "X64": "IMAGE_FILE_MACHINE_AMD64",
+                    "IA32": "IMAGE_FILE_MACHINE_I386",
+                    "AARCH64": "IMAGE_FILE_MACHINE_ARM64",
+                    "ARM": "IMAGE_FILE_MACHINE_ARM"
+                },
+                "IMAGE_FILE_MACHINE_AMD64": {
+                    "DEFAULT": {
+                        "DATA_CODE_SEPARATION": True,
+                        "ALLOWED_SUBSYSTEMS": [
+                            "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
+                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                        ],
+                        "ALIGNMENT": [
+                            {
+                                "COMPARISON": "==",
+                                "VALUE": 4096
+                            }
+                        ]
+                    },
+                    "APP": {
+                        "ALLOWED_SUBSYSTEMS": [
+                            "IMAGE_SUBSYSTEM_EFI_APPLICATION"
+                        ]
+                    },
+                    "DRIVER": {
+                        "ALLOWED_SUBSYSTEMS": [
+                            "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
+                            "IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER"
+                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                        ]
+                    },
+                    "PEI": {}
+                },
+                "IMAGE_FILE_MACHINE_ARM": {
+                    "DEFAULT": {
+                        "DATA_CODE_SEPARATION": True,
+                        "ALLOWED_SUBSYSTEMS": [
+                            "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
+                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                        ],
+                        "ALIGNMENT_LOGIC_SEP": "OR",
+                        "ALIGNMENT": [
+                            {
+                                "COMPARISON": "==",
+                                "VALUE": 64
+                            },
+                            {
+                                "COMPARISON": "==",
+                                "VALUE": 32
+                            }
+                        ]
+                    },
+                    "APP": {
+                        "ALLOWED_SUBSYSTEMS": [
+                            "IMAGE_SUBSYSTEM_EFI_APPLICATION"
+                        ],
+                        "ALIGNMENT": [
+                            {
+                                "COMPARISON": "==",
+                                "VALUE": 64
+                            }
+                        ]
+                    },
+                    "DXE_DRIVER": {
+                        "ALLOWED_SUBSYSTEMS": [
+                            "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
+                            "IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER",
+                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                        ],
+                        "ALIGNMENT": [
+                            {
+                                "COMPARISON": "==",
+                                "VALUE": 64
+                            }
+                        ]},
+                    "PEI": {
+                        "ALIGNMENT": [
+                            {
+                                "COMPARISON": "==",
+                                "VALUE": 32
+                            }
+                        ]
+                    }
+                },
+                "IMAGE_FILE_MACHINE_ARM64": {
+                    "DEFAULT": {
+                        "DATA_CODE_SEPARATION": True,
+                        "ALLOWED_SUBSYSTEMS": [
+                            "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
+                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                        ],
+                        "ALIGNMENT_LOGIC_SEP": "OR",
+                        "ALIGNMENT": [
+                            {
+                                "COMPARISON": "==",
+                                "VALUE": 64
+                            },
+                            {
+                                "COMPARISON": "==",
+                                "VALUE": 32
+                            }
+                        ]
+                    },
+                    "APP": {
+                        "ALLOWED_SUBSYSTEMS": [
+                            "IMAGE_SUBSYSTEM_EFI_APPLICATION"
+                        ],
+                        "ALIGNMENT": [
+                            {
+                                "COMPARISON": "==",
+                                "VALUE": 64
+                            }
+                        ]
+                    },
+                    "DXE_DRIVER": {
+                        "ALLOWED_SUBSYSTEMS": [
+                            "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
+                            "IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER",
+                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                        ],
+                        "ALIGNMENT": [
+                            {
+                                "COMPARISON": "==",
+                                "VALUE": 64
+                            }
+                        ]},
+                    "PEI": {
+                        "ALIGNMENT": [
+                            {
+                                "COMPARISON": "==",
+                                "VALUE": 32
+                            }
+                        ]
+                    }
+                },
+                "IMAGE_FILE_MACHINE_I386": {
+                    "DEFAULT": {
+                        "DATA_CODE_SEPARATION": True,
+                        "ALLOWED_SUBSYSTEMS": [
+                            "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
+                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                        ],
+                        "ALIGNMENT": [
+                            {
+                                "COMPARISON": "==",
+                                "VALUE": 4096
+                            }
+                        ]
+                    },
+                    "APP": {
+                        "ALLOWED_SUBSYSTEMS": [
+                            "IMAGE_SUBSYSTEM_EFI_APPLICATION"
+                        ]
+                    },
+                    "DRIVER": {
+                        "ALLOWED_SUBSYSTEMS": [
+                            "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
+                            "IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER"
+                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                        ]
+                    },
+                    "PEI": {}
+                }
+            }
+
+    def add_test(self, test):
+        """
+        Adds a test to the test manager. Will be executed in the order added
+
+        @param test: [Test(TestInterface)] A class that inherits and overrides
+            the TestInterface class
+        """
+        self.tests.append(test)
+
+    def add_tests(self, tests):
+        """
+        Adds multiple test to the test manager. Tests will be executed in the
+        order added.
+
+        @param test: [List[Test(TestInterface)]] A list of classes that
+            inherits and overrides the TestInterface class
+        """
+        self.tests.extend(tests)
+
+    def run_tests(self, pe, profile="DEFAULT"):
+        """
+        Runs all tests that have been added to the test manager. Tests will be
+        executed in the order added
+
+        @param pe         : [PE] The parsed pe
+        @param target_info: [Dict] A Dict that contains MACHINE_TYPE and
+            PROFILE information. If MachineType is not present, it will be
+            pulled from the parsed pe, however the user must provide the Module
+            Type
+
+        @return Result.PASS : All tests passed successfully (including warnings)
+        @return Result.SKIP : There is no information in the config file for the target and fv file type
+        @return Result.ERROR: At least one test failed. Error messages can be found in the log
+        """
+
+        machine_type = MACHINE_TYPE[pe.FILE_HEADER.Machine]
+        if not self.config_data[machine_type].get(profile):
+            profile = "DEFAULT"
+
+        # Fill any missing configurations for the specific module type with the default
+        target_requirements = self.config_data[machine_type][profile]
+        if profile != "DEFAULT":
+            for key in self.config_data[machine_type]["DEFAULT"]:
+                if key not in target_requirements:
+                    target_requirements[key] = self.config_data[machine_type]["DEFAULT"][key]
+
+        target_requirements = self.config_data[machine_type][profile]
+        target_info = {
+            "MACHINE_TYPE": machine_type,
+            "PROFILE": profile
+        }
+        test_config_data = {
+            "TARGET_INFO": target_info,
+            "TARGET_REQUIREMENTS": target_requirements
+        }
+
+        logging.debug(f'Executing tests with settings [{machine_type}][{profile}]')
+        overall_result = Result.PASS
+        for test in self.tests:
+            logging.debug(f'Starting test: [{test.name()}]')
+
+            result = test.execute(pe, test_config_data)
+
+            # Overall Result an only go lower (Pass -> Warn -> Error)
+            if result == Result.PASS:
+                logging.debug(f'{result}')
+            elif result == Result.SKIP:
+                logging.debug(f'{result}: No Requirements for [{machine_type}][{profile}]')
+            elif overall_result == Result.PASS:
+                overall_result = result
+            elif overall_result == Result.WARN and result == Result.FAIL:
+                overall_result = result
+
+        return overall_result
+
+
+###########################
+#       TESTS START       #
+###########################
+class TestWriteExecuteFlags(TestInterface):
+    """
+    Test: Section data / code separation verification
+
+    Detailed Description:
+        This test ensures that each section of the binary is not both
+        write-able and execute-able. Sections can only be one or the other
+        (or neither).This test is done by iterating over each section and
+        checking the characteristics label for the Write Mask (0x80000000)
+        and Execute Mask (0x20000000).
+
+    Output:
+        @Success: Only one (or neither) of the two masks (Write, Execute) are
+            present
+        @Skip: Test Skipped per config
+        @Fail: Both the Write and Execute flags are present
+            Possible Solution:
+
+    Possible Solution:
+        Update the failed section's characteristics to ensure it is either
+        Write-able or Read-able, but not both.
+    """
+
+    def name(self):
+        return 'Section data / code separation verification'
+
+    def execute(self, pe, config_data):
+        target_requirements = config_data["TARGET_REQUIREMENTS"]
+
+        if (not target_requirements.get("DATA_CODE_SEPARATION")
+           or target_requirements.get("DATA_CODE_SEPARATION") is False):
+            return Result.SKIP
+
+        for section in pe.sections:
+            if (has_characteristic(section.Characteristics, SECTION_CHARACTERISTICS["IMAGE_SCN_MEM_EXECUTE"])
+               and has_characteristic(section.Characteristics, SECTION_CHARACTERISTICS["IMAGE_SCN_MEM_WRITE"])):
+
+                logging.error(f'[{Result.FAIL}]: Section [{section.Name.decode().strip()}] \
+                              should not be both Write and Execute')
+                return Result.FAIL
+        return Result.PASS
+
+
+class TestSectionAlignment(TestInterface):
+    """
+    Test: Section alignment verification
+
+    Detailed Description:
+        Checks the section alignment of the binary by accessing the optional
+        header, then the section alignment. This value must meet the
+        requirements specified in the config file.
+
+    Output:
+        @Success: Image alignment meets the requirement specified in the
+            config file
+        @Warn: Image Alignment value is not found in the Optional Header or
+            set to 0
+        @Skip: No Alignment requirements specified in the config file
+        @Fail: Image alignment does not meet the requirements specified in
+            the config file
+    Possible Solution:
+        Update the section alignment of the binary to match the
+        requirements specified in the config file
+    """
+
+    def name(self):
+        return 'Section alignment verification'
+
+    def execute(self, pe, config_data):
+        target_requirements = config_data["TARGET_REQUIREMENTS"]
+        target_info = config_data["TARGET_INFO"]
+
+        alignments = target_requirements.get("ALIGNMENT")
+        if alignments is None or len(alignments) == 0:
+            return Result.SKIP
+
+        try:
+            alignment = pe.OPTIONAL_HEADER.SectionAlignment
+        except:
+            logging.warning("Section Alignment is not present")
+            return Result.WARN
+
+        if alignment is None or alignment == 0:
+            return Result.WARN
+
+        if len(alignments) > 1:
+            logical_separator = target_requirements.get("ALIGNMENT_LOGIC_SEP")
+
+            if logical_separator is None:
+                logging.error("Multiple alignment requirements exist, but no logical separator provided")
+                return Result.FAIL
+            elif logical_separator == "AND":
+                result = True
+                for reqs in alignments:
+                    result = result and eval(f'{alignment} {reqs["COMPARISON"]} {reqs["VALUE"]}')
+            elif logical_separator == "OR":
+                result = False
+                for reqs in alignments:
+                    result = result or eval(f'{alignment} {reqs["COMPARISON"]} {reqs["VALUE"]}')
+            else:
+                logging.error("Invalid logical separator provided")
+                return Result.FAIL
+        else:
+            req = alignments[0]
+            result = eval(f'{alignment} {req["COMPARISON"]} {req["VALUE"]}')
+        if result is False:
+            logging.error(f'[{Result.FAIL}: Section Alignment Required: \
+                            [{target_info["MACHINE_TYPE"]}] \
+                            [{target_info["PROFILE"]}]: \
+                            [(Detected): {alignment}]')
+            return Result.FAIL
+
+        return Result.PASS
+
+
+class TestSubsystemValue(TestInterface):
+    """
+    Test: Subsystem type verification
+
+    Detailed Description:
+        Checks the subsystem value by accessing the optional header, then
+        subsystem value. This value must match one of the allowed subsystem
+        described in the config file
+
+    Output:
+        @Success: Subsystem type found in the optional header matches one of
+            the allowed subsystems
+        @Warn   : Subsystem type is not found in the optional header
+        @Skip   : No subsystem type restrictions specified
+        @Fail   : Subsystem type found in the optional header does not match
+            one of the allowed subsystems
+
+    Possible Solution:
+        Update the subsystem type in the source code.
+    """
+
+    def name(self):
+        return 'Subsystem type verification'
+
+    def execute(self, pe, config_data):
+        target_requirements = config_data["TARGET_REQUIREMENTS"]
+
+        subsystems = target_requirements.get("ALLOWED_SUBSYSTEMS")
+        if subsystems is None or len(subsystems) == 0:
+            return Result.SKIP
+
+        try:
+            subsystem = pe.OPTIONAL_HEADER.Subsystem
+        except:
+            logging.warn("Section Alignment is not present")
+            return Result.WARN
+
+        if subsystem is None:
+            logging.warning(f'[{Result.WARN}]: Subsystem type is not present in the optional header.')
+            return Result.WARN
+
+        actual_subsystem = SUBSYSTEM_TYPE.get(subsystem)
+
+        if actual_subsystem is None:
+            logging.error(f'[{Result.WARN}]: Invalid Subsystem present')
+            return Result.FAIL
+
+        if actual_subsystem in subsystems:
+            return Result.PASS
+        else:
+            logging.error(f'{Result.FAIL}: Submodule Type [{actual_subsystem}] not allowed.')
+            return Result.FAIL
+###########################
+#        TESTS END        #
+###########################
+
+
+#
+# Command Line Interface configuration
+#
+def get_cli_args(args):
+    parser = argparse.ArgumentParser(description='A Image validation tool for memory mitigation')
+
+    parser.add_argument('-i', '--file',
+                        type=str,
+                        required=True,
+                        help='The image that needs validated.')
+    parser.add_argument('-d', '--debug',
+                        action='store_true',
+                        default=False)
+
+    parser.add_argument('-p', '--profile',
+                        type=str,
+                        default=None,
+                        help='[Optional] The profile config to be verified againt. \
+                            Will use the default, if not provided')
+
+    group = parser.add_argument_group('NX compatability flag control')
+
+    group.add_argument('--set-nx-compat',
+                       type=str,
+                       help='[Optional] Sets the NX_COMPAT flag. returns <file>_nx_set.<filetype>')
+
+    group.add_argument('--clear-nx-compat',
+                       type=str,
+                       help='[Optional] Clears the NX_COMPAT flag')
+
+    group.add_argument('--get-nx-compat',
+                       action='store_true',
+                       default=False,
+                       help='Returns the value of the NX_COMPAT flag')
+
+    return parser.parse_args(args)
+
+
+def main():
+    # setup main console as logger
+    logger = logging.getLogger('')
+    logger.setLevel(logging.INFO)
+    console = edk2_logging.setup_console_logging(False)
+    logger.addHandler(console)
+
+    args = get_cli_args(sys.argv[1:])
+
+    if args.debug is True:
+        console.setLevel(logging.DEBUG)
+
+    logging.info("Log Started: " + datetime.strftime(
+        datetime.now(), "%A, %B %d, %Y %I:%M%p"))
+
+    # Set the nx compatability flag and exit
+    if args.set_nx_compat is not None:
+        pe = PE(args.file)
+        dllchar = pe.OPTIONAL_HEADER.DllCharacteristics
+        dllchar = set_bit(dllchar, 8)  # 8th bit is the nx_compat_flag
+        pe.OPTIONAL_HEADER.DllCharacteristics = dllchar
+        basename = os.path.basename(args.file).split('.')
+        pe.write(args.set_nx_compat, filename=f'{basename[0]}_nx_set.{basename[1]}')
+        sys.exit(0)
+
+    # clear the nx compatability flag and exit
+    if args.clear_nx_compat is not None:
+        pe = PE(args.file)
+        dllchar = pe.OPTIONAL_HEADER.DllCharacteristics
+        dllchar = clear_bit(dllchar, 8)  # 8th bit is the nx_compat_flag
+        pe.OPTIONAL_HEADER.DllCharacteristics = dllchar
+        basename = os.path.basename(args.file).split('.')
+        pe.write(args.set_nx_compat, filename=f'{basename[0]}_nx_clear.{basename[1]}')
+        sys.exit(0)
+
+    # exit with status equal to if nx compatability is present or not
+    if args.get_nx_compat is True:
+        pe = PE(args.file)
+        dllchar = pe.OPTIONAL_HEADER.DllCharacteristics
+
+        if has_characteristic(dllchar, 256):  # 256 (8th bit) is the mask
+            logging.info('True')
+            sys.exit(1)
+        else:
+            logging.info('False')
+            sys.exit(0)
+
+    test_manager = TestManager()
+    test_manager.add_test(TestWriteExecuteFlags())
+    test_manager.add_test(TestSectionAlignment())
+    test_manager.add_test(TestSubsystemValue())
+
+    pe = PE(args.file)
+    if not args.module:
+        result = test_manager.run_tests(pe)
+    else:
+        result = test_manager.run_tests(pe, args.module)
+
+    logging.info(f'Overall Result: {result}')
+    if result == Result.SKIP:
+        logging.info('No Test requirements in the config file for this file.')
+    elif result == Result.PASS or result == Result.WARN:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/edk2toolext/tests/test_image_validation.py
+++ b/edk2toolext/tests/test_image_validation.py
@@ -32,11 +32,6 @@ class PE:
 # def subTest(self, msg=_subtest_msg_sentinel, **params):
 class Test_image_validation(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        logger = logging.getLogger('')
-        logger.disabled = True
-
     def test_add_test(self):
 
         test_manager = TestManager()

--- a/edk2toolext/tests/test_image_validation.py
+++ b/edk2toolext/tests/test_image_validation.py
@@ -6,9 +6,10 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 import unittest
-import logging
 from edk2toolext.image_validation import Result, TestManager, TestSectionAlignment
 from edk2toolext.image_validation import TestSubsystemValue, TestWriteExecuteFlags
+from edk2toolext.image_validation import set_bit, clear_bit, has_characteristic
+from edk2toolext.image_validation import TestInterface, fill_missing_requirements
 
 
 class Section:
@@ -23,14 +24,20 @@ class OptionalHeader:
         self.Subsystem = Subsystem
 
 
+class FileHeader:
+    def __init__(self):
+        self.Machine = 0x8664
+
+
 class PE:
     def __init__(self, sections=None, optional_header=None):
         self.sections = sections
         self.OPTIONAL_HEADER = optional_header
+        self.FILE_HEADER = FileHeader()
 
 
 # def subTest(self, msg=_subtest_msg_sentinel, **params):
-class Test_image_validation(unittest.TestCase):
+class TestImageValidationInterface(unittest.TestCase):
 
     def test_add_test(self):
 
@@ -45,52 +52,77 @@ class Test_image_validation(unittest.TestCase):
         test_manager.add_tests([TestSectionAlignment(), TestSubsystemValue()])
         self.assertEqual(len(test_manager.tests), 2)
 
+    def test_test_manager(self):
+        config_data = {
+            "TARGET_ARCH": {
+                "X64": "IMAGE_FILE_MACHINE_AMD64"
+            },
+            "IMAGE_FILE_MACHINE_AMD64": {
+                "DEFAULT": {
+                    "DATA_CODE_SEPARATION": False
+                }
+            }
+        }
+        test_manager = TestManager(config_data=config_data)
+        self.assertEqual(test_manager.config_data, config_data)
+
+        pe = PE(sections=[Section("S1.1".encode("utf-8"), characteristics=0x80000000)])
+        test_manager.add_test(TestWriteExecuteFlags())
+        result = test_manager.run_tests(pe, "BAD_PROFILE")
+        self.assertEqual(result, Result.PASS)
+
     def test_write_execute_flags_test(self):
         """
         TestWriteExecuteFlags follows the following logic:
         1. If test requirement is not specified, or equal to false, return Result.SKIP
         3. Return Result.PASS / Result.FAIL returned based on Characteristic value
         """
-        TEST_PE0 = PE(sections=[
+        test_pe0 = PE(sections=[
             Section("S1.1".encode("utf-8"), characteristics=0x80000000),
             Section("S1.2".encode("utf-8"), characteristics=0x20000000),
             Section("S1.3".encode("utf-8"), characteristics=0x00000000)])
 
-        TEST_PE1 = PE(sections=[
+        test_pe1 = PE(sections=[
             Section("S2.1".encode("utf-8"), characteristics=0xA0000000),
             Section("S2.2".encode("utf-8"), characteristics=0x20000000),
             Section("S2.3".encode("utf-8"), characteristics=0x00000000)])
 
-        TEST_PE2 = PE(sections=[
+        test_pe2 = PE(sections=[
             Section("S3.1".encode("utf-8"), characteristics=0x20000000),
             Section("S3.2".encode("utf-8"), characteristics=0x80000000),
             Section("S3.3".encode("utf-8"), characteristics=0xC0000000)])
 
-        TEST_PE3 = PE(sections=[
+        test_pe3 = PE(sections=[
             Section("S4.1".encode("utf-8"), characteristics=0xE0000000)])
-
-        test_write_execute_flags = TestWriteExecuteFlags()
-        tests = [(TEST_PE0, Result.PASS), (TEST_PE1, Result.FAIL), (TEST_PE2, Result.PASS), (TEST_PE3, Result.FAIL)]
-
-        config_data0 = {
-            "TARGET_REQUIREMENTS": {"DATA_CODE_SEPARATION": True}
-        }
-        for i in range(len(tests)):
-            with self.subTest("test@config=True", i=i):
-                pe, result = tests[i]
-                self.assertEqual(test_write_execute_flags.execute(pe, config_data0), result)
 
         config_data1 = {
             "TARGET_REQUIREMENTS": {"DATA_CODE_SEPARATION": False}
         }
+
+        config_data2 = {"TARGET_REQUIREMENTS": {}}
+
+        test_write_execute_flags = TestWriteExecuteFlags()
+        tests = [(test_pe0, Result.PASS), (test_pe1, Result.FAIL), (test_pe2, Result.PASS), (test_pe3, Result.FAIL)]
+
+        config_data0 = {
+            "TARGET_REQUIREMENTS": {"DATA_CODE_SEPARATION": True}
+        }
+
+        # Test set 1
         for i in range(len(tests)):
-            with self.subTest("test@config=False", i=i):
+            with self.subTest("test_write_execute1", i=i):
+                pe, result = tests[i]
+                self.assertEqual(test_write_execute_flags.execute(pe, config_data0), result)
+
+        # Test set 2
+        for i in range(len(tests)):
+            with self.subTest("test_write_execute2", i=i):
                 pe, _ = tests[i]
                 self.assertEqual(test_write_execute_flags.execute(pe, config_data1), Result.SKIP)
 
-        config_data2 = {"TARGET_REQUIREMENTS": {}}
+        # Test set 3
         for i in range(len(tests)):
-            with self.subTest("test@config=False", i=i):
+            with self.subTest("test_write_execute3", i=i):
                 pe, _ = tests[i]
                 self.assertEqual(test_write_execute_flags.execute(pe, config_data2), Result.SKIP)
 
@@ -138,31 +170,36 @@ class Test_image_validation(unittest.TestCase):
             "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
         }
 
-        TEST_PE0 = PE(optional_header=OptionalHeader(SectionAlignment=4096))
+        test_pe0 = PE(optional_header=OptionalHeader(SectionAlignment=4096))
+        test_pe1 = PE(optional_header=OptionalHeader(SectionAlignment=0))
+        test_pe2 = PE(optional_header=None)
+
         test_section_alignment_test = TestSectionAlignment()
         tests0 = [(config_data0, Result.SKIP), (config_data1, Result.SKIP),
                   (config_data2, Result.PASS), (config_data3, Result.FAIL),
                   (config_data4, Result.PASS), (config_data5, Result.FAIL)]
+
+        # Test set 1
         for i in range(len(tests0)):
             with self.subTest("test_section_alignment_test0", i=i):
                 config, result = tests0[i]
-                self.assertEqual(test_section_alignment_test.execute(TEST_PE0, config), result)
+                self.assertEqual(test_section_alignment_test.execute(test_pe0, config), result)
 
-        TEST_PE1 = PE(optional_header=OptionalHeader(SectionAlignment=0))
         tests1 = [(config_data0, Result.SKIP), (config_data1, Result.SKIP),
                   (config_data2, Result.WARN), (config_data3, Result.WARN),
                   (config_data4, Result.WARN), (config_data5, Result.WARN)]
 
+        # Test set 2
         for i in range(len(tests1)):
             with self.subTest("test_section_alignment_test1", i=i):
                 config, result = tests1[i]
-                self.assertEqual(test_section_alignment_test.execute(TEST_PE1, config), result)
+                self.assertEqual(test_section_alignment_test.execute(test_pe1, config), result)
 
-        TEST_PE2 = PE(optional_header=None)
+        # Test set 3
         for i in range(len(tests1)):
             with self.subTest("test_section_alignment_test2", i=i):
                 config, result = tests1[i]
-                self.assertEqual(test_section_alignment_test.execute(TEST_PE2, config), result)
+                self.assertEqual(test_section_alignment_test.execute(test_pe2, config), result)
 
     def test_section_alignment_test2(self):
 
@@ -229,8 +266,6 @@ class Test_image_validation(unittest.TestCase):
                 config, result = tests[i]
                 self.assertEqual(test_section_alignment_test.execute(pe, config), result)
 
-    test_pe_and = PE(optional_header=OptionalHeader(SectionAlignment=4096))
-
     def test_subsystem_value_test(self):
         """
         TestSubsystemValue follows the following logic:
@@ -282,3 +317,64 @@ class Test_image_validation(unittest.TestCase):
             with self.subTest("test_subsystem_value2", i=i):
                 config, result = tests2[i]
                 self.assertEqual(test_subsystem_value_test.execute(TEST_PE2, config), result)
+
+    def test_helper_functions(self):
+
+        data = 0b00000000
+        results = [1, 2, 4, 8, 16, 32, 64]
+
+        for i in range(len(results)):
+            with self.subTest("test_set_bit1", i=i):
+                self.assertEqual(set_bit(data, i), results[i])
+
+        data = 0b11111111
+        result = 255
+        for i in range(7):
+            with self.subTest("test_set_bit2", i=i):
+                self.assertEqual(set_bit(data, i), result)
+
+        data = 0b11111111
+        result = [254, 253, 251, 247, 239, 223, 191, 127]
+
+        for i in range(len(result)):
+            with self.subTest("test_clear_bit1", i=i):
+                self.assertEqual(clear_bit(data, i), result[i])
+
+        data = 0b00000000
+        result = 0
+
+        for i in range(7):
+            with self.subTest("test_clear_bit2", i=i):
+                self.assertEqual(clear_bit(data, i), result)
+
+        data = 0b11001101
+        masks = [0b10100000, 0b10000001, 0b10101010, 0b11110000, 0b00000001]
+        result = [False, True, False, False, True]
+
+        for i in range(len(result)):
+            with self.subTest("test_has_characteristic", i=i):
+                self.assertEqual(has_characteristic(data, masks[i]), result[i])
+
+        default_config = {
+            "T1": "T",
+            "T2": "T",
+            "T3": "T",
+        }
+        target_config = {
+            "T2": "F"
+        }
+        final_config = {
+            "T1": "T",
+            "T2": "F",
+            "T3": "T"
+        }
+
+        self.assertEqual(fill_missing_requirements(default_config, target_config), final_config)
+
+    def test_test_interface(self):
+        c = TestInterface()
+
+        with self.assertRaises(NotImplementedError):
+            c.name()
+        with self.assertRaises(NotImplementedError):
+            c.execute(1, 2)

--- a/edk2toolext/tests/test_image_validation.py
+++ b/edk2toolext/tests/test_image_validation.py
@@ -34,7 +34,6 @@ class PE:
         self.FILE_HEADER = FileHeader()
 
 
-# def subTest(self, msg=_subtest_msg_sentinel, **params):
 class TestImageValidationInterface(unittest.TestCase):
 
     def test_add_test(self):
@@ -67,6 +66,9 @@ class TestImageValidationInterface(unittest.TestCase):
         pe = PE(sections=[Section("S1.1".encode("utf-8"), characteristics=0x80000000)])
         test_manager.add_test(IV.TestWriteExecuteFlags())
         result = test_manager.run_tests(pe, "BAD_PROFILE")
+        self.assertEqual(result, IV.Result.FAIL)
+
+        result = test_manager.run_tests(pe)
         self.assertEqual(result, IV.Result.PASS)
 
     def test_write_execute_flags_test(self):

--- a/edk2toolext/tests/test_image_validation.py
+++ b/edk2toolext/tests/test_image_validation.py
@@ -1,0 +1,289 @@
+# @file test_image_validation.py
+# This contains unit tests for the image validation tool.
+##
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+import unittest
+import logging
+from edk2toolext.image_validation import Result, TestManager, TestSectionAlignment
+from edk2toolext.image_validation import TestSubsystemValue, TestWriteExecuteFlags
+
+
+class Section:
+    def __init__(self, name, characteristics=None):
+        self.Characteristics = characteristics
+        self.Name = name
+
+
+class OptionalHeader:
+    def __init__(self, SectionAlignment=None, Subsystem=None):
+        self.SectionAlignment = SectionAlignment
+        self.Subsystem = Subsystem
+
+
+class PE:
+    def __init__(self, sections=None, optional_header=None):
+        self.sections = sections
+        self.OPTIONAL_HEADER = optional_header
+
+
+# def subTest(self, msg=_subtest_msg_sentinel, **params):
+class Test_image_validation(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        logger = logging.getLogger('')
+        logger.disabled = True
+
+    def test_add_test(self):
+
+        test_manager = TestManager()
+        self.assertEqual(len(test_manager.tests), 0)
+        test_manager.add_test(TestSectionAlignment())
+        self.assertEqual(len(test_manager.tests), 1)
+
+    def test_add_tests(self):
+        test_manager = TestManager()
+        self.assertEqual(len(test_manager.tests), 0)
+        test_manager.add_tests([TestSectionAlignment(), TestSubsystemValue()])
+        self.assertEqual(len(test_manager.tests), 2)
+
+    def test_write_execute_flags_test(self):
+        """
+        TestWriteExecuteFlags follows the following logic:
+        1. If test requirement is not specified, or equal to false, return Result.SKIP
+        3. Return Result.PASS / Result.FAIL returned based on Characteristic value
+        """
+        TEST_PE0 = PE(sections=[
+            Section("S1.1".encode("utf-8"), characteristics=0x80000000),
+            Section("S1.2".encode("utf-8"), characteristics=0x20000000),
+            Section("S1.3".encode("utf-8"), characteristics=0x00000000)])
+
+        TEST_PE1 = PE(sections=[
+            Section("S2.1".encode("utf-8"), characteristics=0xA0000000),
+            Section("S2.2".encode("utf-8"), characteristics=0x20000000),
+            Section("S2.3".encode("utf-8"), characteristics=0x00000000)])
+
+        TEST_PE2 = PE(sections=[
+            Section("S3.1".encode("utf-8"), characteristics=0x20000000),
+            Section("S3.2".encode("utf-8"), characteristics=0x80000000),
+            Section("S3.3".encode("utf-8"), characteristics=0xC0000000)])
+
+        TEST_PE3 = PE(sections=[
+            Section("S4.1".encode("utf-8"), characteristics=0xE0000000)])
+
+        test_write_execute_flags = TestWriteExecuteFlags()
+        tests = [(TEST_PE0, Result.PASS), (TEST_PE1, Result.FAIL), (TEST_PE2, Result.PASS), (TEST_PE3, Result.FAIL)]
+
+        config_data0 = {
+            "TARGET_REQUIREMENTS": {"DATA_CODE_SEPARATION": True}
+        }
+        for i in range(len(tests)):
+            with self.subTest("test@config=True", i=i):
+                pe, result = tests[i]
+                self.assertEqual(test_write_execute_flags.execute(pe, config_data0), result)
+
+        config_data1 = {
+            "TARGET_REQUIREMENTS": {"DATA_CODE_SEPARATION": False}
+        }
+        for i in range(len(tests)):
+            with self.subTest("test@config=False", i=i):
+                pe, _ = tests[i]
+                self.assertEqual(test_write_execute_flags.execute(pe, config_data1), Result.SKIP)
+
+        config_data2 = {"TARGET_REQUIREMENTS": {}}
+        for i in range(len(tests)):
+            with self.subTest("test@config=False", i=i):
+                pe, _ = tests[i]
+                self.assertEqual(test_write_execute_flags.execute(pe, config_data2), Result.SKIP)
+
+    def test_section_alignment_test(self):
+        """
+        TestSectionAlignment follows the following logic:
+        1. If requirements are not specified, or is empty, return Result.SKIP
+        2. If SectionAlignment is not present, or is 0, return Result.WARN
+        3. Return Result.PASS / Result.FAIL returned based on alignment requirements
+        """
+
+        config_data0 = {
+            "TARGET_REQUIREMENTS": {},
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+        }
+        config_data1 = {
+            "TARGET_REQUIREMENTS": {"ALIGNMENT": []},
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+        }
+        config_data2 = {
+            "TARGET_REQUIREMENTS": {"ALIGNMENT": [{"COMPARISON": ">=", "VALUE": 0}]},
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+        }
+
+        config_data3 = {
+            "TARGET_REQUIREMENTS": {"ALIGNMENT": [{"COMPARISON": "==", "VALUE": 1}]},
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+        }
+
+        config_data4 = {
+            "TARGET_REQUIREMENTS": {"ALIGNMENT": [
+                {"COMPARISON": ">=", "VALUE": 0},
+                {"COMPARISON": ">=", "VALUE": 64},
+                {"COMPARISON": "<=", "VALUE": 8192}],
+                "ALIGNMENT_LOGIC_SEP": "AND"},
+            "TARGET_INFO": {}
+        }
+
+        config_data5 = {
+            "TARGET_REQUIREMENTS": {"ALIGNMENT": [
+                {"COMPARISON": ">=", "VALUE": 0},
+                {"COMPARISON": ">=", "VALUE": 64},
+                {"COMPARISON": "!=", "VALUE": 4096}],
+                "ALIGNMENT_LOGIC_SEP": "AND"},
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+        }
+
+        TEST_PE0 = PE(optional_header=OptionalHeader(SectionAlignment=4096))
+        test_section_alignment_test = TestSectionAlignment()
+        tests0 = [(config_data0, Result.SKIP), (config_data1, Result.SKIP),
+                  (config_data2, Result.PASS), (config_data3, Result.FAIL),
+                  (config_data4, Result.PASS), (config_data5, Result.FAIL)]
+        for i in range(len(tests0)):
+            with self.subTest("test_section_alignment_test0", i=i):
+                config, result = tests0[i]
+                self.assertEqual(test_section_alignment_test.execute(TEST_PE0, config), result)
+
+        TEST_PE1 = PE(optional_header=OptionalHeader(SectionAlignment=0))
+        tests1 = [(config_data0, Result.SKIP), (config_data1, Result.SKIP),
+                  (config_data2, Result.WARN), (config_data3, Result.WARN),
+                  (config_data4, Result.WARN), (config_data5, Result.WARN)]
+
+        for i in range(len(tests1)):
+            with self.subTest("test_section_alignment_test1", i=i):
+                config, result = tests1[i]
+                self.assertEqual(test_section_alignment_test.execute(TEST_PE1, config), result)
+
+        TEST_PE2 = PE(optional_header=None)
+        for i in range(len(tests1)):
+            with self.subTest("test_section_alignment_test2", i=i):
+                config, result = tests1[i]
+                self.assertEqual(test_section_alignment_test.execute(TEST_PE2, config), result)
+
+    def test_section_alignment_test2(self):
+
+        target_config0 = {
+            "TARGET_REQUIREMENTS": {
+                "ALIGNMENT": [
+                    {"COMPARISON": ">=", "VALUE": 0},
+                    {"COMPARISON": "<=", "VALUE": 8192}],
+                "ALIGNMENT_LOGIC_SEP": "AND"},
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+        }
+
+        target_config1 = {
+            "TARGET_REQUIREMENTS": {
+                "ALIGNMENT": [
+                    {"COMPARISON": "==", "VALUE": 0},
+                    {"COMPARISON": "<=", "VALUE": 8192}],
+                "ALIGNMENT_LOGIC_SEP": "AND"},
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+        }
+
+        target_config2 = {
+            "TARGET_REQUIREMENTS": {
+                "ALIGNMENT": [
+                    {"COMPARISON": "==", "VALUE": 32},
+                    {"COMPARISON": "==", "VALUE": 4096}],
+                "ALIGNMENT_LOGIC_SEP": "OR"},
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+        }
+
+        target_config3 = {
+            "TARGET_REQUIREMENTS": {
+                "ALIGNMENT": [
+                    {"COMPARISON": "==", "VALUE": 31},
+                    {"COMPARISON": "==", "VALUE": 61}],
+                "ALIGNMENT_LOGIC_SEP": "OR"},
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+        }
+
+        target_config4 = {
+            "TARGET_REQUIREMENTS": {
+                "ALIGNMENT": [
+                    {"COMPARISON": "==", "VALUE": 32},
+                    {"COMPARISON": "==", "VALUE": 64}]},
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+        }
+
+        target_config5 = {
+            "TARGET_REQUIREMENTS": {
+                "ALIGNMENT": [
+                    {"COMPARISON": "==", "VALUE": 32},
+                    {"COMPARISON": "==", "VALUE": 64}],
+                "ALIGNMENT_LOGIC_SEP": "AR"},
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+        }
+
+        test_section_alignment_test = TestSectionAlignment()
+        pe = PE(optional_header=OptionalHeader(SectionAlignment=4096))
+        tests = [(target_config0, Result.PASS), (target_config1, Result.FAIL), (target_config2, Result.PASS),
+                 (target_config3, Result.FAIL), (target_config4, Result.FAIL), (target_config5, Result.FAIL)]
+
+        for i in range(len(tests)):
+            with self.subTest("test_section_alignment_and_or_logic", i=i):
+                config, result = tests[i]
+                self.assertEqual(test_section_alignment_test.execute(pe, config), result)
+
+    test_pe_and = PE(optional_header=OptionalHeader(SectionAlignment=4096))
+
+    def test_subsystem_value_test(self):
+        """
+        TestSubsystemValue follows the following logic:
+        1. If Allowed Subsystems are not specified, or empty, return Result.SKIP
+        2. If subsystem type is not present, return Result.WARN
+        3. If subsystem type is invalid, return Result.FAIL
+        3. return Result.PASS / Result.FAIL returned based on subsystem value
+        """
+        config_data0 = {
+            "TARGET_REQUIREMENTS": {}
+        }
+        config_data1 = {
+            "TARGET_REQUIREMENTS": {"ALLOWED_SUBSYSTEMS": []}
+        }
+        config_data2 = {
+            "TARGET_REQUIREMENTS": {"ALLOWED_SUBSYSTEMS": ["IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER"]}
+        }
+        config_data3 = {
+            "TARGET_REQUIREMENTS": {"ALLOWED_SUBSYSTEMS":
+                                    ["IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
+                                     "IMAGE_SUBSYSTEM_EFI_APPLICATION"]}
+        }
+
+        test_subsystem_value_test = TestSubsystemValue()
+
+        TEST_PE0 = PE(optional_header=OptionalHeader(Subsystem=10))
+        tests0 = [(config_data0, Result.SKIP), (config_data1, Result.SKIP),
+                  (config_data2, Result.FAIL), (config_data3, Result.PASS)]
+
+        for i in range(len(tests0)):
+            with self.subTest("test_subsystem_value0", i=i):
+                config, result = tests0[i]
+                self.assertEqual(test_subsystem_value_test.execute(TEST_PE0, config), result)
+
+        TEST_PE1 = PE(optional_header=OptionalHeader(Subsystem="UEFI_"))
+        tests1 = [(config_data0, Result.SKIP), (config_data1, Result.SKIP),
+                  (config_data2, Result.FAIL), (config_data3, Result.FAIL)]
+
+        for i in range(len(tests1)):
+            with self.subTest("test_subsystem_value1", i=i):
+                config, result = tests1[i]
+                self.assertEqual(test_subsystem_value_test.execute(TEST_PE1, config), result)
+
+        TEST_PE2 = PE(optional_header=OptionalHeader(Subsystem=None))
+        tests2 = [(config_data0, Result.SKIP), (config_data1, Result.SKIP),
+                  (config_data2, Result.WARN), (config_data3, Result.WARN)]
+
+        for i in range(len(tests2)):
+            with self.subTest("test_subsystem_value2", i=i):
+                config, result = tests2[i]
+                self.assertEqual(test_subsystem_value_test.execute(TEST_PE2, config), result)

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,8 @@ setuptools.setup(
                             'sig_db_tool=edk2toolext.uefi.sig_db_tool:main',
                             'firmware_policy_tool=edk2toolext.windows.policy.firmware_policy_tool:main',
                             'edk2_capsule_tool=edk2toolext.capsule.capsule_tool:main',
-                            'versioninfo_tool=edk2toolext.versioninfo.versioninfo_tool:main']
+                            'versioninfo_tool=edk2toolext.versioninfo.versioninfo_tool:main',
+                            'validate_image_tool=edk2toolext.image_validation:main']
     },
     install_requires=[
         'pyyaml>=5.3.1',


### PR DESCRIPTION
Add a PE/COFF image validation tool for command line that can be used to
verify that memory protection requirements such as section alignment and
write / execute exclusion settings have been applied correctly to
PE/COFF files.