### PR TITLE
Propagate failures from ci_setup and setup

### DIFF
--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -109,7 +109,7 @@ def resolve(file_system_path, dependency, force=False, ignore=False, update_ok=F
 # dependencies is a list of objects - it has Path, Commit, Branch,
 
 
-def resolve_all(WORKSPACE_PATH, dependencies, force=False, ignore=False, update_ok=False, omnicache_dir=None):
+def resolve_all(workspace_path, dependencies, force=False, ignore=False, update_ok=False, omnicache_dir=None):
     logger = logging.getLogger("git")
     repos = []
     if force:
@@ -122,14 +122,14 @@ def resolve_all(WORKSPACE_PATH, dependencies, force=False, ignore=False, update_
         if "ReferencePath" not in dependency and omnicache_dir:
             dependency["ReferencePath"] = omnicache_dir
         if "ReferencePath" in dependency:  # make sure that the omnicache dir is relative to the working directory
-            dependency["ReferencePath"] = os.path.join(WORKSPACE_PATH, dependency["ReferencePath"])
-        git_path = os.path.join(WORKSPACE_PATH, dep_path)
+            dependency["ReferencePath"] = os.path.join(workspace_path, dependency["ReferencePath"])
+        git_path = os.path.join(workspace_path, dep_path)
         repos.append(git_path)
         resolve(git_path, dependency, force, ignore, update_ok)
 
     # print out the details- this is optional
     for dependency in dependencies:
-        git_path = os.path.join(WORKSPACE_PATH, dependency["Path"])
+        git_path = os.path.join(workspace_path, dependency["Path"])
         GitDetails = get_details(git_path)
         # print out details
         logger.info("{3} = Git Details: Url: {0} Branch {1} Commit {2}".format(

--- a/edk2toolext/invocables/edk2_ci_setup.py
+++ b/edk2toolext/invocables/edk2_ci_setup.py
@@ -70,15 +70,16 @@ class Edk2CiBuildSetup(Edk2MultiPkgAwareInvocable):
         return "CISETUP"
 
     def Go(self):
-
-        ret = repo_resolver.resolve_all(self.GetWorkspaceRoot(),
-                                        self.PlatformSettings.GetDependencies(),
+        setup_dependencies = self.PlatformSettings.GetDependencies()
+        logging.debug(f"Dependencies list {setup_dependencies}")
+        repos = repo_resolver.resolve_all(self.GetWorkspaceRoot(),
+                                        setup_dependencies,
                                         ignore=self.git_ignore, force=self.git_force,
                                         update_ok=self.git_update, omnicache_dir=self.omnicache_path)
 
-        logging.info(f"Repo resolver resolved {ret}")
+        logging.info(f"Repo resolver resolved {repos}")
 
-        return ret
+        return 0 if None not in repos else -1
 
 
 def main():

--- a/edk2toolext/invocables/edk2_ci_setup.py
+++ b/edk2toolext/invocables/edk2_ci_setup.py
@@ -73,9 +73,9 @@ class Edk2CiBuildSetup(Edk2MultiPkgAwareInvocable):
         setup_dependencies = self.PlatformSettings.GetDependencies()
         logging.debug(f"Dependencies list {setup_dependencies}")
         repos = repo_resolver.resolve_all(self.GetWorkspaceRoot(),
-                                        setup_dependencies,
-                                        ignore=self.git_ignore, force=self.git_force,
-                                        update_ok=self.git_update, omnicache_dir=self.omnicache_path)
+                                          setup_dependencies,
+                                          ignore=self.git_ignore, force=self.git_force,
+                                          update_ok=self.git_update, omnicache_dir=self.omnicache_path)
 
         logging.info(f"Repo resolver resolved {repos}")
 

--- a/edk2toolext/invocables/edk2_ci_setup.py
+++ b/edk2toolext/invocables/edk2_ci_setup.py
@@ -78,7 +78,7 @@ class Edk2CiBuildSetup(Edk2MultiPkgAwareInvocable):
 
         logging.info(f"Repo resolver resolved {ret}")
 
-        return 0
+        return ret
 
 
 def main():

--- a/edk2toolext/invocables/edk2_setup.py
+++ b/edk2toolext/invocables/edk2_setup.py
@@ -122,9 +122,10 @@ class Edk2PlatformSetup(Edk2MultiPkgAwareInvocable):
                 logging.error("FAILED!\n")
                 logging.error("Error while trying to clean the environment!")
                 logging.error(str(e))
-                return
+                return -1
 
         # Grab the remaining Git repos.
+        result = 0
         if required_submodules and len(required_submodules) > 0:
 
             # Git Repos: STEP 1 --------------------------------------
@@ -140,7 +141,7 @@ class Edk2PlatformSetup(Edk2MultiPkgAwareInvocable):
                 logging.error("FAILED!\n")
                 logging.error("Error while trying to synchronize the environment!")
                 logging.error(str(e))
-                return
+                return -1
 
             # Git Repos: STEP 2 --------------------------------------
             # Iterate through all repos and see whether they should be fetched.
@@ -190,8 +191,9 @@ class Edk2PlatformSetup(Edk2MultiPkgAwareInvocable):
                     logging.error("FAILED!\n")
                     logging.error("Failed to fetch required repository!\n")
                     logging.error(str(e))
+                    result = -1
 
-        return 0
+        return result
 
 
 def main():

--- a/edk2toolext/tests/test_edk2_ci_setup.py
+++ b/edk2toolext/tests/test_edk2_ci_setup.py
@@ -63,7 +63,7 @@ class TestEdk2CiSetup(unittest.TestCase):
     def test_ci_setup(self):
         builder = Edk2CiBuildSetup()
         settings_file = os.path.join(self.minimalTree, "settings.py")
-        sys.argv = ["stuart_ci_setup", "-c", settings_file]
+        sys.argv = ["stuart_ci_setup", "-c", settings_file, "-v"]
         try:
             builder.Invoke()
         except SystemExit as e:


### PR DESCRIPTION
Currently, a failure in setup or ci_setup will not cause the pipeline to fail. The only indication
that a failure has occurred would be a failure in later build steps.

This change enables those failures to be detected at the pipeline level.