### PR TITLE
Override comput_published_path in git_dependency.py to include repo root

### DIFF
--- a/edk2toolext/environment/extdeptypes/git_dependency.py
+++ b/edk2toolext/environment/extdeptypes/git_dependency.py
@@ -104,3 +104,7 @@ class GitDependency(ExternalDependency):
 
         self.logger.debug("Verify '%s' returning '%s'." % (self.name, result))
         return result
+
+    # Override to include the repository name in published path
+    def compute_published_path(self):
+        return os.path.join(super().compute_published_path(), self.name)


### PR DESCRIPTION
[Issue #287]

Change the default behavior for the published path of a git dependency to include the repository root directory. This is needed to reference the repo contents for builds.

Before: ...\MU_BASECORE_extdep
After: ...\MU_BASECORE_extdep\MU_BASECORE

