### PR TITLE
Bug: Check all directories in env directory traversal

### DIFF
--- a/edk2toolext/environment/self_describing_environment.py
+++ b/edk2toolext/environment/self_describing_environment.py
@@ -54,7 +54,11 @@ class self_describing_environment(object):
         matches = {}
         for root, dirs, files in os.walk(base_path, topdown=True):
             # Check to see whether any of these directories should be skipped..
-            dirs[:] = [d for d in dirs if pathlib.Path(root, d) not in self.skipped_dirs and pathlib.Path(root, d).name != '.git']
+            dirs[:] = [d
+                       for d
+                       in dirs
+                       if pathlib.Path(root, d) not in self.skipped_dirs
+                       and pathlib.Path(root, d).name != '.git']
 
             # Check for any files that match the extensions we're looking for.
             for file in files:

--- a/edk2toolext/environment/self_describing_environment.py
+++ b/edk2toolext/environment/self_describing_environment.py
@@ -54,11 +54,7 @@ class self_describing_environment(object):
         matches = {}
         for root, dirs, files in os.walk(base_path, topdown=True):
             # Check to see whether any of these directories should be skipped..
-            for index, dir in enumerate(dirs):
-                dir_path = pathlib.Path(root, dir)
-                if dir_path in self.skipped_dirs or dir_path.name == '.git':
-                    logging.debug(f"Skipping: {dir_path.resolve()}")
-                    del dirs[index]
+            dirs[:] = [d for d in dirs if pathlib.Path(root, d) not in self.skipped_dirs and pathlib.Path(root, d).name != '.git']
 
             # Check for any files that match the extensions we're looking for.
             for file in files:


### PR DESCRIPTION
161e4be added support to self_describing_environment._gather_env_files()
to skip directories specified by a platform. That commit reused existing
directory walk logic which modifies the dir list used for the walk based
on index.

This does not work when multiple directories might be removed
from a single root as when a directory is removed in-place during
enumeration, the index is incremented by one and the next directory is
removed. This effectively causes the new index to skip the actual next
item on the next iteration.

For example:
  dirs = ['.git', 'a', 'b', 'c', 'd']
  i = 1
  del dirs[i] removes dirs[1] => 'a'

  dirs = ['.git', 'b', 'c', 'd']
  i = 2
  dirs[i] now = 'c' not 'b'

This change modifies the in-place assignment of dirs to use slice
assignment which similarly prunes the dir list for subsequent file
enumeration without depending upon an index value.

This would not surface as an issue unless two consecutive directories
in the directory are removed, in which case, the second directory is
ignored instead of removed.

test_multiple_duplicate_ext_deps_skip_dir() added to test_edk2_update.py
demonstrates this. It fails with the previous logic as
six/seventh/eighth directly proceeds third/fourth/fifth in the dir list
causing it to be skipped over. It is properly removed with the new logic.