### PR TITLE
Lock CSpell to 5.20.0

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -7,6 +7,7 @@
         "python",
         "cpp"
     ],
+    "allowCompoundWords": true,
     "ignorePaths": [
         "*.exe"
     ],

--- a/azure-pipelines/templates/spell-test-steps.yml
+++ b/azure-pipelines/templates/spell-test-steps.yml
@@ -13,7 +13,7 @@ parameters:
 steps:
 - task: NodeTool@0
   inputs:
-    versionSpec: '12.x'
+    versionSpec: '18.x'
 
 - script: npm install -g cspell
   displayName: 'Install cspell npm'

--- a/azure-pipelines/templates/spell-test-steps.yml
+++ b/azure-pipelines/templates/spell-test-steps.yml
@@ -15,7 +15,7 @@ steps:
   inputs:
     versionSpec: '18.x'
 
-- script: npm install -g cspell
+- script: npm install -g cspell@5.20.0
   displayName: 'Install cspell npm'
 
 - script: cspell -c .cspell.json "**/*.py" "**/*.md"


### PR DESCRIPTION
This PR Locks Cspell to 5.20.0 and updates the NodeJS Version to 18.X to meet Cspell requirements.