### PR TITLE
Update Integration Tests

### DIFF
--- a/integration_test/edk2_stuart_pr_eval.robot
+++ b/integration_test/edk2_stuart_pr_eval.robot
@@ -127,7 +127,7 @@ Test Stuart PR for Policy 3 for package dependency on change of public header fi
     Commit changes  "Changes"  ${ws_root}
 
     # Core CI test  package dependency # Policy 3
-    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,UefiCpuPkg  ${default_branch}  ${EMPTY}  ${ws_root}
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
 
     [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}

--- a/integration_test/mu_stuart_pr_eval.robot
+++ b/integration_test/mu_stuart_pr_eval.robot
@@ -271,7 +271,7 @@ Test Stuart PR for changing a file at the root of repo
     [Tags]           PrEval
 
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
-    ${file_to_modify}=   Set Variable    edksetup.bat
+    ${file_to_modify}=   Set Variable    ReadMe.rst
 
     Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}


### PR DESCRIPTION
This PR updates two integration tests. for PR evaluation.; The first is a Project Mu test that removes a file at the root of the repo. The file, edksetup.bat, is in Project Mu's .gitignore, so performing git operations on the file fails, failing the test. The file has been updated. The second is an EDK2 test for package dependency, where it is expected a change in CryptoPkg will not result in MdePkg, MdeModulePkg, or UefiCpuPkg needing to be built. With recent changes to EDK2, UefiCpuPkg now relies on CryptoPkg, so this test is failing. UefiCpuPkg has been removed from the test.