### PR TITLE
Fix an issue where a bad variable name caused a trace in an error branch

### DIFF
--- a/edk2toolext/invocables/edk2_ci_setup.py
+++ b/edk2toolext/invocables/edk2_ci_setup.py
@@ -54,7 +54,7 @@ class Edk2CiBuildSetup(Edk2MultiPkgAwareInvocable):
         self.git_update = args.git_update
         self.omnicache_path = args.omnicache_path
         if (self.omnicache_path is not None) and (not os.path.exists(self.omnicache_path)):
-            logging.warning(f"Omnicache path set to invalid path: {args.omnicache_Path}")
+            logging.warning(f"Omnicache path set to invalid path: {args.omnicache_path}")
             self.omnicache_path = None
 
         super().RetrieveCommandLineOptions(args)

--- a/edk2toolext/tests/test_edk2_ci_setup.py
+++ b/edk2toolext/tests/test_edk2_ci_setup.py
@@ -69,3 +69,13 @@ class TestEdk2CiSetup(unittest.TestCase):
         except SystemExit as e:
             self.assertEqual(e.code, 0, "We should have a non zero error code")
             pass
+
+    def test_ci_setup_bad_omnicache_path(self):
+        builder = Edk2CiBuildSetup()
+        settings_file = os.path.join(self.minimalTree, "settings.py")
+        sys.argv = ["stuart_ci_setup", "-c", settings_file, "-v", "--omnicache", "does_not_exist"]
+        try:
+            builder.Invoke()
+        except SystemExit as e:
+            self.assertEqual(e.code, 0, "We should have a non zero error code")
+            pass


### PR DESCRIPTION
Fixed a variable name issue in edk2_ci_setup and added a test case to catch it.