### PR TITLE
Improve NuGet dependency semantic version handling

### DIFF
--- a/edk2toolext/tests/test_nuget_dependency.py
+++ b/edk2toolext/tests/test_nuget_dependency.py
@@ -163,43 +163,6 @@ class TestNugetDependency(unittest.TestCase):
             ext_dep.fetch()
         self.assertFalse(ext_dep.verify())
 
-    def test_normalize_version(self):
-        version1 = "5.10.05.0"
-        proper_version1 = "5.10.5"
-        self.assertEqual(proper_version1, NugetDependency.normalize_version(version1))
-        version2 = "6.10"
-        proper_version2 = "6.10.0"
-        self.assertEqual(proper_version2, NugetDependency.normalize_version(version2))
-        version3 = "6"
-        proper_version3 = "6.0.0"
-        self.assertEqual(proper_version3, NugetDependency.normalize_version(version3))
-        version4 = "6-beta"
-        proper_version4 = "6.0.0-beta"
-        self.assertEqual(proper_version4, NugetDependency.normalize_version(version4))
-        version5 = "3.2.1.-alpha"
-        proper_version5 = "3.2.1-alpha"
-        self.assertEqual(proper_version5, NugetDependency.normalize_version(version5))
-        version6 = "3.2.1.0-rc1"
-        proper_version6 = "3.2.1-rc1"
-        self.assertEqual(proper_version6, NugetDependency.normalize_version(version6))
-        # try some bad cases
-        with self.assertRaises(ValueError):
-            NugetDependency.normalize_version("not a number")
-        with self.assertRaises(ValueError):
-            NugetDependency.normalize_version("6.0-beta-beta")
-        with self.assertRaises(ValueError):
-            NugetDependency.normalize_version("6.0-bad")
-        with self.assertRaises(ValueError):
-            NugetDependency.normalize_version("6.0-")
-        with self.assertRaises(ValueError):
-            NugetDependency.normalize_version("--")
-        with self.assertRaises(ValueError):
-            NugetDependency.normalize_version("6-")
-        with self.assertRaises(ValueError):
-            NugetDependency.normalize_version("")
-        with self.assertRaises(ValueError):
-            NugetDependency.normalize_version(bad_version)
-
     # missing case
     def test_download_missing_nuget(self):
         ext_dep_file_path = os.path.join(test_dir, "hw_ext_dep.json")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest-cov == 3.0.0
 flake8 == 5.0.4
 pyopenssl == 22.0.0
 pefile == 2022.5.30
+semantic_version == 2.10.0


### PR DESCRIPTION
NuGet package versioning is described here:
https://docs.microsoft.com/en-us/nuget/concepts/package-versioning

It follows semantic versioning described here:
https://semver.org/

Among other things, semantic versioning allows an alphanumeric pre-release version number:
https://semver.org/#spec-item-9

The current NuGet versioning normalization code in nuget_dependency.py only permits a limited set of pre-approved tags such as the following to serve as the pre-release version number:

  ["beta", "alpha", "rc"]

Therefore, a valid NuGet package version string such as the following is considered invalid:

  "2.8.4-92" -[reports]-> "ValueError: Unparsable version tag: 92"

In other cases, the previous logic allowed passed invalid versions. For example:

  "2.15.05"

Which should not be allowed to use a leading zero: https://semver.org/#spec-item-2

This change swaps out the custom semantic versioning handling logic with more formal support provided by the semantic_version module which does correctly validate this string and has better compatibility with the Semantic Versioning Specification.

The "normalize_version()" static method is now made a class method so it can have access to object data fields. There was not a strong use case found for its static ability.

A clear message identifying the NuGet dependency and invalid version string is printed in case of an error.

In addition, "test_normalize_version()" is removed from test_nuget_dependency.py since there is no longer custom logic to validate.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>