### PR TITLE
.vscode/settings.json: Add workspace settings for unit tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "python.testing.unittestArgs": [
+    "-v",
+    "-s",
+    "${workspaceRoot}/edk2toolext/tests",
+    "-p",
+    "test_*.py"
+  ],
+  "python.testing.pytestEnabled": false,
+  "python.testing.unittestEnabled": true
+}


### PR DESCRIPTION
Adds a VS Code workspace settings file to define the
"python.testing.unittestArgs" for running Python unit tests.

This allows the tests in `edk2toolext/tests` to automatically be
recognized and shown in VS Code Test Explorer.

Without this change, the tests are not shown in Test Explorer
and an error message is output to Output -> Python window due to
the test root directory not being valid.

**Before Change**
![image](https://user-images.githubusercontent.com/21320094/193963176-520a159e-563d-4203-a78c-da31c7d6d642.png)

**After Change**
(and running all unit tests via VS Code Test Explorer)
![image](https://user-images.githubusercontent.com/21320094/193963222-25532198-095f-4f50-8ea9-4366d2dfcbf9.png)

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>