### PR TITLE
Add CodeQL build support

### DIFF
--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -28,6 +28,7 @@ import datetime
 
 DEFAULT_CODEQL_PATH = 'Build/codeql-database'
 
+
 class UefiBuilder(object):
 
     def __init__(self):
@@ -167,7 +168,7 @@ class UefiBuilder(object):
                         self.CodeQlPath = shutil.which("codeql")
                     else:
                         logging.critical("CodeQL build enabled but application "
-                                        "not found.")
+                                         "not found.")
                         return -1
 
                 ret = self.Build()


### PR DESCRIPTION
Adds the ability to generate a CodeQL database during build.

The tracing needed to build the CodeQL database must wrap the `build`
command which leads to the changes being concentrated in
uefi_build.py.

By default, the changes focus on adding support to UefiBuilder
subclasses (i.e. platform builders via `stuart_build`) via two new
command line parameters:

  1. `--codeql` - Produce CodeQL database from build. Implies
     `--clean`.
     - A clean build is required for CodeQL to generate a database
       properly.

  2. `--codeqldbpath` - Path relative to workspace root where the
     CodeQL database is created.

In addition, those that interact with UefiBuilders outside of
inheritance (such as build plugins) can enable CodeQL functionality
in a UefiBuilder object via the `EnableCodeQl()` method.

The user is expected to run additional tools outside of the main
Stuart build process to generate CodeQL results from the generated
database.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>
