### PR TITLE
.vscode/settings.json: Enable flake8 linting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,7 @@
     "test_*.py"
   ],
   "python.testing.pytestEnabled": false,
-  "python.testing.unittestEnabled": true
+  "python.testing.unittestEnabled": true,
+  "python.linting.flake8Enabled": true,
+  "python.linting.enabled": true
 }


### PR DESCRIPTION
Enables flake8 linting in .vscode/settings.json since it is required
in this repo. This will help developers find linting issues locally in
VS Code.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>