### PR TITLE
Plugin Loader Updates [Rebase & FF]

### DIFF
--- a/edk2toolext/environment/plugin_manager.py
+++ b/edk2toolext/environment/plugin_manager.py
@@ -95,6 +95,11 @@ class PluginManager(object):
                 py_module_name, py_module_path)
             module = importlib.util.module_from_spec(spec)
             sys.modules[py_module_name] = module
+
+            py_module_dir = os.path.dirname(py_module_path)
+            if py_module_dir not in sys.path:
+                sys.path.append(py_module_dir)
+
             spec.loader.exec_module(module)
         except Exception:
             exc_info = sys.exc_info()

--- a/edk2toolext/environment/plugin_manager.py
+++ b/edk2toolext/environment/plugin_manager.py
@@ -9,7 +9,7 @@
 
 import sys
 import os
-import imp
+import importlib
 import logging
 from edk2toolext.environment import shell_environment
 
@@ -82,32 +82,34 @@ class PluginManager(object):
             PluginDescriptor(PluginDescriptor): the plugin descriptor
         """
         PluginDescriptor.Obj = None
-        PythonFileName = PluginDescriptor.descriptor["module"] + ".py"
-        PyModulePath = os.path.join(os.path.dirname(os.path.abspath(
-            PluginDescriptor.descriptor["descriptor_file"])), PythonFileName)
-        logging.debug("Loading Plugin from %s", PyModulePath)
-        try:
-            with open(PyModulePath, "r") as plugin_file:
-                _module = imp.load_module(
-                    "UefiBuild_Plugin_" + PluginDescriptor.descriptor["module"],
-                    plugin_file,
-                    PyModulePath,
-                    ("py", "r", imp.PY_SOURCE))
 
+        py_file_path = PluginDescriptor.descriptor["module"] + ".py"
+        py_module_path = os.path.join(os.path.dirname(os.path.abspath(
+            PluginDescriptor.descriptor["descriptor_file"])), py_file_path)
+        py_module_name = "UefiBuild_Plugin_" + PluginDescriptor.descriptor["module"]
+
+        logging.debug("Loading Plugin from %s", py_module_path)
+
+        try:
+            spec = importlib.util.spec_from_file_location(
+                py_module_name, py_module_path)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[py_module_name] = module
+            spec.loader.exec_module(module)
         except Exception:
             exc_info = sys.exc_info()
             logging.error("Failed to import plugin: %s",
-                          PyModulePath, exc_info=exc_info)
+                          py_module_path, exc_info=exc_info)
             return -1
 
         # Instantiate the plugin
         try:
-            obj = getattr(_module, PluginDescriptor.descriptor["module"])
+            obj = getattr(module, PluginDescriptor.descriptor["module"])
             PluginDescriptor.Obj = obj()
         except AttributeError:
             exc_info = sys.exc_info()
             logging.error("Failed to instantiate plugin: %s",
-                          PyModulePath, exc_info=exc_info)
+                          py_module_path, exc_info=exc_info)
             return -1
 
         return 0


### PR DESCRIPTION
This series makes two main changes:

1. [Update usage of deprecated loading APIs](https://github.com/tianocore/edk2-pytool-extensions/commit/49a954c5153d0e8acba8bca88e1b8ef962acd885)

   Fixes #337

   Plugins are currently loaded in the `_load()` function in
   plugin_manager.py by using the `imp` standard library:

   https://docs.python.org/3/library/imp.html

   The first sentence of the library documentation states the following:

   ```
   Deprecated since version 3.4, will be removed in version 3.12: The
   imp module is deprecated in favor of importlib.
   ```

   This means, `imp` will be removed in the next Python release.

   Therefore, this change updates the code to use `importlib` standard
   library as recommended by the `imp` documentation.

   The code follows the recipe recommended by the `importlib`
   documentation to directly load a Python source file as is the case
   when loading Python modules based on plugin descriptor information.

   https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly

2. [Add plugin module paths to system path](https://github.com/tianocore/edk2-pytool-extensions/commit/a5757ddf73eb8034a346aac26a73082ae63964be)

   Closes #338 

   Adds dynamically loaded plugin module directory paths to the system
   path so the plugin modules can import other modules relative to their
   path as they would if they were not dynamically loaded.