### PR TITLE
bug_report.yml: Add supported Python versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,6 +22,18 @@ body:
       description: "A clear and concise description of what the bug is."
     validations:
       required: true
+  - type: dropdown
+    id: py_version
+    attributes:
+      label: What Python version are you using?
+      description: "Note: Bug fixes are only supported on these Python versions."
+      multiple: true
+      options:
+        - Python 3.9
+        - Python 3.10
+        - Python 3.11
+    validations:
+      required: true
   - type: textarea
     id: repro
     attributes:
@@ -45,7 +57,7 @@ body:
     id: env
     attributes:
       label: Execution Environment
-      description: "List the OS, python version, system environment variables, etc."
+      description: "List the OS, python micro version (e.g. 3.10.8), system environment variables, etc."
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
Lists the Python versions supported for bug fixes in the bug reporting form.

This is to make it obvious what Python versions are officially supported for bug fixes when a bug is filed.

Contributes to https://github.com/tianocore/edk2-pytool-extensions/issues/345

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>