### PR TITLE
edk2_stuart_pr_eval: Improve robustness of path comparisons

### DIFF
--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -17,6 +17,7 @@ while allowing the invocable itself to remain platform agnostic.
 import os
 import logging
 from io import StringIO
+from pathlib import Path
 from edk2toolext import edk2_logging
 from edk2toolext.invocables.edk2_multipkg_aware_invocable import Edk2MultiPkgAwareInvocable
 from edk2toolext.invocables.edk2_multipkg_aware_invocable import MultiPkgAwareSettingsInterface
@@ -267,6 +268,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
 
             # files are all the files changed edk2 workspace root relative path
             changed_modules = self._get_unique_module_infs_changed(files)
+            changed_modules = [Path(m) for m in changed_modules]
 
             # now check DSC
             dsc = DscParser()
@@ -277,6 +279,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
             dsc.SetInputVars(PlatformDscInfo[1])
             dsc.ParseFile(PlatformDscInfo[0])
             allinfs = dsc.OtherMods + dsc.ThreeMods + dsc.SixMods + dsc.Libs  # get list of all INF files
+            allinfs = [Path(i) for i in allinfs]
 
             #
             # Note: for now we assume that remaining_packages has only 1 package and that it corresponds
@@ -285,7 +288,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
             for p in remaining_packages[:]:  # slice so we can delete as we go
                 for cm in changed_modules:
                     if cm in allinfs:  # is the changed module listed in the DSC file?
-                        packages_to_build[p] = f"Policy 4 - Package Dsc depends on {cm}"
+                        packages_to_build[p] = f"Policy 4 - Package Dsc depends on {str(cm)}"
                         remaining_packages.remove(p)  # remove from remaining packages
                         break
 


### PR DESCRIPTION
Paths are currently returned from various functions and compared in
`get_packages_to_build()`. This change updates the paths to be
represented with `Path` objects so path comparison can leverage
the `Path` object equality method to perform the comparison more
robustly than with raw strings.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>