### PR TITLE
Add required python version for pypi

### DIFF
--- a/docs/contributor/python_release.md
+++ b/docs/contributor/python_release.md
@@ -21,6 +21,18 @@ exceptions, if the newest minor version is 3.11, then overall, we will
 support 3.9, 3.10, and 3.11. Therefore you should update the line to
 `python_requires = ">=3.9.0"`.
 
+Additionally, we must update the classifiers section to show the three
+supported python versions:
+
+```cmd
+classifiers=[
+        ...
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11"
+    ]
+```
+
 ### integration_test/azure-pipelines/windows-robot-integration-test.yml
 
 Since we support the last three minor versions of python, we want to ensure

--- a/docs/contributor/python_release.md
+++ b/docs/contributor/python_release.md
@@ -51,7 +51,7 @@ sure we keep this front page information up to date.
 Due to this, we must update the table under `Current Status`. Within the table,
 you must update the `Toolchain` column to the correct python version and the
 `Test Status` sections to point towards the correct pipeline job. Whenever the
-python version is updated, it changes the job title, so the associatd entry in
+python version is updated, it changes the job title, so the associated entry in
 this table must be updated.
 
 Below is an example of an update due to the job title changing:

--- a/docs/contributor/python_release.md
+++ b/docs/contributor/python_release.md
@@ -13,13 +13,13 @@ specific file that must be updated.
 
 This file is responsible for the release process to pypi. We want to make sure
 we keep the required python version for our pypi releases up to date.
-Within `setuptools.setup()` locate the line `python_requires = "XXX" and
+Within `setuptools.setup()` locate the line `python_requires = "XXX"` and
 update it to the next version.
 
 We typically support the last three minor versions; barring any special
 exceptions, if the newest minor version is 3.11, then overall, we will
 support 3.9, 3.10, and 3.11. Therefore you should update the line to
-`python_requires = ">=3.9.0".
+`python_requires = ">=3.9.0"`.
 
 ### integration_test/azure-pipelines/windows-robot-integration-test.yml
 
@@ -35,10 +35,7 @@ as seen below:
 parameters:
 - name: PythonVersionList
   type: object
-  default:
-    '3_9': '3.9'
-    '3_10': '3.10'
-    '3_11': '3.11'
+  default: ['3.9', '3.10', '3.11']
 ```
 
 ### readme.md
@@ -50,65 +47,47 @@ sure we keep this front page information up to date.
 
 Due to this, we must update the table under `Current Status`. Within the table,
 you must update the `Toolchain` column to the correct python version and the
-`Test Status` sections to point towards the correct pipeline job. Whenever the
-python version is updated, it changes the job title, so the associated entry in
-this table must be updated.
+`Integration Tests` section links to point towards the correct pipeline job.
+Whenever the python version is updated, it changes the job title, so the
+associated entry in this table must be updated. These entries are links that
+can be found at the bottom of the readme.
 
-Below is an example of an update due to the job title changing:
+Links are abbreviated to represent the particular test. In the example below,
+the test link is abbreviated `ewt1` standing for Edk2-Windows-Test #1. When
+updating to a new Python version, we simply need to bump the python version
+in the link as seen below
 
-`![Azure DevOps tests](https://img.shields.io/azure-devops/tests/tianocore/edk2-pytool-extensions/8/master?Job=Build_and_Test_windows_Python_3_9.svg)`
+#### Current Python Version 3.11
 
-`![Azure DevOps tests](https://img.shields.io/azure-devops/tests/tianocore/edk2-pytool-extensions/8/master?Job=Build_and_Test_windows_Python_3_10.svg)`
-
-### azure-pipelines/ubuntu-test-pr-ci.yml
-
-Since we support the last three minor versions of python, we want to ensure
-that we run all unit tests against all three minor versions of python.
-
-Within the `parameters:` section, we must update the python_versions parameter
-to the last three versions. Barring any special exceptions, if the newest minor
-version is 3.11, then overall we will support 3.9, 3.10 and 3.11 as seen below:
-
-```yaml
-parameters
-...
-  python_versions:
-    '3_9': 3.9
-    '3_10': 3.10
-    '3_11': 3.11
+```md
+[ewt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python39
+[ewt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python310
+[ewt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python311
 ```
 
-### azure-pipelines/windows-test-pr-ci.yml
+#### Upgrading to Python Version 3.12
 
-Since we support the last three minor versions of python, we want to ensure
-that we run all unit tests against all three minor versions of python.
-
-Within the `parameters:` section, we must update the python_versions parameter
-to the last three versions. Barring any special exceptions, if the newest minor
-version is 3.11, then overall we will support 3.9, 3.10 and 3.11 as seen below:
-
-```yaml
-parameters
-...
-  python_versions:
-    '3_9': 3.9
-    '3_10': 3.10
-    '3_11': 3.11
+```md
+[ewt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python310
+[ewt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python311
+[ewt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python312
 ```
 
-### azure-pipelines/azure-pipelines-release.yml
+### azure-pipelines/templates/basic-setup-steps.yml
 
-This file is responsible for pushing the release to pypi, therefore we only
-want to run it once, not per supported release. Due to this, we only run it for
-the latest python minor version.
+This file is responsible for setting the python version when pushing the
+release to pypi, which is why we want to keep it on the most up to date
+python version.
 
-Within the `parameters:` section, we must update the python_versions parameter
-to the latest version. Barring any special exceptions, if the latest minor
-version is 3.11, then overall we will run this pipeline for 3.11
+Within the `task: UsePythonVersion@0:` section, we must update the
+`versionSpec` parameter to the latest version. Barring any special
+exceptions, if the latest minor version is 3.11, then overall we will run
+this pipeline for 3.11
 
 ```yaml
 parameters
-...
-  python_versions:
-    '3_11': 3.11
+- task: UsePythonVerion@0
+  inputs:
+    versionSpec: '3.11'
+    architecture: 'x64'
 ```

--- a/docs/contributor/python_release.md
+++ b/docs/contributor/python_release.md
@@ -1,0 +1,114 @@
+# Python Releases and edk2toolext
+
+This document provides information on the necessary steps to update the
+edk2-pytool-extensions repository when a new minor version of python has been
+release (3.9, 3.10, etc).
+
+## Steps
+
+Each individual step will be a different section below and be associated with a
+specific file that must be updated.
+
+### setup.py
+
+This file is responsible for the release process to pypi. We want to make sure
+we keep the required python version for our pypi releases up to date.
+Within `setuptools.setup()` locate the line `python_requires = "XXX" and
+update it to the next version.
+
+We typically support the last three minor versions; barring any special
+exceptions, if the newest minor version is 3.11, then overall, we will
+support 3.9, 3.10, and 3.11. Therefore you should update the line to
+`python_requires = ">=3.9.0".
+
+### integration_test/azure-pipelines/windows-robot-integration-test.yml
+
+Since we support the last three minor versions of python, we want to ensure
+that we run integration tests against all three supported versions.
+
+Within the `parameters:` section, we must update the PythonVersionList
+parameter to the last three versions. Barring any special exceptions, if the
+newest minor version is 3.11, then overall we will support 3.9, 3.10, and 3.11
+as seen below:
+
+```yaml
+parameters:
+- name: PythonVersionList
+  type: object
+  default:
+    '3_9': '3.9'
+    '3_10': '3.10'
+    '3_11': '3.11'
+```
+
+### readme.md
+
+This file is what is visible to a user reviewing the package on pypi or on
+github. It provides status information and shields for each supported minor
+version of python. When there is a new minor version of python, we need to make
+sure we keep this front page information up to date.
+
+Due to this, we must update the table under `Current Status`. Within the table,
+you must update the `Toolchain` column to the correct python version and the
+`Test Status` sections to point towards the correct pipeline job. Whenever the
+python version is updated, it changes the job title, so the associatd entry in
+this table must be updated.
+
+Below is an example of an update due to the job title changing:
+
+`![Azure DevOps tests](https://img.shields.io/azure-devops/tests/tianocore/edk2-pytool-extensions/8/master?Job=Build_and_Test_windows_Python_3_9.svg)`
+
+`![Azure DevOps tests](https://img.shields.io/azure-devops/tests/tianocore/edk2-pytool-extensions/8/master?Job=Build_and_Test_windows_Python_3_10.svg)`
+
+### azure-pipelines/ubuntu-test-pr-ci.yml
+
+Since we support the last three minor versions of python, we want to ensure
+that we run all unit tests against all three minor versions of python.
+
+Within the `parameters:` section, we must update the python_versions parameter
+to the last three versions. Barring any special exceptions, if the newest minor
+version is 3.11, then overall we will support 3.9, 3.10 and 3.11 as seen below:
+
+```yaml
+parameters
+...
+  python_versions:
+    '3_9': 3.9
+    '3_10': 3.10
+    '3_11': 3.11
+```
+
+### azure-pipelines/windows-test-pr-ci.yml
+
+Since we support the last three minor versions of python, we want to ensure
+that we run all unit tests against all three minor versions of python.
+
+Within the `parameters:` section, we must update the python_versions parameter
+to the last three versions. Barring any special exceptions, if the newest minor
+version is 3.11, then overall we will support 3.9, 3.10 and 3.11 as seen below:
+
+```yaml
+parameters
+...
+  python_versions:
+    '3_9': 3.9
+    '3_10': 3.10
+    '3_11': 3.11
+```
+
+### azure-pipelines/azure-pipelines-release.yml
+
+This file is responsible for pushing the release to pypi, therefore we only
+want to run it once, not per supported release. Due to this, we only run it for
+the latest python minor version.
+
+Within the `parameters:` section, we must update the python_versions parameter
+to the latest version. Barring any special exceptions, if the latest minor
+version is 3.11, then overall we will run this pipeline for 3.11
+
+```yaml
+parameters
+...
+  python_versions:
+    '3_11': 3.11
+```

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
+    python_requires = ">=3.9.0",
     cmdclass={
         'sdist': PostSdistCommand,
         'install': PostInstallCommand,

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,9 @@ setuptools.setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers"
+        "Intended Audience :: Developers",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
-    python_requires = ">=3.9.0",
+    python_requires=">=3.9.0",
     cmdclass={
         'sdist': PostSdistCommand,
         'install': PostInstallCommand,


### PR DESCRIPTION
Adds a required minimum version of python during pypi release that is mirrored on pypi.org so that it is obvious what python versions are supported for edk2-pytool-extensions.

Additionally adds a new contributor doc file that specifies all files that must be updated when a new minor version of python is released.

Signed-off-by: Joey Vagedes [joeyvagedes@microsoft.com](mailto:joeyvagedes@microsoft.com)