### PR TITLE
Set close_fds=False when building

### DIFF
--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -4,6 +4,7 @@
 # more extensive and custom behavior.
 ##
 # Copyright (c) Microsoft Corporation
+# Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
@@ -321,7 +322,7 @@ class UefiBuilder(object):
             edk2_build_params = params
         logging.debug(f"Edk2 build parameters are {edk2_build_params}")
 
-        ret = RunCmd(edk2_build_cmd, edk2_build_params)
+        ret = RunCmd(edk2_build_cmd, edk2_build_params, close_fds=False)
         # WORKAROUND - Undo the workaround.
         env.restore_checkpoint(pre_build_env_chk)
 


### PR DESCRIPTION
This change adds close_fds=False to RunCmd when launching the build.

This is necessary to enable GNU make's job control to pass through. GNU make's job control is implemented using tokens on file descriptor.  If the file descriptors remain open, a GNU make calling stuart_build can communicate with a GNU make called by stuart_build.  However, Python's Popen closes file descriptors by default.

A similar change will be proposed in edk2's build.py, completing the connection from the calling make to the called make.