### PR TITLE
Add a check to verify mkdocs builds

### DIFF
--- a/azure-pipelines/templates/basic-setup-steps.yml
+++ b/azure-pipelines/templates/basic-setup-steps.yml
@@ -21,5 +21,8 @@ steps:
 - script: pip install --upgrade -r requirements.txt
   displayName: 'Install requirements'
 
+- script: pip install --upgrade -r docs/user/requirements.txt
+  displayName: 'Install documentation requirements'
+
 - script: pip install -e .
   displayName: 'Install from Source'

--- a/azure-pipelines/templates/build-test-job.yml
+++ b/azure-pipelines/templates/build-test-job.yml
@@ -37,6 +37,8 @@ jobs:
     parameters:
       root_package_folder: ${{parameters.root_package_folder}}
 
+  - template: mkdocs-test-steps.yml
+
   - template: spell-test-steps.yml
 
   - template: markdown-lint-steps.yml

--- a/azure-pipelines/templates/mkdocs-test-steps.yml
+++ b/azure-pipelines/templates/mkdocs-test-steps.yml
@@ -1,0 +1,25 @@
+# File mkdocs-test-steps.yml
+#
+# template file to run mkdocs and if error or warn publish log
+#
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+  
+steps:
+# Catch any mkdocs warnings 
+- script: mkdocs build --strict
+  displayName: 'Check MkDocs for site building warnings or errors'
+  condition: succeededOrFailed()
+
+# Only capture and archive the lint log on failures.
+- script: mkdocs build --strict > mkdocs.err.log
+  displayName: 'Capture MkDocs warnings and failures'
+  condition: Failed()
+
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathtoPublish: 'mkdocs.err.log' 
+    artifactName: 'MkDocs Error log file'
+  continueOnError: true
+  condition: Failed()

--- a/docs/user/requirements.txt
+++ b/docs/user/requirements.txt
@@ -6,3 +6,4 @@ markdown-include==0.6.0
 mkdocs-gen-files==0.4.0
 mkdocs-exclude==1.0.2
 mkdocs-awesome-pages-plugin==2.8.0
+black==22.10.0


### PR DESCRIPTION
Adds a check to the pipeline that verifies mkdocs builds with no errors or warnings.

It was chosen to also force users to fix warnings, as the additional pydocstyle linting requirements for mkdocs only show up as warnings if incorrect.