### PR TITLE
Add Documentation Deployment Action

### DIFF
--- a/.github/workflows/doc-release.yml
+++ b/.github/workflows/doc-release.yml
@@ -1,0 +1,62 @@
+# This workflow builds and deploys documentation on a release.
+#
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+
+name: Doc Deployment
+
+on:
+  release:
+    types: [published]
+
+
+jobs:
+  build:
+    name: Build and Upload Site Artifact
+    
+    runs-on: ubuntu-latest
+
+    env:
+      python-version: "3.11"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Set up Python ${{ env.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.python-version }}
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade -r docs/user/requirements.txt
+      
+      - name: Build Documentation
+        run: |
+          mkdocs build --strict
+      
+      - name: Upload Github Pages Site Artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          name: 'github-pages'
+          path: "site/"
+          
+  deploy:
+    name: Deploy Site Artifact
+
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Deploy Github Pages Site
+      uses: actions/deploy-pages@v1
+      with:
+        token: ${{ github.token }}
+        artifact_name: 'github-pages'

--- a/.github/workflows/doc-release.yml
+++ b/.github/workflows/doc-release.yml
@@ -9,7 +9,6 @@ on:
   release:
     types: [published]
 
-
 jobs:
   build:
     name: Build and Upload Site Artifact
@@ -40,7 +39,7 @@ jobs:
       - name: Upload Github Pages Site Artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          name: 'github-pages'
+          name: "github-pages"
           path: "site/"
           
   deploy:
@@ -59,4 +58,4 @@ jobs:
       uses: actions/deploy-pages@v1
       with:
         token: ${{ github.token }}
-        artifact_name: 'github-pages'
+        artifact_name: "github-pages"

--- a/docs/user/requirements.txt
+++ b/docs/user/requirements.txt
@@ -1,3 +1,4 @@
+black==22.12.0
 mkdocs==1.4.0
 mkdocs-material==8.5.6
 mkdocstrings[python]==0.19.0

--- a/docs/user/requirements.txt
+++ b/docs/user/requirements.txt
@@ -1,4 +1,3 @@
-black==22.12.0
 mkdocs==1.4.0
 mkdocs-material==8.5.6
 mkdocstrings[python]==0.19.0

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,7 @@
 [![pypi]][_pypi]
 [![codecov]][_codecov]
 [![ci]][_ci]
+[![docs]][_docs]
 
 This is a Tianocore maintained project consisting of command line and other
 python tools and extensions for building and maintaining an Edk2 based UEFI
@@ -141,11 +142,14 @@ details.
 
 ## Documentation
 
-Documentation is located in the ```docs/``` folder and is split into two
+[![docs]][_docs]
+
+Documentation for the most recent release of edk2-pytool-extensions is hosted on
+[tianocore.org/edk2-pytool-extensions](https://www.tianocore.org/edk2-pytool-extensions/)]).
+Raw documentation is located in the ```docs/``` folder and is split into two
 separate categories. The first is located at ```docs/user/``` and is
 documentation and API references for those that are using this package in their
-own project. Users can generate a local copy of the
-[ReadTheDocs](https://readthedocs.org/) documentation by executing the
+own project. Users can generate a local copy of the documentation by executing the
 following command from the root of the project:
 
 ```cmd
@@ -162,6 +166,8 @@ contributing to the edk2-pytool-extensions repository.
 [_pypi]: https://pypi.org/project/edk2-pytool-extensions/
 [ci]: https://github.com/tianocore/edk2-pytool-extensions/actions/workflows/prgate.yml/badge.svg?branch=master&event=push
 [_ci]: https://github.com/tianocore/edk2-pytool-extensions/actions/workflows/prgate.yml
+[docs]: https://img.shields.io/website?label=docs&url=https%3A%2F%2Fwww.tianocore.org%2Fedk2-pytool-extensions%2F
+[_docs]: https://www.tianocore.org/edk2-pytool-extensions/
 
 [_it]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_build?definitionId=52&_a=summary&repositoryFilter=2&branchFilter=14
 [ewt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python39

--- a/readme.md
+++ b/readme.md
@@ -169,7 +169,6 @@ contributing to the edk2-pytool-extensions repository.
 [ci]: https://github.com/tianocore/edk2-pytool-extensions/actions/workflows/ci.yml/badge.svg?branch=master&event=push
 [_ci]: https://github.com/tianocore/edk2-pytool-extensions/actions/workflows/ci.yml
 
-
 [_it]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_build?definitionId=52&_a=summary&repositoryFilter=2&branchFilter=14
 [ewt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python39
 [ewt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python310


### PR DESCRIPTION
Adds a github action that executes on a release that deploys the documentation to the pages site.

Example Execution on fork:

Action: https://github.com/Javagedes/edk2-pytool-extensions/actions/workflows/doc-release.yml

Site: https://javagedes.github.io/edk2-pytool-extensions/