### PR TITLE
Synchronize short commit id support

### DIFF
--- a/docs/user/features/extdep.md
+++ b/docs/user/features/extdep.md
@@ -265,7 +265,7 @@ recommended to use this to ensure the contents are as expected.
 ## Git Type Schema Differences
 
 - source: url of git repo
-- version: commit hash to checkout
+- version: commit hash to checkout (short or long)
 
 ### Experimental Option: url_creds_var
 

--- a/docs/user/features/extdep.md
+++ b/docs/user/features/extdep.md
@@ -265,7 +265,9 @@ recommended to use this to ensure the contents are as expected.
 ## Git Type Schema Differences
 
 - source: url of git repo
-- version: commit hash to checkout (short or long)
+- version: commit hash to checkout (short\* or long)
+
+\* Short is considered the first 7 digits of a commit hash
 
 ### Experimental Option: url_creds_var
 

--- a/edk2toolext/environment/extdeptypes/git_dependency.py
+++ b/edk2toolext/environment/extdeptypes/git_dependency.py
@@ -104,7 +104,7 @@ class GitDependency(ExternalDependency):
                 self.logger.warning("Git Dependency: dirty")
                 result = False
 
-            if (r.head.commit != self.version):
+            if (r.head.commit != self.version and r.head.commit[:7] != self.version):
                 self.logger.info(f"Git Dependency: head is {r.head.commit} and version is {self.version}")
                 result = False
 

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -262,7 +262,7 @@ def checkout(abs_file_system_path, dep, repo, update_ok=False, ignore_dep_state_
                 repo.checkout(commit=commit)
             repo.submodule("update", "--init", "--recursive")
         else:
-            if repo.head.commit == commit:
+            if repo.head.commit == commit or repo.head.commit[:7] == commit:
                 logger.debug(
                     "Dependency {0} state ok without update".format(dep["Path"]))
                 return

--- a/edk2toolext/tests/test_git_dependency.py
+++ b/edk2toolext/tests/test_git_dependency.py
@@ -21,6 +21,7 @@ test_dir = None
 uptodate_version = "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"
 behind_one_version = "762941318ee16e59dabbacb1b4049eec22f0d303"
 invalid_version = "762941318ee16e59d123456789049eec22f0d303"
+short_version = "7fd1a60"
 
 hw_json_template = '''
 {
@@ -89,6 +90,16 @@ class TestGitDependency(unittest.TestCase):
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify())
         self.assertEqual(ext_dep.version, uptodate_version)
+
+    def test_fetch_verify_short_commit_hash(self):
+        ext_dep_file_path = os.path.join(test_dir, "hw_ext_dep.json")
+        with open(ext_dep_file_path, "w+") as ext_dep_file:
+            ext_dep_file.write(hw_json_template % short_version)
+        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep = GitDependency(ext_dep_descriptor)
+        ext_dep.fetch()
+        self.assertTrue(ext_dep.verify())
+        self.assertEqual(ext_dep.version, short_version)
 
     def test_fetch_verify_good_repo_at_not_top_of_tree(self):
         ext_dep_file_path = os.path.join(test_dir, "hw_ext_dep.json")

--- a/edk2toolext/tests/test_repo_resolver.py
+++ b/edk2toolext/tests/test_repo_resolver.py
@@ -30,6 +30,13 @@ commit_dependency = {
     "Path": "test_repo",
     "Commit": "b1e35a5d2bf05fb7f58f5b641a702c70d6b32a98"
 }
+
+short_commit_dependency = {
+    "Url": "https://github.com/microsoft/mu",
+    "Path": "test_repo",
+    "Commit": "b1e35a5"
+}
+
 commit_later_dependency = {
     "Url": "https://github.com/microsoft/mu",
     "Path": "test_repo",
@@ -176,6 +183,18 @@ class test_repo_resolver(unittest.TestCase):
 
         self.assertEqual(details['Url'], commit_dependency['Url'])
         self.assertEqual(details['Commit'], commit_dependency['Commit'])
+
+    # check to make sure we support short commits
+    def test_clone_short_commit_repo(self):
+        repo_resolver.resolve(test_dir, short_commit_dependency)
+        folder_path = os.path.join(test_dir, short_commit_dependency["Path"])
+        details = repo_resolver.get_details(folder_path)
+
+        self.assertEqual(details['Url'], short_commit_dependency['Url'])
+        self.assertEqual(details['Commit'][:7], short_commit_dependency['Commit'])
+
+        # Resolve again, making sure we don't fail if repo already exists.
+        repo_resolver.resolve(test_dir, short_commit_dependency)
 
     # check to make sure we can clone a commit correctly
     def test_fail_update(self):


### PR DESCRIPTION
Short commit id's were partially supported in regards to the repo_resolver and git_dependency (ext_dep). This PR adds full support for both and adds tests to ensure they remain supported.

Resolves #236 

Signed-off-by: Joey Vagedes <joeyvagedes@microsoft.com>