### PR TITLE
Update edk2_git.py to use PyGit2 [REBASE&FF]

### DIFF
--- a/edk2toolext/environment/extdeptypes/git_dependency.py
+++ b/edk2toolext/environment/extdeptypes/git_dependency.py
@@ -77,7 +77,7 @@ class GitDependency(ExternalDependency):
 
         if os.path.isdir(self._local_repo_root_path):
             # Clean up git dependency specific stuff
-            repo_resolver.clear_folder(self.contents_dir)
+            repo_resolver.clear_contents(self.contents_dir)
 
         # Let super class clean up common dependency stuff
         super().clean()
@@ -97,14 +97,14 @@ class GitDependency(ExternalDependency):
         if result:
             # valid repo folder
             r = Repo(self._local_repo_root_path)
-            if (not r.initalized):
+            if (not r.initialized):
                 self.logger.info("Git Dependency: Not Initialized")
                 result = False
             elif (r.dirty):
                 self.logger.warning("Git Dependency: dirty")
                 result = False
 
-            if (r.head.commit != self.version and r.head.commit[:7] != self.version):
+            elif (r.head.commit != self.version and r.head.short_commit != self.version):
                 self.logger.info(f"Git Dependency: head is {r.head.commit} and version is {self.version}")
                 result = False
 

--- a/edk2toolext/environment/self_describing_environment.py
+++ b/edk2toolext/environment/self_describing_environment.py
@@ -13,7 +13,7 @@ and then acts upon those files.
 """
 import os
 import logging
-import pygit2
+from edk2toolext import edk2_git
 from edk2toolext.environment import shell_environment
 from edk2toolext.environment import environment_descriptor_files as EDF
 from edk2toolext.environment import external_dependency
@@ -48,12 +48,11 @@ class self_describing_environment(object):
         self.skipped_dirs = tuple(map(Path, (os.path.join(self.workspace, d) for d in skipped_dirs)))
 
         # Respect git worktrees
-        repo_path = pygit2.discover_repository(self.workspace)
+        repo_path = edk2_git.Repo.discover_repository(self.workspace)
         if repo_path:
-            repo = pygit2.Repository(repo_path)
-            worktrees = repo.list_worktrees()
-            for worktree in worktrees:
-                worktree_path = Path(repo.lookup_worktree(worktree).path)
+            repo = edk2_git.Repo(repo_path)
+            for worktree in repo.worktrees:
+                worktree_path = worktree.path
                 if (worktree_path.is_dir()
                         and Path(self.workspace) != worktree_path
                         and worktree_path not in skipped_dirs):

--- a/edk2toolext/tests/test_edk2_git.py
+++ b/edk2toolext/tests/test_edk2_git.py
@@ -1,0 +1,108 @@
+## @file test_edk2_git.py
+# This contains unit tests for edk2_git
+##
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+import unittest
+import tempfile
+from pathlib import Path
+from edk2toolext.edk2_git import Repo
+
+
+class test_edk2_git(unittest.TestCase):
+
+    def test_repo(self):
+        repo_url = tempfile.mkdtemp()
+        r = Repo.clone_from('https://github.com/tianocore/edk2-pytool-extensions', repo_url)
+
+        self.assertEqual(r.active_branch, 'master')
+        self.assertEqual(r.bare, False)
+        self.assertEqual(r.dirty, False)
+        self.assertEqual(r.remotes.origin.url, 'https://github.com/tianocore/edk2-pytool-extensions')
+        self.assertEqual(r.url, 'https://github.com/tianocore/edk2-pytool-extensions')
+        self.assertEqual(len(r.submodules), 0)
+
+        self.assertTrue(r.checkout(commit='9e5ecb2aa7aae5a33ca57f7e2c95eb09c379295f'))
+        self.assertEqual(r.active_branch, 'HEAD')
+        self.assertEqual(r.head.commit, '9e5ecb2aa7aae5a33ca57f7e2c95eb09c379295f')
+        self.assertEqual(r.head.short_commit, '9e5ecb2')
+
+        self.assertTrue(r.checkout(commit='5e17bf6'))
+        self.assertEqual(r.active_branch, 'HEAD')
+        self.assertEqual(r.head.commit, '5e17bf6ad09d1b60236792008b576b348f74d940')
+        self.assertEqual(r.head.short_commit, '5e17bf6')
+
+        self.assertTrue(r.fetch(branch='master'))
+        self.assertTrue(r.checkout('master'))
+        self.assertTrue(r.pull())
+        self.assertEqual(r.active_branch, 'master')
+        r.delete()
+
+        # Repo deleted, verify we get empty repo results
+        self.assertEqual(r.exists, False)
+        self.assertEqual(r.url, None)
+        self.assertEqual(r.active_branch, None)
+        self.assertEqual(r.bare, True)
+        self.assertEqual(r.head, None)
+        self.assertEqual(r.dirty, False)
+        self.assertEqual(len(r.worktrees), 0)
+        self.assertEqual(r.submodules, None)
+
+        # Clone again, update the repo_url with str
+        Repo.clone_from('https://github.com/tianocore/edk2-pytool-extensions', repo_url)
+        r.path = repo_url
+
+        self.assertEqual(r.active_branch, 'master')
+        self.assertEqual(r.bare, False)
+        self.assertEqual(r.dirty, False)
+        self.assertEqual(r.remotes.origin.url, 'https://github.com/tianocore/edk2-pytool-extensions')
+        self.assertEqual(r.url, 'https://github.com/tianocore/edk2-pytool-extensions')
+        self.assertEqual(len(r.submodules), 0)
+
+        r.delete()
+        # Repo deleted, verify we get empty repo results
+        self.assertEqual(r.exists, False)
+        self.assertEqual(r.url, None)
+        self.assertEqual(r.active_branch, None)
+        self.assertEqual(r.bare, True)
+        self.assertEqual(r.head, None)
+        self.assertEqual(r.dirty, False)
+        self.assertEqual(len(r.worktrees), 0)
+        self.assertEqual(r.submodules, None)
+
+        # Clone again, update the repo_url with Path object
+        Repo.clone_from('https://github.com/tianocore/edk2-pytool-extensions', repo_url)
+        r.path = Path(repo_url)
+
+        self.assertEqual(r.active_branch, 'master')
+        self.assertEqual(r.bare, False)
+        self.assertEqual(r.dirty, False)
+        self.assertEqual(r.remotes.origin.url, 'https://github.com/tianocore/edk2-pytool-extensions')
+        self.assertEqual(r.url, 'https://github.com/tianocore/edk2-pytool-extensions')
+        self.assertEqual(len(r.submodules), 0)
+
+        r.delete()
+
+    def test_empty_repo_path(self):
+        repo_url = tempfile.mkdtemp()
+        r = Repo(repo_url)
+
+        self.assertEqual(r.exists, True)
+        self.assertEqual(r.url, None)
+        self.assertEqual(r.active_branch, None)
+        self.assertEqual(r.bare, True)
+        self.assertEqual(r.head, None)
+        self.assertEqual(r.dirty, False)
+        self.assertEqual(len(r.worktrees), 0)
+        self.assertEqual(r.submodules, None)
+
+        r.delete()
+
+    def test_clone_from_bad_url(self):
+        repo_url = tempfile.mkdtemp()
+        repo = Repo.clone_from('https://bad', repo_url)
+        self.assertEqual(repo, None)
+
+        Repo(repo_url).delete()

--- a/edk2toolext/tests/test_repo_resolver.py
+++ b/edk2toolext/tests/test_repo_resolver.py
@@ -64,7 +64,7 @@ def prep_workspace():
         test_dir = tempfile.mkdtemp()
         logging.debug("temp dir is: %s" % test_dir)
     else:
-        repo_resolver.clear_folder(test_dir)
+        repo_resolver.clear_contents(test_dir)
         test_dir = tempfile.mkdtemp()
 
 
@@ -74,7 +74,7 @@ def clean_workspace():
         return
 
     if os.path.isdir(test_dir):
-        repo_resolver.clear_folder(test_dir)
+        repo_resolver.clear_contents(test_dir)
         test_dir = None
 
 


### PR DESCRIPTION
Updates Edk2_git.py to use PyGit2 as backbone of class. Originally, the class was relied heavily on `RunCmd` to get much of the status information used by the `Repo` class. As a side effect of the implementation, these status indicators such as self.dirty are not updated in the class changes.

By using PyGit2, the git database (.git) is now parsed, which is quicker than using RunCmd. Due to this change, the status indicators are now dynamic and will update if the repo updates.

Some changes did ripple across the repo as PyGit2 holds references to certain files, so these references need to be freed if attempting to delete the repo.

Additionally, a small change was made in self_describing_environment so that it no longer uses PyGit2 directly, but uses edk2_git.py