### PR TITLE
edk2_ci_setup: ensure repository with branch dependency is up to date

### DIFF
--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -114,7 +114,8 @@ def resolve(file_system_path, dependency, force=False, ignore=False, update_ok=F
                 raise Exception("The URL of the git Repo {2} in the folder {0} does not match {1}".format(
                     git_path, dependency["Url"], repo.remotes.origin.url))
     # if we've gotten here, we should just checkout as normal
-    repo = checkout(git_path, dependency, repo, update_ok, ignore, force)
+    checkout(git_path, dependency, repo, update_ok, ignore, force)
+    repo.pull()
     return repo
 
 ##

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -115,7 +115,9 @@ def resolve(file_system_path, dependency, force=False, ignore=False, update_ok=F
                     git_path, dependency["Url"], repo.remotes.origin.url))
     # if we've gotten here, we should just checkout as normal
     checkout(git_path, dependency, repo, update_ok, ignore, force)
-    repo.pull()
+    if not repo.pull():
+        logger.critical("Failed to update branch to latest in the git Repo {0}".format(git_path))
+        raise Exception("Failed to update branch to latest in the git Repo {0}".format(git_path))
     return repo
 
 ##

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -114,7 +114,7 @@ def resolve(file_system_path, dependency, force=False, ignore=False, update_ok=F
                 raise Exception("The URL of the git Repo {2} in the folder {0} does not match {1}".format(
                     git_path, dependency["Url"], repo.remotes.origin.url))
     # if we've gotten here, we should just checkout as normal
-    checkout(git_path, dependency, repo, update_ok, ignore, force)
+    repo = checkout(git_path, dependency, repo, update_ok, ignore, force)
     return repo
 
 ##

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -115,9 +115,6 @@ def resolve(file_system_path, dependency, force=False, ignore=False, update_ok=F
                     git_path, dependency["Url"], repo.remotes.origin.url))
     # if we've gotten here, we should just checkout as normal
     checkout(git_path, dependency, repo, update_ok, ignore, force)
-    if not repo.pull():
-        logger.critical("Failed to update branch to latest in the git Repo {0}".format(git_path))
-        raise Exception("Failed to update branch to latest in the git Repo {0}".format(git_path))
     return repo
 
 ##
@@ -236,7 +233,7 @@ def clone_repo(abs_file_system_path, DepObj):
 
 
 def checkout(abs_file_system_path, dep, repo, update_ok=False, ignore_dep_state_mismatch=False, force=False):
-    """Checks out a commit or branch.
+    """Checks out a commit or branch, ensuring the branch is at top of tree.
 
     Args:
         abs_file_system_path (PathLike): The path to the repo
@@ -289,6 +286,7 @@ def checkout(abs_file_system_path, dep, repo, update_ok=False, ignore_dep_state_
                 logger.info("We failed to checkout this branch, we'll try to fetch")
                 repo.fetch(branch=branch)
                 repo.checkout(branch=branch)
+            repo.pull()  # Pull to be top of tree
             repo.submodule("update", "--init", "--recursive")
         else:
             if repo.active_branch == dep["Branch"]:

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -233,7 +233,7 @@ def clone_repo(abs_file_system_path, DepObj):
 
 
 def checkout(abs_file_system_path, dep, repo, update_ok=False, ignore_dep_state_mismatch=False, force=False):
-    """Checks out a commit or branch, ensuring the branch is at top of tree.
+    """Checks out a commit or branch.
 
     Args:
         abs_file_system_path (PathLike): The path to the repo


### PR DESCRIPTION
Within edk2_ci_setup, if a repo dependency has a branch requirement, we only verify that the repo is on the correct branch, but not that the branch is up to date itself. This PR will perform a git pull (if update_ok / force is enabled) and update the branch to latest.