### PR TITLE
Enable Nuget.exe on MacOS and FreeBSD

### DIFF
--- a/edk2toolext/environment/extdeptypes/nuget_dependency.py
+++ b/edk2toolext/environment/extdeptypes/nuget_dependency.py
@@ -55,7 +55,7 @@ class NugetDependency(ExternalDependency):
             (None): none was found
         """
         cmd = []
-        if GetHostInfo().os in ["Linux", "Darwin", "FreeBSD"]:
+        if GetHostInfo().os != "Windows":
             cmd += ["mono"]
 
         nuget_path = os.getenv(cls.NUGET_ENV_VAR_NAME)

--- a/edk2toolext/environment/extdeptypes/nuget_dependency.py
+++ b/edk2toolext/environment/extdeptypes/nuget_dependency.py
@@ -55,7 +55,7 @@ class NugetDependency(ExternalDependency):
             (None): none was found
         """
         cmd = []
-        if GetHostInfo().os == "Linux":
+        if GetHostInfo().os in ["Linux", "Darwin", "FreeBSD"]:
             cmd += ["mono"]
 
         nuget_path = os.getenv(cls.NUGET_ENV_VAR_NAME)


### PR DESCRIPTION
Adds mono to the front of the Nuget command when the OS detected is MacOS or FreeBSD.