### PR TITLE
Shell and build variable deletion

### DIFF
--- a/edk2toolext/environment/shell_environment.py
+++ b/edk2toolext/environment/shell_environment.py
@@ -323,13 +323,15 @@ class ShellEnvironment(metaclass=Singleton):
 
         Args:
             var_name (str): variable to set the value for
-            var_data (obj): data to set
+            var_data (obj | None): data to set or None to delete the var
 
         WARNING: Unlike `set_shell_var`, this only sets the variable in the
         `VarDict`
         """
-        self.logger.debug(
-            "Updating BUILD VAR element '%s': '%s'." % (var_name, var_data))
+        if not var_data:
+            self.logger.debug(f"Removing BUILD VAR element {var_name}")
+        else:
+            self.logger.debug(f"Updating BUILD VAR element '{var_name}': '{var_data}'.")
         self.active_buildvars.SetValue(var_name, var_data, '', overridable=True)
 
     def get_shell_var(self, var_name):
@@ -348,7 +350,7 @@ class ShellEnvironment(metaclass=Singleton):
 
         Args:
             var_name (str): variable to set the value for
-            var_data (obj): data to set
+            var_data (obj | None): data to set or None to delete the var
 
         The variable is set both in the `VarDict` and in the OS
         """
@@ -357,9 +359,12 @@ class ShellEnvironment(metaclass=Singleton):
             self.set_path(var_data)
         elif var_name.upper() == 'PYTHONPATH':
             self.set_pypath(var_data)
+        elif var_data is None:
+            self.logger.debug(f"Removing SHELL VAR element {var_name}")
+            self.active_environ.pop(var_name, None)
+            os.environ.pop(var_name, None)
         else:
-            self.logger.debug(
-                "Updating SHELL VAR element '%s': '%s'." % (var_name, var_data))
+            self.logger.debug(f"Updating SHELL VAR element '{var_name}': '{var_data}'.")
             self.active_environ[var_name] = var_data
             os.environ[var_name] = var_data
 

--- a/edk2toolext/tests/test_shell_environment.py
+++ b/edk2toolext/tests/test_shell_environment.py
@@ -47,6 +47,17 @@ class TestBasicEnvironmentManipulation(unittest.TestCase):
         shell_env.set_shell_var('SE-TEST-VAR-2', new_value)
         self.assertEqual(shell_env.get_shell_var('SE-TEST-VAR-2'), new_value)
 
+    def test_can_set_get_and_delete_os_vars(self):
+        shell_env = SE.ShellEnvironment()
+        var_name = 'SE-TEST-VAR-SHELL-DELETE'
+        var_data = 'Dummy'
+        # Make sure it doesn't exist beforehand.
+        self.assertIs(shell_env.get_shell_var(var_name), None, "test var should not exist before creation")
+        shell_env.set_shell_var(var_name, var_data)
+        self.assertEqual(shell_env.get_shell_var(var_name), var_data, "Get var data should match set var data")
+        shell_env.set_shell_var(var_name, None)
+        self.assertIsNone(shell_env.get_shell_var(var_name), "test var should not exist after deletion")
+
     def test_set_path_string(self):
         shell_env = SE.ShellEnvironment()
 
@@ -224,7 +235,7 @@ class TestBasicEnvironmentManipulation(unittest.TestCase):
         shell_env.remove_pypath_element(new_mid_elem)
         self.assertNotIn(new_mid_elem, shell_env.active_pypath)
 
-    def test_can_set_and_get_build_vars(self):
+    def test_can_set_get_and_delete_build_vars(self):
         shell_env = SE.ShellEnvironment()
 
         var_name = 'SE-TEST-VAR-3'
@@ -233,6 +244,8 @@ class TestBasicEnvironmentManipulation(unittest.TestCase):
         self.assertIs(shell_env.get_build_var(var_name), None, "test var should not exist before creation")
         shell_env.set_build_var(var_name, var_data)
         self.assertEqual(shell_env.get_build_var(var_name), var_data, "get var data should match set var data")
+        shell_env.set_build_var(var_name, None)
+        self.assertIsNone(shell_env.get_build_var(var_name), "test var should not exist after deletion")
 
     def test_set_build_vars_should_default_overrideable(self):
         shell_env = SE.ShellEnvironment()
@@ -247,8 +260,19 @@ class TestBasicEnvironmentManipulation(unittest.TestCase):
 
         self.assertEqual(shell_env.get_build_var(var_name), var_data2)
 
+    def test_can_delete_nonexisting_vars(self):
+        shell_env = SE.ShellEnvironment()
+
+        var_name = "DOES-NOT-EXIST"
+        # Make sure does not assert if deleteing a variable that does not exist
+        shell_env.set_build_var(var_name, None)
+        self.assertIsNone(shell_env.get_build_var(var_name))
+
+        shell_env.set_shell_var(var_name, None)
+        self.assertIsNone(shell_env.get_shell_var(var_name))
 
 class TestShellEnvironmenCheckpoints(unittest.TestCase):
+
 
     def setUp(self):
         # Grab the singleton and restore the initial checkpoint.

--- a/edk2toolext/tests/test_shell_environment.py
+++ b/edk2toolext/tests/test_shell_environment.py
@@ -271,8 +271,8 @@ class TestBasicEnvironmentManipulation(unittest.TestCase):
         shell_env.set_shell_var(var_name, None)
         self.assertIsNone(shell_env.get_shell_var(var_name))
 
-class TestShellEnvironmenCheckpoints(unittest.TestCase):
 
+class TestShellEnvironmenCheckpoints(unittest.TestCase):
 
     def setUp(self):
         # Grab the singleton and restore the initial checkpoint.

--- a/edk2toolext/tests/test_var_dict.py
+++ b/edk2toolext/tests/test_var_dict.py
@@ -201,6 +201,23 @@ class TestVarDict(unittest.TestCase):
         v.SetValue("test2", "value1", "test 1 comment overrideable", True)
         v.PrintAll()
 
+    def test_var_dict_delete_entry(self):
+        v = var_dict.VarDict()
+        # Delete non existing entry
+        self.assertTrue(v.DeleteEntry("EMPTY"))
+
+        # Delete non overridable (Fails)
+        entry = "test_entry"
+        value = "test_value"
+        v.SetValue(entry, value, "")
+        self.assertFalse(v.DeleteEntry(entry))
+        self.assertEqual(v.GetValue(entry), value)
+
+        # Delete overridable
+        v.AllowOverride(entry)
+        self.assertTrue(v.DeleteEntry(entry))
+        self.assertIsNone(v.GetValue(entry))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds shell and build variable deletion functionality from within `ShellEnvironment` by accepting `None` as the variable value for functions `set_shell_var` and `set_build_var`.

Additionally fixes a spelling error `Overrideable ->  Overridable`. This spelling error was for an attribute of EnvEntry, making it a breaking change, however it should have minimal to no impact as it is used only by VarDict.

Closes #132 