### PR TITLE
Add Temporary fix to integration tests

### DIFF
--- a/integration_test/Shared_Keywords.robot
+++ b/integration_test/Shared_Keywords.robot
@@ -162,7 +162,7 @@ Stuart platform run
     [Arguments]  ${setting_file}  ${arch}  ${target}  ${tool_chain}  ${additional_flags}  ${ws}
     Log to console  Stuart Build Run
     ${result}=   Run Process    stuart_build
-    ...  -c  ${setting_file}  -a  ${arch}  TOOL_CHAIN_TAG\=${tool_chain}  TARGET\=${target}  --FlashOnly  QEMU_HEADLESS\=TRUE  ${additional_flags}
+    ...  -c  ${setting_file}  -a  ${arch}  TOOL_CHAIN_TAG\=${tool_chain}  TARGET\=${target}  --FlashOnly  QEMU_HEADLESS\=TRUE  QEMU_CPUHP_QUIRK\=TRUE  ${additional_flags}
     ...  cwd=${ws}  stdout=stdout.txt  stderr=stderr.txt
     Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
     Should Be Equal As Integers  ${result.rc}  0


### PR DESCRIPTION
Integration tests are failing as a bug was found in QEMU, which has a fix, but is not available until version 8 of QEMU. As this version is not available yet, a temporary workaround was added to allow QEMU to boot in the meantime, which is being applied in this PR.