### PR TITLE
Add CLI env information to the argument parser --help

### DIFF
--- a/docs/user/integrate/build.md
+++ b/docs/user/integrate/build.md
@@ -134,14 +134,20 @@ required to have a value associated with them. Variables defined this way are co
 and should be checked for existence rather then value (i.e. `if env.GetValue(var):` or `if not env.GetValue(var)`).
 
 While you can set and get variables anywhere in the `UefiBuilder` portion of the settings file, we provide the following
-two methods to set environment variables, ensuring they are available everywhere that you are allowed to customize:
+three methods to set environment variables, ensuring they are available everywhere that you are allowed to customize:
 
 - [SetPlatformEnv](/api/environment/uefi_build/#edk2toolext.environment.uefi_build.UefiBuilder.SetPlatformEnv)
 
 - [SetPlatfromEnvAfterTarget](/api/environment/uefi_build/#edk2toolext.environment.uefi_build.UefiBuilder.SetPlatformEnvAfterTarget)
 
-Simply override these two functions in your subclass of the `UefiBuilder` and set environment variables until your heart
-is content!
+- [SetPlatformDefaultEnv](/api/environment/uefi_build/#edk2toolext.environment.uefi_build.UefiBuilder.SetPlatformDefaultEnv)
+
+!!! Warning
+    `SetPlatformDefaultEnv` is not like the others. Rather then setting the environment variables directly, it should
+    return a limited list of the most commonly overridden variables and their default values! The values returned are
+    printed to the terminal when using the `-h, --help` flags so that develops can easily find the common ways to
+    customize a platforms build. Additionally, if these variables have not been set anywhere else in the build, they
+    will be set to the default values.
 
 !!! Note
     Not all variables are passed through stuart to the actual build command. Only variables with the prefix `BLD_*_`,

--- a/docs/user/using/build.md
+++ b/docs/user/using/build.md
@@ -31,6 +31,12 @@ typically located in the same directory as the platform's DSC file, however
 **refer to your platform's build instructions for the exact name and location
 of this file.**
 
+!!! tip
+    Common to most command line tools, you can use `-h, --help` on any of
+    the commands to find any options. Using it with stuart_build can be
+    particularly useful as it will provide you with common env variable
+    overrides to customize the build: `stuart_build -c <filepath> --help`
+
 Curious about what each command does? Check out the below sections.
 
 ## stuart_setup
@@ -59,6 +65,13 @@ additional build flags needed to build.**
 
 ```cmd
 stuart_build -c path/to/SettingsFile.py
+```
+
+As mentioned previously, using the `-h, --help` flag can be particularly useful
+as it will provide you with common env variable overrides to customize the build.
+
+```cmd
+stuart_build -c path/to/SettingsFile.py --help
 ```
 
 ## FAQ

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -319,6 +319,21 @@ class Edk2Invocable(BaseAbstractInvocable):
         """Directory containing all logging files."""
         return "Build"
 
+    def AddParserEpilog(self):
+        """Adds additional information to the end of the argument parser."""
+        epilog = dedent('''\
+            CLI Env Guide:
+              <key>=<value>              - Set an env variable for the pre/post build process
+              <key>                      - Set a non-valued env variable for the pre/post build process
+              BLD_*_<key>=<value>        - Set a build flag for all build types
+                                           (key=value will get passed to build process)
+              BLD_*_<key>                - Set a non-valued build flag for all build types
+              BLD_<TARGET>_<key>=<value> - Set a build flag for build type of <target>
+                                           (key=value will get passed to build process for given build type)
+              BLD_<TARGET>_<key>         - Set a non-valued build flag for a build type of <target>
+            ''')
+        return epilog
+
     def ParseCommandLineOptions(self):
         """Parses command line options.
 
@@ -329,20 +344,7 @@ class Edk2Invocable(BaseAbstractInvocable):
         # first argparser will only get settings manager and help will be disabled
         settingsParserObj = argparse.ArgumentParser(add_help=False)
         # instantiate the second argparser that will get passed around
-
-        epilog = dedent('''\
-            positional arguments:
-              <key>=<value>              - Set an env variable for the pre/post build process
-              <key>                      - Set a non-valued env variable for the pre/post build process
-              BLD_*_<key>=<value>        - Set a build flag for all build types
-                                           (key=value will get passed to build process)
-              BLD_*_<key>                - Set a non-valued build flag for all build types
-              BLD_<TARGET>_<key>=<value> - Set a build flag for build type of <target>
-                                           (key=value will get passed to build process for given build type)
-              BLD_<TARGET>_<key>         - Set a non-valued build flag for a build type of <target>
-            ''')
-
-        parserObj = argparse.ArgumentParser(epilog=epilog, formatter_class=argparse.RawDescriptionHelpFormatter,)
+        parserObj = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,)
 
         settingsParserObj.add_argument('-c', '--platform_module', dest='platform_module',
                                        default="PlatformBuild.py", type=str,
@@ -406,6 +408,9 @@ class Edk2Invocable(BaseAbstractInvocable):
                                help='Provide shell variables in a file')
         parserObj.add_argument('--verbose', '--VERBOSE', '-v', dest="verbose", action='store_true', default=False,
                                help='verbose')
+
+        # set the epilog to display with --help, -h
+        parserObj.epilog = self.AddParserEpilog()
 
         # setup sys.argv and argparse round 2
         sys.argv = [sys.argv[0]] + unknown_args

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -319,8 +319,12 @@ class Edk2Invocable(BaseAbstractInvocable):
         """Directory containing all logging files."""
         return "Build"
 
-    def AddParserEpilog(self):
-        """Adds additional information to the end of the argument parser."""
+    def AddParserEpilog(self) -> str:
+        """Adds an epilog to the end of the argument parser when displaying help information.
+
+        Returns:
+            (str): The string to be added to the end of the argument parser.
+        """
         epilog = dedent('''\
             CLI Env Guide:
               <key>=<value>              - Set an env variable for the pre/post build process
@@ -343,8 +347,6 @@ class Edk2Invocable(BaseAbstractInvocable):
         """
         # first argparser will only get settings manager and help will be disabled
         settingsParserObj = argparse.ArgumentParser(add_help=False)
-        # instantiate the second argparser that will get passed around
-        parserObj = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,)
 
         settingsParserObj.add_argument('-c', '--platform_module', dest='platform_module',
                                        default="PlatformBuild.py", type=str,
@@ -394,7 +396,9 @@ class Edk2Invocable(BaseAbstractInvocable):
             print(e)
             sys.exit(2)
 
-        # now to get the big arg parser going...
+        # instantiate the second argparser that will get passed around
+        parserObj = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,)
+
         # first pass it to the subclass
         self.AddCommandLineOptions(parserObj)
 

--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -28,15 +28,7 @@ from edk2toollib.utility_functions import RunCmd, RemoveTree
 from edk2toolext import edk2_logging
 from edk2toolext.environment.plugintypes.uefi_build_plugin import IUefiBuildPlugin
 import datetime
-
-
-class PlatformEnv():
-    """Container representing a Platform Environment Variable."""
-    def __init__(self, name, description, default):
-        """Inits a Platform Environment Variable."""
-        self.name = name
-        self.description = description
-        self.default = default
+from collections import namedtuple
 
 
 class UefiBuilder(object):
@@ -133,14 +125,6 @@ class UefiBuilder(object):
             self.SkipPreBuild = True
             self.SkipPostBuild = True
             self.FlashImage = False
-
-    def DeclareCriticalPlatformEnv(self) -> list[PlatformEnv]:
-        """Returns a list of Env Variables that customize the build.
-
-        Variables set here are printed to the terminal when executing
-        stuart_build -c <Platform> --help.
-        """
-        return []
 
     def Go(self, WorkSpace, PackagesPath, PInHelper, PInManager):
         """Core executable that performs all build steps."""
@@ -506,6 +490,10 @@ class UefiBuilder(object):
         # set environment variables for the build process
         os.environ["EFI_SOURCE"] = self.ws
 
+        # set critical platform Env Defaults if not set anywhere else in the build.
+        for env_var in self.SetPlatformDefaultEnv():
+            self.env.SetValue(env_var.name, env_var.default, "Default Critical Platform Env Value.")
+
         return 0
 
     def FlashRomImage(self):
@@ -558,6 +546,24 @@ class UefiBuilder(object):
             (int): 0 on success, 1 on failure
         """
         return 0
+
+    @classmethod
+    def SetPlatformDefaultEnv(self) -> list[namedtuple]:
+        """Sets platform default environment variables by returning them as a list.
+
+        Variables returned from this method are printed to the command line when
+        calling stuart_build with -h, --help. Variables added here should be
+        reserved only those that are commonly overwritten in the command line for
+        developers.
+
+        Variables returned from this function are the last variables to be set,
+        ensuring that default values are only added if none have been provided by
+        other means.
+
+        Returns:
+            (list[namedtuple]): List of named tuples containing name, description, default
+        """
+        return []
 
     @classmethod
     def PlatformBuildRom(self):

--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -30,6 +30,15 @@ from edk2toolext.environment.plugintypes.uefi_build_plugin import IUefiBuildPlug
 import datetime
 
 
+class PlatformEnv():
+    """Container representing a Platform Environment Variable."""
+    def __init__(self, name, description, default):
+        """Inits a Platform Environment Variable."""
+        self.name = name
+        self.description = description
+        self.default = default
+
+
 class UefiBuilder(object):
     """Object responsible for the full build process.
 
@@ -124,6 +133,14 @@ class UefiBuilder(object):
             self.SkipPreBuild = True
             self.SkipPostBuild = True
             self.FlashImage = False
+
+    def DeclareCriticalPlatformEnv(self) -> list[PlatformEnv]:
+        """Returns a list of Env Variables that customize the build.
+
+        Variables set here are printed to the terminal when executing
+        stuart_build -c <Platform> --help.
+        """
+        return []
 
     def Go(self, WorkSpace, PackagesPath, PInHelper, PInManager):
         """Core executable that performs all build steps."""

--- a/edk2toolext/invocables/edk2_platform_build.py
+++ b/edk2toolext/invocables/edk2_platform_build.py
@@ -86,7 +86,6 @@ class Edk2PlatformBuild(Edk2Invocable):
 
         variables = self.PlatformBuilder.SetPlatformDefaultEnv()
         if any(variables):
-            variables.sort(key=lambda v: v.name)
             max_name_len = max(len(var.name) for var in variables)
             max_desc_len = min(max(len(var.description) for var in variables), 55)
 

--- a/edk2toolext/invocables/edk2_platform_build.py
+++ b/edk2toolext/invocables/edk2_platform_build.py
@@ -16,6 +16,7 @@ itself to remain platform agnostic.
 import os
 import sys
 import logging
+from textwrap import wrap
 from edk2toolext import edk2_logging
 from edk2toolext.environment import plugin_manager
 from edk2toolext.environment.plugintypes.uefi_helper_plugin import HelperFunctions
@@ -74,21 +75,31 @@ class Edk2PlatformBuild(Edk2Invocable):
         """Retrieve command line options from the argparser."""
         self.PlatformBuilder.RetrievePlatformCommandLineOptions(args)
 
-    def AddParserEpilog(self):
-        """Adds additional information to the end of the argument parser."""
+    def AddParserEpilog(self) -> str:
+        """Adds an epilog to the end of the argument parser when displaying help information.
+
+        Returns:
+            (str): The string to be added to the end of the argument parser.
+        """
         epilog = super().AddParserEpilog()
         custom_epilog = ""
 
-        variables = self.PlatformBuilder.DeclareCriticalPlatformEnv()
+        variables = self.PlatformBuilder.SetPlatformDefaultEnv()
         if any(variables):
             variables.sort(key=lambda v: v.name)
-
             max_name_len = max(len(var.name) for var in variables)
-            max_desc_len = max(len(var.description) for var in variables)
+            max_desc_len = min(max(len(var.description) for var in variables), 55)
 
             custom_epilog += "CLI Env Variables:"
             for v in variables:
-                custom_epilog += f"\n  {v.name:<{max_name_len}} - {v.description:<{max_desc_len}}  [{v.default}]"
+                # Setup wrap and print first portion of description
+                desc = wrap(v.description, max_desc_len,
+                            drop_whitespace=True, break_on_hyphens=True, break_long_words=True)
+                custom_epilog += f"\n  {v.name:<{max_name_len}} - {desc[0]:<{max_desc_len}}  [{v.default}]"
+
+                # If the line actually wrapped, we can print the rest of the lines here
+                for d in desc[1:]:
+                    custom_epilog += f"\n  {'':<{max_name_len}}   {d:{max_desc_len}}"
             custom_epilog += '\n\n'
 
         return custom_epilog + epilog

--- a/edk2toolext/invocables/edk2_platform_build.py
+++ b/edk2toolext/invocables/edk2_platform_build.py
@@ -74,6 +74,25 @@ class Edk2PlatformBuild(Edk2Invocable):
         """Retrieve command line options from the argparser."""
         self.PlatformBuilder.RetrievePlatformCommandLineOptions(args)
 
+    def AddParserEpilog(self):
+        """Adds additional information to the end of the argument parser."""
+        epilog = super().AddParserEpilog()
+        custom_epilog = ""
+
+        variables = self.PlatformBuilder.DeclareCriticalPlatformEnv()
+        if any(variables):
+            variables.sort(key=lambda v: v.name)
+
+            max_name_len = max(len(var.name) for var in variables)
+            max_desc_len = max(len(var.description) for var in variables)
+
+            custom_epilog += "CLI Env Variables:"
+            for v in variables:
+                custom_epilog += f"\n  {v.name:<{max_name_len}} - {v.description:<{max_desc_len}}  [{v.default}]"
+            custom_epilog += '\n\n'
+
+        return custom_epilog + epilog
+
     def GetSettingsClass(self):
         """Returns the BuildSettingsManager class.
 


### PR DESCRIPTION
Adds a method to Edk2Invocable, AddParserEpilog(), that allows an invocable to customize the epilog of the argument parser when --help is used. In particular, Edk2PlatformBuild uses this method to append platform specified critical build env variables so that developers no longer need to dig through the code to see what build customizations are available.

Example output:
`stuart_build -c Platforms\QemuQ35Pkg\PlatformBuild.py --help`
`C:\src\mu_tiano_platforms\Platforms\QemuQ35Pkg> py PlatformBuild.py --help`

```cmd
options:
  -h, --help            show this help message and exit
  --SKIPBUILD, --skipbuild, --SkipBuild
                        Skip the build process
  --SKIPPREBUILD, --skipprebuild, --SkipPrebuild
                        Skip prebuild process
  --SKIPPOSTBUILD, --skippostbuild, --SkipPostBuild
                        Skip postbuild process
  --FLASHONLY, --flashonly, --FlashOnly
                        Flash rom after build.
  --FLASHROM, --flashrom, --FlashRom
                        Flash rom. Rom must be built previously.
  --UPDATECONF, --updateconf, --UpdateConf
                        Update Conf. Builders Conf files will be replaced with latest template files
  --CLEAN, --clean, --CLEAN
                        Clean. Remove all old build artifacts and intermediate files
  --CLEANONLY, --cleanonly, --CleanOnly
                        Clean Only. Do clean operation and don't build just exit.
  --OUTPUTCONFIG OUTPUTCONFIG, --outputconfig OUTPUTCONFIG, --OutputConfig OUTPUTCONFIG
                        Provide shell variables in a file
  -a BUILD_ARCH, --arch BUILD_ARCH
                        Optional - CSV of architecture to build. IA32,X64 will use IA32 for PEI and X64 for DXE and is the only valid option for this    
                        platform.
  --codeql              Optional - Produces CodeQL results from the build. See MU_BASECORE/.pytool/Plugin/CodeQL/Readme.md for more information.
  --build-config BUILD_CONFIG
                        Provide shell variables in a file
  --verbose, --VERBOSE, -v
                        verbose

CLI Env Variables:
  BLD_*_MEMORY_PROTECTION - If Memory protections are enabled.                       [TRUE]
  EMPTY_DRIVE             - Clears the Virtual Drive. We also allow for wrapping     [FALSE]
                            extremely long lines. See an example on this line. It
                            is very long!  It will also ignore new lines.
  QEMU_HEADLESS           - Run Qemu on Terminal Only.                               [FALSE]
  RUN_TESTS               - Runs tests specified by TEST_REGEX.                      [FALSE]
  SHUTDOWN_AFTER_RUN      - Shutdown after executing Startup.nsh.                    [FALSE]
  TARGET                  - The build target.                                        [DEBUG]
  TEST_REGEX              - Tests to Run.                                            [FALSE]
  TOOL_CHAIN_TAG          - The build toolchain.                                     [VS2019]

CLI Env Guide:
  <key>=<value>              - Set an env variable for the pre/post build process
  <key>                      - Set a non-valued env variable for the pre/post build process
  BLD_*_<key>=<value>        - Set a build flag for all build types
                               (key=value will get passed to build process)
  BLD_*_<key>                - Set a non-valued build flag for all build types
  BLD_<TARGET>_<key>=<value> - Set a build flag for build type of <target>
                               (key=value will get passed to build process for given build type)
  BLD_<TARGET>_<key>         - Set a non-valued build flag for a build type of <target>
```

The output is generated by implementing `SetPlatformDefaultEnv()` in the PlatformBuild.py which returns must return a list of `PlatformEnv` objects.

Here is an exmaple:

```python
def SetPlatformDefaultEnv(self) -> list[namedtuple]:
        """Returns a list of Env Variables that customize the build.

        Variables set here are printed to the terminal when executing
        stuart_build -c <Platform> --help.
        """
PlatformEnv = namedtuple('PlatformEnv', 'name description default')        
return [
            PlatformEnv("TOOL_CHAIN_TAG", "The build toolchain.", "VS2019"),
            PlatformEnv("TARGET", "The build target.", "DEBUG"),
            PlatformEnv("EMPTY_DRIVE", "Clears the Virtual Drive.", "FALSE"),
            PlatformEnv("RUN_TESTS", "Runs tests specified by TEST_REGEX.", "FALSE"),
            PlatformEnv("TEST_REGEX", "Tests to Run.", "FALSE"),
            PlatformEnv("QEMU_HEADLESS", "Run Qemu on Terminal Only.", "FALSE"),
            PlatformEnv("SHUTDOWN_AFTER_RUN", "Shutdown after executing Startup.nsh.", "FALSE"),
            PlatformEnv("BLD_*_MEMORY_PROTECTION", "If Memory protections are enabled.", "TRUE")
        ]