### PR TITLE
Add ability to skip verification of external dependencies

### DIFF
--- a/docs/user/requirements.txt
+++ b/docs/user/requirements.txt
@@ -1,6 +1,6 @@
 black==22.12.0
 mkdocs==1.4.2
-mkdocs-material==9.0.5
+mkdocs-material==9.0.6
 mkdocstrings[python]==0.20.0
 mkdocstrings-python==0.8.3
 markdown-include==0.8.0

--- a/docs/user/requirements.txt
+++ b/docs/user/requirements.txt
@@ -1,7 +1,7 @@
 black==22.12.0
 mkdocs==1.4.2
 mkdocs-material==9.0.5
-mkdocstrings[python]==0.19.1
+mkdocstrings[python]==0.20.0
 mkdocstrings-python==0.8.3
 markdown-include==0.8.0
 mkdocs-gen-files==0.4.0

--- a/edk2toolext/environment/extdeptypes/git_dependency.py
+++ b/edk2toolext/environment/extdeptypes/git_dependency.py
@@ -83,7 +83,17 @@ class GitDependency(ExternalDependency):
         super().clean()
 
     def verify(self):
-        """Verifies the clone was successful."""
+        """Verifies the clone was successful.
+
+        !!! Note
+            If verify is set to false in the dependencies state file,
+            it will always skip the verification process.
+        """
+        state_data = self.get_state_file_data()
+        if state_data and state_data['verify'] is False:
+            logging.warn(f'{self.name} is unverified. Unexpected results may occur.')
+            return True
+
         result = True
 
         if not os.path.isdir(self._local_repo_root_path):

--- a/edk2toolext/invocables/edk2_platform_build.py
+++ b/edk2toolext/invocables/edk2_platform_build.py
@@ -68,11 +68,26 @@ class Edk2PlatformBuild(Edk2Invocable):
             except (TypeError):
                 raise RuntimeError(f"UefiBuild not found in module:\n{dir(self.PlatformModule)}")
 
+        parserObj.add_argument('-n', '--no-verify', '--NO-VERIFY',
+                               dest="verify", default=True, action='store_false',
+                               help='Skip verifying external dependencies before build.')
         self.PlatformBuilder.AddPlatformCommandLineOptions(parserObj)
 
     def RetrieveCommandLineOptions(self, args):
         """Retrieve command line options from the argparser."""
+        self.verify = args.verify
         self.PlatformBuilder.RetrievePlatformCommandLineOptions(args)
+
+    def GetVerifyCheckRequired(self) -> bool:
+        """Will call self_describing_environment.VerifyEnvironment if this returns True.
+
+        !!! hint
+            Optional override in a subclass
+
+        Returns:
+            (bool): whether verify check is required or not
+        """
+        return self.verify
 
     def GetSettingsClass(self):
         """Returns the BuildSettingsManager class.

--- a/edk2toolext/invocables/edk2_platform_build.py
+++ b/edk2toolext/invocables/edk2_platform_build.py
@@ -88,7 +88,7 @@ class Edk2PlatformBuild(Edk2Invocable):
             (bool): whether verify check is required or not
         """
         if not self.verify:
-            logging.warning("Skipping Environment Verification.")
+            logging.warning("Skipping Environment Verification. Unexpected results may occur.")
         return self.verify
 
     def GetSettingsClass(self):

--- a/edk2toolext/invocables/edk2_platform_build.py
+++ b/edk2toolext/invocables/edk2_platform_build.py
@@ -87,6 +87,8 @@ class Edk2PlatformBuild(Edk2Invocable):
         Returns:
             (bool): whether verify check is required or not
         """
+        if not self.verify:
+            logging.warning("Skipping Environment Verification.")
         return self.verify
 
     def GetSettingsClass(self):

--- a/edk2toolext/invocables/edk2_platform_build.py
+++ b/edk2toolext/invocables/edk2_platform_build.py
@@ -68,7 +68,7 @@ class Edk2PlatformBuild(Edk2Invocable):
             except (TypeError):
                 raise RuntimeError(f"UefiBuild not found in module:\n{dir(self.PlatformModule)}")
 
-        parserObj.add_argument('-n', '--no-verify', '--NO-VERIFY',
+        parserObj.add_argument('-nv', '-NV', '--noverify', '--NOVERIFY', '--NoVerify',
                                dest="verify", default=True, action='store_false',
                                help='Skip verifying external dependencies before build.')
         self.PlatformBuilder.AddPlatformCommandLineOptions(parserObj)

--- a/edk2toolext/tests/test_edk2_update.py
+++ b/edk2toolext/tests/test_edk2_update.py
@@ -84,7 +84,7 @@ class TestEdk2Update(unittest.TestCase):
         updater = self.invoke_update(tree.get_settings_provider_path())
         # make sure it worked
         self.assertTrue(os.path.exists(os.path.join(WORKSPACE, "Edk2TestUpdate_extdep",
-                                                    "NuGet.CommandLine_extdep", "extdep_state.json")))
+                                                    "NuGet.CommandLine_extdep", "extdep_state.yaml")))
         build_env, shell_env, failure = updater.PerformUpdate()
         # we should have no failures
         self.assertEqual(failure, 0)

--- a/edk2toolext/tests/test_self_describing_environment.py
+++ b/edk2toolext/tests/test_self_describing_environment.py
@@ -10,6 +10,7 @@ import os
 import pygit2
 import unittest
 import tempfile
+import yaml
 from edk2toolext.environment import self_describing_environment
 from edk2toolext.tests.uefi_tree import uefi_tree
 from edk2toolext.environment import version_aggregator
@@ -165,6 +166,33 @@ class Testself_describing_environment(unittest.TestCase):
         # Because this is a subtree, the duplicate ext_deps should be ignored
         # that are present in the worktree
         self_describing_environment.BootstrapEnvironment(self.workspace, ('global',))
+
+    def test_no_verify_extdep(self):
+        tree = uefi_tree(self.workspace, create_platform=False)
+        tree.create_ext_dep(dep_type="git",
+                            scope="global",
+                            name="HelloWorld",
+                            source="https://github.com/octocat/Hello-World.git",
+                            version="7fd1a60b01f91b314f59955a4e4d4e80d8edf11d")
+
+        # Bootstrap the environment
+        self_describing_environment.BootstrapEnvironment(self.workspace, ("global",))
+        self_describing_environment.UpdateDependencies(self.workspace, scopes=("global",))
+        self_describing_environment.VerifyEnvironment(self.workspace, scopes=("global",))
+
+        # Delete the readme to make the repo dirty then verify it fails
+        readme = os.path.join(tree.get_workspace(), "HelloWorld_extdep", "HelloWorld", "README")
+        os.remove(readme)
+        self.assertFalse(self_describing_environment.VerifyEnvironment(self.workspace, scopes=("global",)))
+
+        # Update the state file to not verify the specific external dependency then verify it passes
+        state_file = os.path.join(tree.get_workspace(), "HelloWorld_extdep", "extdep_state.yaml")
+        with open(state_file, 'r+') as f:
+            content = yaml.safe_load(f)
+            f.seek(0)
+            content["verify"] = False
+            yaml.safe_dump(content, f)
+        self.assertTrue(self_describing_environment.VerifyEnvironment(self.workspace, scopes=("global",)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds two separate ways to skip verification of external dependencies.  This is to enable co-development of feature repos that are downloaded as external dependencies instead of submodules.

1. Adds a --noverify flag to stuart_build which will skip verification for all external dependencies for that single run
2. Adds a state flag in the extdep_state.yaml file, verify, that by default is true, but can be set to false to disable verification indefinitely for that external dependency.

Closes #415 