### PR TITLE
nuget_publishing: Make `license` entry in config file optional

### DIFF
--- a/edk2toolext/nuget_publishing.py
+++ b/edk2toolext/nuget_publishing.py
@@ -116,7 +116,8 @@ class NugetSupport(object):
     def SetBasicData(self, authors, license, project, description, server, copyright):
         """Set basic data in the config data."""
         self.ConfigData["author_string"] = authors
-        self.ConfigData["license"] = license
+        if license:
+            self.ConfigData["license"] = license
         self.ConfigData["project_url"] = project
         self.ConfigData["description_string"] = description
         self.ConfigData["server_url"] = server
@@ -139,6 +140,9 @@ class NugetSupport(object):
 
     def IsValidLicense(self):
         """Returns whether the License is valid."""
+        if "license" not in self.ConfigData:
+            return False
+
         license = self.ConfigData["license"]
 
         if license in LICENSE_IDENTIFIER_SUPPORTED.values():
@@ -453,7 +457,10 @@ def main():
         # Support Standard License or Custom License
         # Custom License path provided during pack operation
         if args.LicenseIdentifier is True:
-            license = "Use --CustomLicensePath in Pack command to set this"
+            logging.critical("Provide either a `license` entry in the NuGet config file or "
+                             "use the `--CustomLicensePath` parameter in the Pack command to "
+                             "set the license file path.")
+            license = None
         else:
             license = LICENSE_IDENTIFIER_SUPPORTED[args.LicenseIdentifier]
 

--- a/edk2toolext/tests/test_nuget_publish.py
+++ b/edk2toolext/tests/test_nuget_publish.py
@@ -186,8 +186,7 @@ class test_nuget_publish(unittest.TestCase):
                     "--FeedUrl",
                     " https://github.com",
                     "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--CustomLicense"]
+                    tempfolder]
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
 
@@ -224,8 +223,7 @@ class test_nuget_publish(unittest.TestCase):
                     "--FeedUrl",
                     " https://github.com",
                     "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--CustomLicense"]
+                    tempfolder]
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
         sys.argv = ["",
@@ -261,8 +259,7 @@ class test_nuget_publish(unittest.TestCase):
                     "--FeedUrl",
                     " https://github.com",
                     "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--CustomLicense"]
+                    tempfolder]
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
         sys.argv = ["",

--- a/edk2toolext/tests/test_nuget_publish.py
+++ b/edk2toolext/tests/test_nuget_publish.py
@@ -197,6 +197,8 @@ class test_nuget_publish(unittest.TestCase):
                     os.path.join(tempfolder, "Test.config.yaml"),
                     "--Version",
                     "1.0.0",
+                    "--Copyright",
+                    "2023",
                     "--InputFolderPath",
                     tempfolder,
                     "--CustomLicensePath",
@@ -204,6 +206,39 @@ class test_nuget_publish(unittest.TestCase):
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
+        sys.argv = args
+
+    def test_main_new_and_pack_no_CustomLicense(self):
+        args = sys.argv
+        tempfolder = tempfile.mkdtemp()
+        sys.argv = ["",
+                    "--Operation",
+                    "New",
+                    "--Name",
+                    "Test",
+                    "--Author",
+                    "test",
+                    "--ProjectUrl",
+                    "https://github.com",
+                    "--Description",
+                    "test",
+                    "--FeedUrl",
+                    " https://github.com",
+                    "--ConfigFileFolderPath",
+                    tempfolder]
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+        sys.argv = ["",
+                    "--Operation",
+                    "Pack",
+                    "--ConfigFilePath",
+                    os.path.join(tempfolder, "Test.config.yaml"),
+                    "--Version",
+                    "1.0.0",
+                    "--InputFolderPath",
+                    tempfolder]
+
+        self.assertRaises(Exception, nuget_publishing.main)
         sys.argv = args
 
     def test_main_new_and_pack_CustomLicense_invalid_path(self):


### PR DESCRIPTION
Previously the NuGet config file required a dummy license value to
be present if `--CustomLicensePath` was given. This change removes
the dummy value being required.

Co-authored-by: Joey Vagedes <joeyvagedes@microsoft.com>
Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>