### PR TITLE
nuget_publishing: Add repository metadata support

### DIFF
--- a/edk2toolext/nuget_publishing.py
+++ b/edk2toolext/nuget_publishing.py
@@ -48,6 +48,7 @@ class NugetSupport(object):
         <license></license>
         <releaseNotes></releaseNotes>
         <projectUrl></projectUrl>
+        <repository />
         <copyright></copyright>
         <tags></tags>
     </metadata>
@@ -113,7 +114,9 @@ class NugetSupport(object):
         with open(self.Config, "r") as c:
             self.ConfigData = yaml.safe_load(c)
 
-    def SetBasicData(self, authors, license, project, description, server, copyright):
+    def SetBasicData(self, authors, license, project, description, server, copyright,
+                     repositoryType=None, repositoryUrl=None, repositoryBranch=None,
+                     repositoryCommit=None):
         """Set basic data in the config data."""
         self.ConfigData["author_string"] = authors
         if license:
@@ -121,7 +124,14 @@ class NugetSupport(object):
         self.ConfigData["project_url"] = project
         self.ConfigData["description_string"] = description
         self.ConfigData["server_url"] = server
-
+        if repositoryType:
+            self.ConfigData["repository_type"] = repositoryType
+        if repositoryUrl:
+            self.ConfigData["repository_url"] = repositoryUrl
+        if repositoryBranch:
+            self.ConfigData["repository_branch"] = repositoryBranch
+        if repositoryCommit:
+            self.ConfigData["repository_commit"] = repositoryCommit
         if not copyright:
             copyright = "Copyright %d" % datetime.date.today().year
         self.ConfigData["copyright_string"] = copyright
@@ -165,6 +175,21 @@ class NugetSupport(object):
         """Update tags in the config data."""
         self.ConfigData["tags_string"] = " ".join(tags)
         self.ConfigChanged = True
+
+    def UpdateRepositoryInfo(self, type=None, url=None, branch=None, commit=None):
+        """Update repository information."""
+        if type:
+            self.ConfigData["repository_type"] = type
+            self.ConfigChanged = True
+        if url:
+            self.ConfigData["repository_url"] = url
+            self.ConfigChanged = True
+        if branch:
+            self.ConfigData["repository_branch"] = branch
+            self.ConfigChanged = True
+        if commit:
+            self.ConfigData["repository_commit"] = commit
+            self.ConfigChanged = True
 
     def Print(self):
         """Print info about the Nuget Object."""
@@ -217,6 +242,17 @@ class NugetSupport(object):
         meta.find("version").text = self.NewVersion
         meta.find("authors").text = self.ConfigData["author_string"]
         meta.find("projectUrl").text = self.ConfigData["project_url"]
+        repository_item_present = bool([k for k in self.ConfigData.keys() if "repository" in k.lower()])
+        if repository_item_present:
+            r = meta.find("repository")
+            if "repository_type" in self.ConfigData:
+                r.set("type", self.ConfigData["repository_type"])
+            if "repository_url" in self.ConfigData:
+                r.set("url", self.ConfigData["repository_url"])
+            if "repository_branch" in self.ConfigData:
+                r.set("branch", self.ConfigData["repository_branch"])
+            if "repository_commit" in self.ConfigData:
+                r.set("commit", self.ConfigData["repository_commit"])
         meta.find("description").text = self.ConfigData["description_string"]
         meta.find("copyright").text = self.ConfigData["copyright_string"]
         if "tags_string" in self.ConfigData:
@@ -368,6 +404,10 @@ def GatherArguments():
                             required=True)
         parser.add_argument('--Author', dest="Author", help="<Required> Author string for publishing", required=True)
         parser.add_argument("--ProjectUrl", dest="Project", help="<Required> Project Url", required=True)
+        parser.add_argument("--RepositoryType", dest="RepositoryType", help="<Optional> Repository Type", required=False)
+        parser.add_argument("--RepositoryUrl", dest="RepositoryUrl", help="<Optional> Repository Url", required=False)
+        parser.add_argument("--RepositoryBranch", dest="RepositoryBranch", help="<Optional> Repository Branch", required=False)
+        parser.add_argument("--RepositoryCommit", dest="RepositoryCommit", help="<Optional> Repository Commit", required=False)
         parser.add_argument('--LicenseIdentifier', dest="LicenseIdentifier", default=None,
                             choices=LICENSE_IDENTIFIER_SUPPORTED.keys(), help="Standard Licenses")
         parser.add_argument('--Description', dest="Description",
@@ -395,6 +435,10 @@ def GatherArguments():
         parser.add_argument('--CustomLicensePath', dest="CustomLicensePath", default=None,
                             help="<Optional> If CustomLicense set in `new` phase, provide absolute path of License \
                             File to pack. Does not override existing valid license.")
+        parser.add_argument("--RepositoryType", dest="RepositoryType", help="<Optional> Repository Type", required=False)
+        parser.add_argument("--RepositoryUrl", dest="RepositoryUrl", help="<Optional> Change the repository Url", required=False)
+        parser.add_argument("--RepositoryBranch", dest="RepositoryBranch", help="<Optional> Change the repository branch", required=False)
+        parser.add_argument("--RepositoryCommit", dest="RepositoryCommit", help="<Optional> Change the repository commit", required=False)
 
     elif (args.op.lower() == "push"):
         parser.add_argument("--ConfigFilePath", dest="ConfigFilePath",
@@ -457,7 +501,17 @@ def main():
         else:
             license = LICENSE_IDENTIFIER_SUPPORTED[args.LicenseIdentifier]
 
-        nu.SetBasicData(args.Author, license, args.Project, args.Description, args.FeedUrl, args.Copyright)
+        nu.SetBasicData(
+            args.Author,
+            license,
+            args.Project,
+            args.Description,
+            args.FeedUrl,
+            args.Copyright,
+            args.RepositoryType,
+            args.RepositoryUrl,
+            args.RepositoryBranch,
+            args.RepositoryCommit)
         nu.LogObject()
         ret = nu.ToConfigFile(ConfigFilePath)
         return ret
@@ -500,6 +554,10 @@ def main():
 
         if (args.Copyright is not None):
             nu.UpdateCopyright(args.Copyright)
+
+        nu.UpdateRepositoryInfo(args.RepositoryType, args.RepositoryUrl,
+                                args.RepositoryBranch, args.RepositoryCommit)
+
         if (len(args.Tags) > 0):
             tagListSet = set()
             for item in args.Tags:  # Parse out the individual packages

--- a/edk2toolext/nuget_publishing.py
+++ b/edk2toolext/nuget_publishing.py
@@ -243,8 +243,8 @@ class NugetSupport(object):
         meta.find("authors").text = self.ConfigData["author_string"]
         meta.find("projectUrl").text = self.ConfigData["project_url"]
         repository_item_present = bool([k for k in self.ConfigData.keys() if "repository" in k.lower()])
+        r = meta.find("repository")
         if repository_item_present:
-            r = meta.find("repository")
             if "repository_type" in self.ConfigData:
                 r.set("type", self.ConfigData["repository_type"])
             if "repository_url" in self.ConfigData:
@@ -253,6 +253,8 @@ class NugetSupport(object):
                 r.set("branch", self.ConfigData["repository_branch"])
             if "repository_commit" in self.ConfigData:
                 r.set("commit", self.ConfigData["repository_commit"])
+        else:
+            meta.remove(r)
         meta.find("description").text = self.ConfigData["description_string"]
         meta.find("copyright").text = self.ConfigData["copyright_string"]
         if "tags_string" in self.ConfigData:
@@ -404,14 +406,16 @@ def GatherArguments():
                             required=True)
         parser.add_argument('--Author', dest="Author", help="<Required> Author string for publishing", required=True)
         parser.add_argument("--ProjectUrl", dest="Project", help="<Required> Project Url", required=True)
-        parser.add_argument("--RepositoryType", dest="RepositoryType", help="<Optional> Repository Type",
-                            required=False)
-        parser.add_argument("--RepositoryUrl", dest="RepositoryUrl", help="<Optional> Repository Url",
-                            required=False)
-        parser.add_argument("--RepositoryBranch", dest="RepositoryBranch", help="<Optional> Repository Branch",
-                            required=False)
-        parser.add_argument("--RepositoryCommit", dest="RepositoryCommit", help="<Optional> Repository Commit",
-                            required=False)
+        repo_group = parser.add_argument_group(title="Repository Parameters",
+                                               description="Optional Repository Parameters")
+        repo_group.add_argument("--RepositoryType", dest="RepositoryType", help="<Optional> Repository Type",
+                                required=False)
+        repo_group.add_argument("--RepositoryUrl", dest="RepositoryUrl", help="<Optional> Repository Url",
+                                required=False)
+        repo_group.add_argument("--RepositoryBranch", dest="RepositoryBranch", help="<Optional> Repository Branch",
+                                required=False)
+        repo_group.add_argument("--RepositoryCommit", dest="RepositoryCommit", help="<Optional> Repository Commit",
+                                required=False)
         parser.add_argument('--LicenseIdentifier', dest="LicenseIdentifier", default=None,
                             choices=LICENSE_IDENTIFIER_SUPPORTED.keys(), help="Standard Licenses")
         parser.add_argument('--Description', dest="Description",
@@ -439,14 +443,16 @@ def GatherArguments():
         parser.add_argument('--CustomLicensePath', dest="CustomLicensePath", default=None,
                             help="<Optional> If CustomLicense set in `new` phase, provide absolute path of License \
                             File to pack. Does not override existing valid license.")
-        parser.add_argument("--RepositoryType", dest="RepositoryType", help="<Optional> Repository Type",
-                            required=False)
-        parser.add_argument("--RepositoryUrl", dest="RepositoryUrl", help="<Optional> Change the repository Url",
-                            required=False)
-        parser.add_argument("--RepositoryBranch", dest="RepositoryBranch",
-                            help="<Optional> Change the repository branch", required=False)
-        parser.add_argument("--RepositoryCommit", dest="RepositoryCommit",
-                            help="<Optional> Change the repository commit", required=False)
+        repo_group = parser.add_argument_group(title="Repository Parameters",
+                                               description="Optional Repository Parameters")
+        repo_group.add_argument("--RepositoryType", dest="RepositoryType", help="<Optional> Repository Type",
+                                required=False)
+        repo_group.add_argument("--RepositoryUrl", dest="RepositoryUrl", help="<Optional> Change the repository Url",
+                                required=False)
+        repo_group.add_argument("--RepositoryBranch", dest="RepositoryBranch",
+                                help="<Optional> Change the repository branch", required=False)
+        repo_group.add_argument("--RepositoryCommit", dest="RepositoryCommit",
+                                help="<Optional> Change the repository commit", required=False)
 
     elif (args.op.lower() == "push"):
         parser.add_argument("--ConfigFilePath", dest="ConfigFilePath",

--- a/edk2toolext/nuget_publishing.py
+++ b/edk2toolext/nuget_publishing.py
@@ -404,10 +404,14 @@ def GatherArguments():
                             required=True)
         parser.add_argument('--Author', dest="Author", help="<Required> Author string for publishing", required=True)
         parser.add_argument("--ProjectUrl", dest="Project", help="<Required> Project Url", required=True)
-        parser.add_argument("--RepositoryType", dest="RepositoryType", help="<Optional> Repository Type", required=False)
-        parser.add_argument("--RepositoryUrl", dest="RepositoryUrl", help="<Optional> Repository Url", required=False)
-        parser.add_argument("--RepositoryBranch", dest="RepositoryBranch", help="<Optional> Repository Branch", required=False)
-        parser.add_argument("--RepositoryCommit", dest="RepositoryCommit", help="<Optional> Repository Commit", required=False)
+        parser.add_argument("--RepositoryType", dest="RepositoryType", help="<Optional> Repository Type",
+                            required=False)
+        parser.add_argument("--RepositoryUrl", dest="RepositoryUrl", help="<Optional> Repository Url",
+                            required=False)
+        parser.add_argument("--RepositoryBranch", dest="RepositoryBranch", help="<Optional> Repository Branch",
+                            required=False)
+        parser.add_argument("--RepositoryCommit", dest="RepositoryCommit", help="<Optional> Repository Commit",
+                            required=False)
         parser.add_argument('--LicenseIdentifier', dest="LicenseIdentifier", default=None,
                             choices=LICENSE_IDENTIFIER_SUPPORTED.keys(), help="Standard Licenses")
         parser.add_argument('--Description', dest="Description",
@@ -435,10 +439,14 @@ def GatherArguments():
         parser.add_argument('--CustomLicensePath', dest="CustomLicensePath", default=None,
                             help="<Optional> If CustomLicense set in `new` phase, provide absolute path of License \
                             File to pack. Does not override existing valid license.")
-        parser.add_argument("--RepositoryType", dest="RepositoryType", help="<Optional> Repository Type", required=False)
-        parser.add_argument("--RepositoryUrl", dest="RepositoryUrl", help="<Optional> Change the repository Url", required=False)
-        parser.add_argument("--RepositoryBranch", dest="RepositoryBranch", help="<Optional> Change the repository branch", required=False)
-        parser.add_argument("--RepositoryCommit", dest="RepositoryCommit", help="<Optional> Change the repository commit", required=False)
+        parser.add_argument("--RepositoryType", dest="RepositoryType", help="<Optional> Repository Type",
+                            required=False)
+        parser.add_argument("--RepositoryUrl", dest="RepositoryUrl", help="<Optional> Change the repository Url",
+                            required=False)
+        parser.add_argument("--RepositoryBranch", dest="RepositoryBranch",
+                            help="<Optional> Change the repository branch", required=False)
+        parser.add_argument("--RepositoryCommit", dest="RepositoryCommit",
+                            help="<Optional> Change the repository commit", required=False)
 
     elif (args.op.lower() == "push"):
         parser.add_argument("--ConfigFilePath", dest="ConfigFilePath",

--- a/edk2toolext/tests/test_nuget_publish.py
+++ b/edk2toolext/tests/test_nuget_publish.py
@@ -312,6 +312,418 @@ class test_nuget_publish(unittest.TestCase):
         self.assertRaises(Exception, nuget_publishing.main)
         sys.argv = args
 
+    def test_main_new_RepositoryType_and_pack(self):
+        args = sys.argv
+        tempfolder = tempfile.mkdtemp()
+        sys.argv = ["",
+                    "--Operation",
+                    "New",
+                    "--Name",
+                    "Test",
+                    "--Author",
+                    "test",
+                    "--ProjectUrl",
+                    "https://github.com",
+                    "--Description",
+                    "test",
+                    "--FeedUrl",
+                    " https://github.com",
+                    "--ConfigFileFolderPath",
+                    tempfolder,
+                    "--LicenseIdentifier",
+                    "BSD2",
+                    "--RepositoryType",
+                    "git"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+
+        sys.argv = ["",
+                    "--Operation",
+                    "Pack",
+                    "--ConfigFilePath",
+                    os.path.join(tempfolder, "Test.config.yaml"),
+                    "--Version",
+                    "1.0.0",
+                    "--InputFolderPath",
+                    tempfolder]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+        sys.argv = args
+
+    def test_main_new_RepositoryUrl_and_pack(self):
+        args = sys.argv
+        tempfolder = tempfile.mkdtemp()
+        sys.argv = ["",
+                    "--Operation",
+                    "New",
+                    "--Name",
+                    "Test",
+                    "--Author",
+                    "test",
+                    "--ProjectUrl",
+                    "https://github.com",
+                    "--Description",
+                    "test",
+                    "--FeedUrl",
+                    " https://github.com",
+                    "--ConfigFileFolderPath",
+                    tempfolder,
+                    "--LicenseIdentifier",
+                    "BSD2",
+                    "--RepositoryUrl",
+                    "https://github.com/microsoft/mu_basecore"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+
+        sys.argv = ["",
+                    "--Operation",
+                    "Pack",
+                    "--ConfigFilePath",
+                    os.path.join(tempfolder, "Test.config.yaml"),
+                    "--Version",
+                    "1.0.0",
+                    "--InputFolderPath",
+                    tempfolder]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+        sys.argv = args
+
+    def test_main_new_RepositoryBranch_and_pack(self):
+        args = sys.argv
+        tempfolder = tempfile.mkdtemp()
+        sys.argv = ["",
+                    "--Operation",
+                    "New",
+                    "--Name",
+                    "Test",
+                    "--Author",
+                    "test",
+                    "--ProjectUrl",
+                    "https://github.com",
+                    "--Description",
+                    "test",
+                    "--FeedUrl",
+                    " https://github.com",
+                    "--ConfigFileFolderPath",
+                    tempfolder,
+                    "--LicenseIdentifier",
+                    "BSD2",
+                    "--RepositoryBranch",
+                    "main"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+
+        sys.argv = ["",
+                    "--Operation",
+                    "Pack",
+                    "--ConfigFilePath",
+                    os.path.join(tempfolder, "Test.config.yaml"),
+                    "--Version",
+                    "1.0.0",
+                    "--InputFolderPath",
+                    tempfolder]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+        sys.argv = args
+
+    def test_main_new_RepositoryCommit_and_pack(self):
+        args = sys.argv
+        tempfolder = tempfile.mkdtemp()
+        sys.argv = ["",
+                    "--Operation",
+                    "New",
+                    "--Name",
+                    "Test",
+                    "--Author",
+                    "test",
+                    "--ProjectUrl",
+                    "https://github.com",
+                    "--Description",
+                    "test",
+                    "--FeedUrl",
+                    " https://github.com",
+                    "--ConfigFileFolderPath",
+                    tempfolder,
+                    "--LicenseIdentifier",
+                    "BSD2",
+                    "--RepositoryCommit",
+                    "cd845afd5c3c838a9f7af7dad238452ae9a17146"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+
+        sys.argv = ["",
+                    "--Operation",
+                    "Pack",
+                    "--ConfigFilePath",
+                    os.path.join(tempfolder, "Test.config.yaml"),
+                    "--Version",
+                    "1.0.0",
+                    "--InputFolderPath",
+                    tempfolder]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+        sys.argv = args
+
+    def test_main_new_RepositoryAll_and_pack(self):
+        args = sys.argv
+        tempfolder = tempfile.mkdtemp()
+        sys.argv = ["",
+                    "--Operation",
+                    "New",
+                    "--Name",
+                    "Test",
+                    "--Author",
+                    "test",
+                    "--ProjectUrl",
+                    "https://github.com",
+                    "--Description",
+                    "test",
+                    "--FeedUrl",
+                    " https://github.com",
+                    "--ConfigFileFolderPath",
+                    tempfolder,
+                    "--LicenseIdentifier",
+                    "BSD2",
+                    "--RepositoryType",
+                    "git",
+                    "--RepositoryUrl",
+                    "https://github.com/microsoft/mu_plus",
+                    "--RepositoryBranch",
+                    "master",
+                    "--RepositoryCommit",
+                    "06df12360d561b2007e03503491510c36426d860"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+
+        sys.argv = ["",
+                    "--Operation",
+                    "Pack",
+                    "--ConfigFilePath",
+                    os.path.join(tempfolder, "Test.config.yaml"),
+                    "--Version",
+                    "1.0.0",
+                    "--InputFolderPath",
+                    tempfolder]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+        sys.argv = args
+
+    def test_main_new_and_pack_RepositoryType(self):
+        args = sys.argv
+        tempfolder = tempfile.mkdtemp()
+        sys.argv = ["",
+                    "--Operation",
+                    "New",
+                    "--Name",
+                    "Test",
+                    "--Author",
+                    "test",
+                    "--ProjectUrl",
+                    "https://github.com",
+                    "--Description",
+                    "test",
+                    "--FeedUrl",
+                    " https://github.com",
+                    "--ConfigFileFolderPath",
+                    tempfolder,
+                    "--LicenseIdentifier",
+                    "BSD2"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+
+        sys.argv = ["",
+                    "--Operation",
+                    "Pack",
+                    "--ConfigFilePath",
+                    os.path.join(tempfolder, "Test.config.yaml"),
+                    "--Version",
+                    "1.0.0",
+                    "--InputFolderPath",
+                    tempfolder,
+                    "--RepositoryType",
+                    "git"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+        sys.argv = args
+
+    def test_main_new_and_pack_RepositoryUrl(self):
+        args = sys.argv
+        tempfolder = tempfile.mkdtemp()
+        sys.argv = ["",
+                    "--Operation",
+                    "New",
+                    "--Name",
+                    "Test",
+                    "--Author",
+                    "test",
+                    "--ProjectUrl",
+                    "https://github.com",
+                    "--Description",
+                    "test",
+                    "--FeedUrl",
+                    " https://github.com",
+                    "--ConfigFileFolderPath",
+                    tempfolder,
+                    "--LicenseIdentifier",
+                    "BSD2"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+
+        sys.argv = ["",
+                    "--Operation",
+                    "Pack",
+                    "--ConfigFilePath",
+                    os.path.join(tempfolder, "Test.config.yaml"),
+                    "--Version",
+                    "1.0.0",
+                    "--InputFolderPath",
+                    tempfolder,
+                    "--RepositoryUrl",
+                    "https://github.com/microsoft/mu_basecore"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+        sys.argv = args
+
+    def test_main_new_and_pack_RepositoryBranch(self):
+        args = sys.argv
+        tempfolder = tempfile.mkdtemp()
+        sys.argv = ["",
+                    "--Operation",
+                    "New",
+                    "--Name",
+                    "Test",
+                    "--Author",
+                    "test",
+                    "--ProjectUrl",
+                    "https://github.com",
+                    "--Description",
+                    "test",
+                    "--FeedUrl",
+                    " https://github.com",
+                    "--ConfigFileFolderPath",
+                    tempfolder,
+                    "--LicenseIdentifier",
+                    "BSD2"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+
+        sys.argv = ["",
+                    "--Operation",
+                    "Pack",
+                    "--ConfigFilePath",
+                    os.path.join(tempfolder, "Test.config.yaml"),
+                    "--Version",
+                    "1.0.0",
+                    "--InputFolderPath",
+                    tempfolder,
+                    "--RepositoryBranch",
+                    "main"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+        sys.argv = args
+
+    def test_main_new_and_pack_RepositoryCommit(self):
+        args = sys.argv
+        tempfolder = tempfile.mkdtemp()
+        sys.argv = ["",
+                    "--Operation",
+                    "New",
+                    "--Name",
+                    "Test",
+                    "--Author",
+                    "test",
+                    "--ProjectUrl",
+                    "https://github.com",
+                    "--Description",
+                    "test",
+                    "--FeedUrl",
+                    " https://github.com",
+                    "--ConfigFileFolderPath",
+                    tempfolder,
+                    "--LicenseIdentifier",
+                    "BSD2"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+
+        sys.argv = ["",
+                    "--Operation",
+                    "Pack",
+                    "--ConfigFilePath",
+                    os.path.join(tempfolder, "Test.config.yaml"),
+                    "--Version",
+                    "1.0.0",
+                    "--InputFolderPath",
+                    tempfolder,
+                    "--RepositoryCommit",
+                    "cd845afd5c3c838a9f7af7dad238452ae9a17146"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+        sys.argv = args
+
+    def test_main_new_and_pack_RepositoryAll(self):
+        args = sys.argv
+        tempfolder = tempfile.mkdtemp()
+        sys.argv = ["",
+                    "--Operation",
+                    "New",
+                    "--Name",
+                    "Test",
+                    "--Author",
+                    "test",
+                    "--ProjectUrl",
+                    "https://github.com",
+                    "--Description",
+                    "test",
+                    "--FeedUrl",
+                    " https://github.com",
+                    "--ConfigFileFolderPath",
+                    tempfolder,
+                    "--LicenseIdentifier",
+                    "BSD2"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+
+        sys.argv = ["",
+                    "--Operation",
+                    "Pack",
+                    "--ConfigFilePath",
+                    os.path.join(tempfolder, "Test.config.yaml"),
+                    "--Version",
+                    "1.0.0",
+                    "--InputFolderPath",
+                    tempfolder,
+                    "--RepositoryType",
+                    "git",
+                    "--RepositoryUrl",
+                    "https://github.com/microsoft/mu_plus",
+                    "--RepositoryBranch",
+                    "master",
+                    "--RepositoryCommit",
+                    "06df12360d561b2007e03503491510c36426d860"]
+
+        ret = nuget_publishing.main()
+        self.assertEqual(ret, 0)
+        sys.argv = args
+
     # TODO: finish unit test
 
 


### PR DESCRIPTION
NuGet packages can associate a package with source repositories using
the `repository` metadata element.

The following for optional attributes are allowed per the corresponding
nuspec version:

- `type` (4.0+)
- `url` (4.0+)
- `branch` (4.6+)
- `commit` (4.6+)

See the following nuspec reference for more info:
https://learn.microsoft.com/en-us/nuget/reference/nuspec#repository

The GitHub NuGet registry (among others) can use this information to
associate a given package with the specified source content.

See the following GitHub doc for more info:
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry

This change adds support for the `repository` element in both the
`New` (set in config file) and `Pack` (change at cmd line) commands
so it can be used when publishing NuGet packages.

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>