### PR TITLE
shell_environment: set_shell_var() exception

### DIFF
--- a/edk2toolext/environment/shell_environment.py
+++ b/edk2toolext/environment/shell_environment.py
@@ -319,15 +319,21 @@ class ShellEnvironment(metaclass=Singleton):
         return self.active_buildvars.GetValue(var_name)
 
     def set_build_var(self, var_name, var_data):
-        """Sets the build var.
+        """Sets the variable as internal build variable.
+
+        !!! note
+            Variables set in this manner are only accessable inside stuart, and are not an
+            os environment variable. Refer to set_shell_var to set an os environment variable.
 
         Args:
             var_name (str): variable to set the value for
             var_data (obj): data to set
 
-        WARNING: Unlike `set_shell_var`, this only sets the variable in the
-        `VarDict`
+        Raises:
+            (ValueError): var_data is none
         """
+        if var_data is None:
+            raise ValueError("Unexpected var_data: None")
         self.logger.debug(
             "Updating BUILD VAR element '%s': '%s'." % (var_name, var_data))
         self.active_buildvars.SetValue(var_name, var_data, '', overridable=True)
@@ -344,15 +350,18 @@ class ShellEnvironment(metaclass=Singleton):
         return self.active_environ.get(var_name, None)
 
     def set_shell_var(self, var_name, var_data):
-        """Sets the shell variable.
+        """Sets the variable as an OS environment variable.
 
         Args:
             var_name (str): variable to set the value for
             var_data (obj): data to set
 
-        The variable is set both in the `VarDict` and in the OS
+        Raises:
+            (ValueError): var_data is None
         """
         # Check for the "special" shell vars.
+        if var_data is None:
+            raise ValueError("Unexpected var_data: None")
         if var_name.upper() == 'PATH':
             self.set_path(var_data)
         elif var_name.upper() == 'PYTHONPATH':

--- a/edk2toolext/environment/shell_environment.py
+++ b/edk2toolext/environment/shell_environment.py
@@ -321,6 +321,10 @@ class ShellEnvironment(metaclass=Singleton):
     def set_build_var(self, var_name, var_data):
         """Sets the variable as internal build variable.
 
+        Unlike set_shell_var, var_data can be `None`; this sets var_name as a non-valued
+        build variable (e.g. E1000_ENABLE). Additional information can be found at:
+        https://www.tianocore.org/edk2-pytool-extensions/integrate/build/#setting-getting-environment-variables.
+
         !!! note
             Variables set in this manner are only accessable inside stuart, and are not an
             os environment variable. Refer to set_shell_var to set an os environment variable.
@@ -328,12 +332,7 @@ class ShellEnvironment(metaclass=Singleton):
         Args:
             var_name (str): variable to set the value for
             var_data (obj): data to set
-
-        Raises:
-            (ValueError): var_data is none
         """
-        if var_data is None:
-            raise ValueError("Unexpected var_data: None")
         self.logger.debug(
             "Updating BUILD VAR element '%s': '%s'." % (var_name, var_data))
         self.active_buildvars.SetValue(var_name, var_data, '', overridable=True)

--- a/edk2toolext/tests/test_shell_environment.py
+++ b/edk2toolext/tests/test_shell_environment.py
@@ -41,6 +41,9 @@ class TestBasicEnvironmentManipulation(unittest.TestCase):
         shell_env.set_shell_var('SE-TEST-VAR-1', new_value)
         self.assertEqual(os.environ['SE-TEST-VAR-1'], new_value)
 
+        with self.assertRaises(ValueError):
+            shell_env.set_shell_var('SE-TEST-VAR-FAIL', None)
+
     def test_can_get_os_vars(self):
         shell_env = SE.ShellEnvironment()
         new_value = 'Dummy2'


### PR DESCRIPTION
Add an exception to `set_shell_var()` when var_data is None as it is not supported. It will throw an error when it attempts to set os.environ[var_name] = None. Adds this information to the pydocs for the function.