### PR TITLE
Update release pipeline unit testing

### DIFF
--- a/azure-pipelines/templates/pytest-test-steps.yml
+++ b/azure-pipelines/templates/pytest-test-steps.yml
@@ -10,38 +10,5 @@ parameters:
   codecov_enabled: false # by default, we don't upload code coverage
 
 steps:
-- script: pytest -v --junitxml=test.junit.xml --html=pytest_report.html --self-contained-html --cov=${{ parameters.root_package_folder }} --cov-report html:cov_html --cov-report xml:cov.xml --cov-config .coveragerc
+- script: coverage run -m pytest
   displayName: 'Run UnitTests'
-
-# Publish Test Results to Azure Pipelines/TFS
-- task: PublishTestResults@2
-  displayName: 'Publish junit test results'
-  continueOnError: true
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: 'JUnit' # Options: JUnit, NUnit, VSTest, xUnit
-    testResultsFiles: 'test.junit.xml' 
-    mergeTestResults: true # Optional
-    publishRunAttachments: true # Optional
-
-# Publish build artifacts to Azure Pipelines
-- task: PublishBuildArtifacts@1
-  inputs:
-    pathtoPublish: 'pytest_report.html' 
-    artifactName: 'unit test report' 
-  continueOnError: true
-  condition: succeededOrFailed()
-
-- script: |
-    curl -s https://codecov.io/bash | bash -s -- -C $(Build.SourceVersion) -F $(Agent.OS)
-  displayName: 'Upload to codecov.io'
-  continueOnError: true
-  condition: ${{parameters.codecov_enabled}}
-
-# Publish Cobertura code coverage results
-- task: PublishCodeCoverageResults@1
-  inputs:
-    codeCoverageTool: 'cobertura' # Options: cobertura, jaCoCo
-    summaryFileLocation: $(System.DefaultWorkingDirectory)/cov.xml
-    reportDirectory: $(System.DefaultWorkingDirectory)/cov_html
-  condition: succeededOrFailed()

--- a/edk2toolext/environment/plugintypes/uefi_build_plugin.py
+++ b/edk2toolext/environment/plugintypes/uefi_build_plugin.py
@@ -11,6 +11,14 @@
 class IUefiBuildPlugin(object):
     """Plugin that supports Pre and Post Build Steps."""
 
+    def runs_on_list(self):
+        """Returns a list of build types to execute the plugin for.
+
+        dsc == building a platform or platform equivalent (dsc)
+        inf == building a single module (inf)
+        """
+        return ["dsc"]
+
     def do_post_build(self, thebuilder):
         """Runs Post Build Plugin Operations.
 


### PR DESCRIPTION
Updates the release pipeline unit testing to match that of the github action for CI. Removes the ability for the release pipeline to upload unit testing results as this is handled by the github action.