### PR TITLE
Update pypi required dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyopenssl == 23.0.0
 pefile == 2023.2.7
 semantic_version == 2.10.0
 pygit2 == 1.11.1
+pyyaml == 6.0.0

--- a/setup.py
+++ b/setup.py
@@ -80,9 +80,9 @@ setuptools.setup(
                             'validate_image_tool=edk2toolext.image_validation:main']
     },
     install_requires=[
-        'pyyaml>=5.3.1',
-        'edk2-pytool-library>=0.12.1',
-        'pefile>=2019.4.18',
+        'pyyaml>=6.0.0',
+        'edk2-pytool-library>=0.14.0',
+        'pefile>=2023.2.7',
         'semantic_version>=2.10.0',
         'pygit2>=1.11.1'
     ],


### PR DESCRIPTION
Updates the required dependencies for PyPi. Notably we now require edk2-pytool-library to be greater than 0.14.0 and pefile to be greater than 2023.2.7 due to the detected security issue.

Additionally fixes a bug where we were getting our pyyaml requirement from edk2-pytool-library rather than specifying it here. If someone installed only edk2-pytool-extensions and not edk2-pytool-library, they may be missing that requirement.