### PR TITLE
edk2toolext/nuget: Download NuGet 6.4.0 (latest release)

### DIFF
--- a/edk2toolext/bin/nuget.py
+++ b/edk2toolext/bin/nuget.py
@@ -12,9 +12,9 @@ import urllib.request
 import logging
 
 # Update this when you want a new version of NuGet
-VERSION = "5.10.0"
+VERSION = "6.4.0"
 URL = "https://dist.nuget.org/win-x86-commandline/v{}/nuget.exe".format(VERSION)
-SHA256 = "852b71cc8c8c2d40d09ea49d321ff56fd2397b9d6ea9f96e532530307bbbafd3"
+SHA256 = "26730829b240581a3e6a4e276b9ace088930032df0c680d5591beccf6452374e"
 
 
 def DownloadNuget(unpack_folder: str = None) -> list:


### PR DESCRIPTION
Updates edk2-pytool-extensions from downloading NuGet 5.10.0 to
6.4.0 as many functional and security bugs have been addressed
during this time.

See the NuGet release notes for more detailed information:

https://learn.microsoft.com/en-us/nuget/release-notes/nuget-6.4

Signed-off-by: Michael Kubacki <michael.kubacki@microsoft.com>