### PR TITLE
Non valued build variable bugfix

### DIFF
--- a/edk2toolext/environment/var_dict.py
+++ b/edk2toolext/environment/var_dict.py
@@ -154,7 +154,7 @@ class VarDict(object):
         """
         key = k.upper()
         en = self.GetEntry(key)
-        if not v:
+        if v is None:
             value = ''.join(choice(ascii_letters) for _ in range(20))
         else:
             value = str(v)

--- a/edk2toolext/tests/test_var_dict.py
+++ b/edk2toolext/tests/test_var_dict.py
@@ -201,6 +201,14 @@ class TestVarDict(unittest.TestCase):
         v.SetValue("test2", "value1", "test 1 comment overrideable", True)
         v.PrintAll()
 
+    def test_var_dict_non_valued_var(self):
+        v = var_dict.VarDict()
+        v.SetValue("var1", "", "Test Comment")
+        self.assertEqual(v.GetValue("var1"), "")
+        v.SetValue("var2", None, "Test Comment")
+        self.assertNotEqual(v.GetValue("var2"), None)
+        self.failIf(not v.GetValue("var2"), "Should return True")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Non valued build variables could incorrectly be created when specifying a variable's value be "" (var_dict.SetValue("VAR_NAME", "", "Comment")). Non-valued build variables should only be created when setting a build variables value to None:
(var_dict.SetValue("VAR_NAME", None, "Comment)).

This commit fixes the check to only create a non-valued build variable when the variable value is None.