### PR TITLE
Enable build type specific plugin execution (inf vs dsc) 

### DIFF
--- a/edk2toolext/environment/plugintypes/uefi_build_plugin.py
+++ b/edk2toolext/environment/plugintypes/uefi_build_plugin.py
@@ -11,13 +11,13 @@
 class IUefiBuildPlugin(object):
     """Plugin that supports Pre and Post Build Steps."""
 
-    def runs_on_list(self, thebuilder) -> list[str]:
-        """Returns a list of build types this plugin should execute on.
+    def runs_on(self, thebuilder) -> str:
+        """Returns the type of build this plugin should execute on.
 
         !!! note "Known build types"
-            dsc, inf
+            single-module, multi-module, all
         """
-        return ["dsc"]
+        return "multi-module"
 
     def do_post_build(self, thebuilder):
         """Runs Post Build Plugin Operations.

--- a/edk2toolext/environment/plugintypes/uefi_build_plugin.py
+++ b/edk2toolext/environment/plugintypes/uefi_build_plugin.py
@@ -11,6 +11,14 @@
 class IUefiBuildPlugin(object):
     """Plugin that supports Pre and Post Build Steps."""
 
+    def runs_on_list(self, thebuilder) -> list[str]:
+        """Returns a list of build types this plugin should execute on.
+
+        !!! note "Known build types"
+            dsc, inf
+        """
+        return ["dsc"]
+
     def do_post_build(self, thebuilder):
         """Runs Post Build Plugin Operations.
 

--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -355,7 +355,8 @@ class UefiBuilder(object):
         #
         for Descriptor in self.pm.GetPluginsOfClass(IUefiBuildPlugin):
             # Run the plugin only if it is supported for the build type.
-            if self._GetBuildType() not in Descriptor.Obj.runs_on_list(self):
+            runs_on = Descriptor.Obj.runs_on(self)
+            if runs_on != "all" and runs_on != self._GetBuildType():
                 continue
             rc = Descriptor.Obj.do_pre_build(self)
             if (rc != 0):
@@ -392,7 +393,8 @@ class UefiBuilder(object):
         #
         for Descriptor in self.pm.GetPluginsOfClass(IUefiBuildPlugin):
             # Run the plugin only if it is supported for the build type.
-            if self._GetBuildType() not in Descriptor.Obj.runs_on_list(self):
+            runs_on = Descriptor.Obj.runs_on(self)
+            if runs_on != "all" and runs_on != self._GetBuildType():
                 continue
             rc = Descriptor.Obj.do_post_build(self)
             if (rc != 0):
@@ -726,8 +728,8 @@ class UefiBuilder(object):
         return 0
 
     def _GetBuildType(self):
-        """Returns inf or dsc depending on the value of BUILDMODULE."""
+        """Returns the type of build depending on the value of BUILDMODULE."""
         mod = self.env.GetValue("BUILDMODULE")
         if (mod is not None and len(mod.strip()) > 0):
-            return "inf"
-        return "dsc"
+            return "single-module"
+        return "multi-module"

--- a/edk2toolext/tests/test_uefi_build.py
+++ b/edk2toolext/tests/test_uefi_build.py
@@ -19,16 +19,18 @@ import stat
 from inspect import cleandoc
 from edk2toolext.environment import shell_environment
 
+
 # Raise exceptions in Plugins to show that they successfuly execute.
 class _AllPlugin(uefi_build_plugin.IUefiBuildPlugin):
     def runs_on(self, thebuilder) -> str:
         return "all"
-    
+
     def do_pre_build(self, thebuilder):
         raise Exception
 
     def do_post_build(self, thebuilder):
         raise Exception
+
 
 class _SingleModulePlugin(uefi_build_plugin.IUefiBuildPlugin):
     def runs_on(self, thebuilder) -> str:
@@ -37,8 +39,9 @@ class _SingleModulePlugin(uefi_build_plugin.IUefiBuildPlugin):
     def do_pre_build(self, thebuilder):
         raise Exception
 
-    def do_post_build(self, thebuilder):    
+    def do_post_build(self, thebuilder):
         raise Exception
+
 
 class _MultiModulePlugin(uefi_build_plugin.IUefiBuildPlugin):
     def runs_on(self, thebuilder) -> str:
@@ -49,6 +52,7 @@ class _MultiModulePlugin(uefi_build_plugin.IUefiBuildPlugin):
 
     def do_post_build(self, thebuilder):
         raise Exception
+
 
 class TestUefiBuild(unittest.TestCase):
 
@@ -190,8 +194,6 @@ class TestUefiBuild(unittest.TestCase):
         # Check that the build wrapper ran successfully by checking that the
         # file written by the build wrapper file exists
         self.assertTrue(os.path.isfile(test_file_path))
-
-    
     # TODO finish unit test
 
 


### PR DESCRIPTION
Allows Build plugins to specify if they run on dsc builds, inf builds, or both.

## Breaking Change!
All plugins will stop executing on single module builds when updating to 0.22.0; some may be necessary, even for single module builds! These necessary build plugins must override the new method `runs_on_list()` to return ["dsc", "inf"] (or only "inf" if it should only run during a single module build). using [MU_BASECORE](https://github.com/Microsoft/mu_basecore) as an example, both the LinuxGcc5ToolChain and WindowsVsToolChain must be updated.

Closes #386