### PR TITLE
Update minimum git version to 2.36.0

### DIFF
--- a/edk2toolext/invocables/edk2_setup.py
+++ b/edk2toolext/invocables/edk2_setup.py
@@ -115,7 +115,7 @@ class Edk2PlatformSetup(Edk2MultiPkgAwareInvocable):
         version_aggregator.GetVersionAggregator().ReportVersion("Git",
                                                                 git_version,
                                                                 version_aggregator.VersionTypes.TOOL)
-        min_git = "2.11.0"
+        min_git = "2.36.0"
         # This code is highly specific to the return value of "git version"...
         if version_compare(min_git, git_version) > 0:
             logging.error("FAILED!\n")


### PR DESCRIPTION
v0.22.0 release of edk2-pytool-extensions unknowlingly increased the minimum required git version from 2.11 to 2.36. This PR updates the check to now verify 2.36.0

`repo_details()` uses `git worktree list --porcelain` to gather repository subtrees in an easy-to-parse way. git version 2.36.0 adds an additional flag, `-z`, to assist in parsing the return by changing the line terminator from `\n` to `\0`, making it possible to parse output when the output contains new lines.