### PR TITLE
Pytest updates [REBASE&FF]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "python.testing.pytestEnabled": true,
   "python.testing.pytestArgs": [
-    "edk2toolext/tests"
+    "${workspaceFolder}/edk2toolext/tests"
   ],
   "python.testing.unittestEnabled": false,
   "python.linting.flake8Enabled": true,

--- a/edk2toolext/environment/extdeptypes/git_dependency.py
+++ b/edk2toolext/environment/extdeptypes/git_dependency.py
@@ -93,7 +93,7 @@ class GitDependency(ExternalDependency):
         """
         state_data = self.get_state_file_data()
         if state_data and state_data['verify'] is False:
-            logging.warn(f'{self.name} is unverified. Unexpected results may occur.')
+            logging.warning(f'{self.name} is unverified. Unexpected results may occur.')
             return True
 
         result = True

--- a/edk2toolext/tests/test_var_dict.py
+++ b/edk2toolext/tests/test_var_dict.py
@@ -207,7 +207,7 @@ class TestVarDict(unittest.TestCase):
         self.assertEqual(v.GetValue("var1"), "")
         v.SetValue("var2", None, "Test Comment")
         self.assertNotEqual(v.GetValue("var2"), None)
-        self.failIf(not v.GetValue("var2"), "Should return True")
+        self.assertTrue(v.GetValue("var2"), "Should return True")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolves two deprecation warnings and adds back in pytests prepending the path to the tests folder with the workspace path.