### PR TITLE
Update Cryptography requirement to at least 39.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pefile == 2023.2.7
 semantic_version == 2.10.0
 GitPython == 3.1.31
 pyyaml == 6.0.0
+cryptography == 39.0.2

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,8 @@ setuptools.setup(
         'edk2-pytool-library>=0.14.0',
         'pefile>=2023.2.7',
         'semantic_version>=2.10.0',
-        'GitPython>=3.1.30'
+        'GitPython>=3.1.30',
+        'cryptography >= 39.0.1'
     ],
     extras_require={
         'openssl': ['pyopenssl']


### PR DESCRIPTION
Older versions of Cryptography are vulnerable to CVE-2023-0286, which is due to the fact that earlier versions bundle a pre-compiled version of openssl that has a known vulnerability noted in https://www.openssl.org/news/secadv/20230207.txt and https://www.openssl.org/news/secadv/20221213.txt.

Previously, the cryptography package version was downloaded from pyopenssl, however it is best that we specify the version ourselfs.