### PR TITLE
Switch from flake8 to black [REBASE&FF]

### DIFF
--- a/.github/workflows/CIRunner.yml
+++ b/.github/workflows/CIRunner.yml
@@ -54,9 +54,9 @@ jobs:
         npm install -g markdownlint-cli@0.32.2
         npm install -g cspell@5.20.0
     
-    - name: Run flake8
+    - name: Run black Format Checker
       if: success() || failure()
-      run: flake8 ${{ inputs.package-src }}
+      run: black ${{ inputs.package-src }} --check --verbose --diff --color
     
     - name: Run markdownlint
       if: success() || failure()

--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,2 +1,3 @@
 [pydocstyle]
 convention = google
+add-ignore = D202

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+    "recommendations": ["ms-python.black-formatter", "ms-python.python"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,11 @@
     "${workspaceFolder}/edk2toolext/tests"
   ],
   "python.testing.unittestEnabled": false,
-  "python.linting.flake8Enabled": true,
+  "python.formatting.provider": "none",
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.black-formatter",
+    "editor.formatOnSave": true
+  },
   "python.linting.enabled": true,
   "python.linting.pydocstyleEnabled": true,
 }

--- a/BasicDevTests.py
+++ b/BasicDevTests.py
@@ -23,7 +23,9 @@ def TestEncodingOk(apath, encodingValue):
         with open(apath, "rb") as f_obj:
             f_obj.read().decode(encodingValue)
     except Exception as exp:
-        logging.critical("Encoding failure: file: {0} type: {1}".format(apath, encodingValue))
+        logging.critical(
+            "Encoding failure: file: {0} type: {1}".format(apath, encodingValue)
+        )
         logging.error("EXCEPTION: while processing {1} - {0}".format(exp, apath))
         return False
     return True
@@ -39,10 +41,11 @@ def TestFilenameLowercase(apath):
 
 def PackageAndModuleValidCharacters(apath):
     """Check pep8 recommendations for package and module names."""
-    match = re.match('^[a-z0-9_/.]+$', apath.replace("\\", "/"))
+    match = re.match("^[a-z0-9_/.]+$", apath.replace("\\", "/"))
     if match is None:
         logging.critical(
-            f"PackageAndModuleValidCharacters failure: package or module name {apath} has something invalid")
+            f"PackageAndModuleValidCharacters failure: package or module name {apath} has something invalid"
+        )
         return False
     return True
 
@@ -55,7 +58,9 @@ def TestNoSpaces(apath):
 
 
 def TestRequiredLicense(apath):
-    licenses = ["SPDX-License-Identifier: BSD-2-Clause-Patent", ]
+    licenses = [
+        "SPDX-License-Identifier: BSD-2-Clause-Patent",
+    ]
     try:
         with open(apath, "rb") as f_obj:
             contents = f_obj.read().decode()
@@ -65,7 +70,9 @@ def TestRequiredLicense(apath):
                     found = True
                     break
             if not found:
-                logging.critical(f"License failure: file {apath} has incorrect, invalid, or unsupported license")
+                logging.critical(
+                    f"License failure: file {apath} has incorrect, invalid, or unsupported license"
+                )
                 return False
     except Exception as exp:
         logging.critical(f"License failure: Exception trying to read file: {apath}")
@@ -79,15 +86,17 @@ py_files = glob.glob(os.path.join(p, "**", "*.py"), recursive=True)
 error = 0
 for a in py_files:
     aRelativePath = os.path.relpath(a, os.getcwd())
-    if (not TestEncodingOk(a, "ascii")):
+    if not TestEncodingOk(a, "ascii"):
         error += 1
-    if (not TestFilenameLowercase(aRelativePath)):
+    if not TestFilenameLowercase(aRelativePath):
         error += 1
-    if (not TestNoSpaces(aRelativePath)):
+    if not TestNoSpaces(aRelativePath):
         error += 1
-    if (not TestRequiredLicense(a)):
+    if not TestRequiredLicense(a):
         error += 1
-    if (not PackageAndModuleValidCharacters(aRelativePath)):  # use relative path so only test within package
+    if not PackageAndModuleValidCharacters(
+        aRelativePath
+    ):  # use relative path so only test within package
         error += 1
 
 logging.critical(f"Found {error} error(s) in {len(py_files)} file(s)")

--- a/ConfirmVersionAndTag.py
+++ b/ConfirmVersionAndTag.py
@@ -13,7 +13,7 @@ import sys
 
 p = os.path.join(os.getcwd(), "dist")
 whl_file = glob.glob(os.path.join(p, "*.whl"))
-if (len(whl_file) != 1):
+if len(whl_file) != 1:
     for filename in whl_file:
         print(filename)
     raise Exception("Too many wheel files")

--- a/docs/contributor/developing.md
+++ b/docs/contributor/developing.md
@@ -90,15 +90,17 @@ out all the different parts.
 
 ## Testing
 
-1. Run a Basic Syntax/Lint Check (using flake8) and resolve any issues
+1. Run a Basic Syntax/Lint Check (using black) and resolve any issues
 
     ``` cmd
-    flake8 .
+    black . --check --verbose --diff --color
     ```
 
-    INFO: Newer editors are very helpful in resolving source formatting errors
-    (whitespace, indentation, etc). In VSCode open the py file and use
-    ++alt+shift+f++ to auto format.
+    Note: black is an autoformatter by default,run `black .` to format all files
+    automatically.
+
+    Note: If Visual Studio Code is used, and the recommended extensions are installed
+    for the project, then black should autoformat the file on save.
 
 2. Run a Basic Python docstring Check (using pydocstring) and resolve any issues
 

--- a/docs/user/gen_api.py
+++ b/docs/user/gen_api.py
@@ -19,10 +19,22 @@ def main():
     """Entry into script that is executed."""
     files = glob.glob("**/*.py", recursive=True, root_dir="edk2toolext")
 
-    excluded_files = ["__init__.py", "capsule_helper.py", "capsule_tool.py", "pyopenssl_signer.py",
-                      "signing_helper.py", "signtool_signer.py", "sig_db_tool.py",
-                      "firmware_policy_tool.py", "image_validation.py", "nuget_publishing.py",
-                      "omnicache.py", "nuget.py", "versioninfo_tool.py", "versioninfo_helper.py"]
+    excluded_files = [
+        "__init__.py",
+        "capsule_helper.py",
+        "capsule_tool.py",
+        "pyopenssl_signer.py",
+        "signing_helper.py",
+        "signtool_signer.py",
+        "sig_db_tool.py",
+        "firmware_policy_tool.py",
+        "image_validation.py",
+        "nuget_publishing.py",
+        "omnicache.py",
+        "nuget.py",
+        "versioninfo_tool.py",
+        "versioninfo_helper.py",
+    ]
 
     for file_path in files:
         edit_path = file_path
@@ -39,7 +51,7 @@ def main():
 
         filename = f"api{os.sep}{file_path}"
         with mkdocs_gen_files.open(filename, "w") as f:
-            ff = file_path.replace(os.sep, '.').replace('.md', '')
+            ff = file_path.replace(os.sep, ".").replace(".md", "")
             ff = f"edk2toolext.{ff}"
             print(f"::: {ff}", file=f)
             print("    handler: python", file=f)
@@ -53,7 +65,7 @@ def main():
             print("        show_source: False", file=f)
 
         # Point the "Edit on Github" button in the docs to point at the source code
-        edit_path = os.path.join('..', 'edk2toolext', edit_path)
+        edit_path = os.path.join("..", "edk2toolext", edit_path)
         mkdocs_gen_files.set_edit_path(filename, edit_path)
 
 

--- a/docs/user/requirements.txt
+++ b/docs/user/requirements.txt
@@ -1,4 +1,3 @@
-black==23.1.0
 mkdocs==1.4.2
 mkdocs-material==9.1.1
 mkdocstrings[python]==0.20.0

--- a/edk2toolext/base_abstract_invocable.py
+++ b/edk2toolext/base_abstract_invocable.py
@@ -28,6 +28,7 @@ class BaseAbstractInvocable(object):
         plugin_manager (plugin_manager.PluginManager): the plugin manager
         helper (HelperFunctions): container for all helper functions
     """
+
     def __init__(self):
         """Init the Invocable."""
         self.log_filename = None
@@ -171,7 +172,7 @@ class BaseAbstractInvocable(object):
         !!! tip
             Optional override in a subclass if new behavior is needed
         """
-        logger = logging.getLogger('')
+        logger = logging.getLogger("")
         logger.setLevel(self.GetLoggingLevel("base"))
 
         # Adjust console mode depending on mode.
@@ -179,16 +180,20 @@ class BaseAbstractInvocable(object):
 
         edk2_logging.setup_console_logging(self.GetLoggingLevel("con"))
 
-        log_directory = os.path.join(self.GetWorkspaceRoot(), self.GetLoggingFolderRelativeToRoot())
+        log_directory = os.path.join(
+            self.GetWorkspaceRoot(), self.GetLoggingFolderRelativeToRoot()
+        )
 
         txtlogfile = self.GetLoggingLevel("txt")
-        if (txtlogfile is not None):
-            logfile, filelogger = edk2_logging.setup_txt_logger(log_directory,
-                                                                self.GetLoggingFileName("txt"),
-                                                                txtlogfile)
+        if txtlogfile is not None:
+            logfile, filelogger = edk2_logging.setup_txt_logger(
+                log_directory, self.GetLoggingFileName("txt"), txtlogfile
+            )
             self.log_filename = logfile
 
-        logging.info("Log Started: " + datetime.strftime(datetime.now(), "%A, %B %d, %Y %I:%M%p"))
+        logging.info(
+            "Log Started: " + datetime.strftime(datetime.now(), "%A, %B %d, %Y %I:%M%p")
+        )
 
         return
 
@@ -208,20 +213,32 @@ class BaseAbstractInvocable(object):
         # Next, get the environment set up.
         #
         (build_env, shell_env) = self_describing_environment.BootstrapEnvironment(
-            self.GetWorkspaceRoot(), self.GetActiveScopes(), self.GetSkippedDirectories())
+            self.GetWorkspaceRoot(),
+            self.GetActiveScopes(),
+            self.GetSkippedDirectories(),
+        )
 
         # Make sure the environment verifies IF it is required for this invocation
-        if self.GetVerifyCheckRequired() and not self_describing_environment.VerifyEnvironment(
-                self.GetWorkspaceRoot(), self.GetActiveScopes(), self.GetSkippedDirectories()):
-            raise RuntimeError("External Dependencies in the environment are out of date. "
-                               "Consider running stuart_update to possibly resolve this issue.")
+        if (
+            self.GetVerifyCheckRequired()
+            and not self_describing_environment.VerifyEnvironment(
+                self.GetWorkspaceRoot(),
+                self.GetActiveScopes(),
+                self.GetSkippedDirectories(),
+            )
+        ):
+            raise RuntimeError(
+                "External Dependencies in the environment are out of date. "
+                "Consider running stuart_update to possibly resolve this issue."
+            )
 
         # Load plugins
         logging.log(edk2_logging.SECTION, "Loading Plugins")
 
         self.plugin_manager = plugin_manager.PluginManager()
         failedPlugins = self.plugin_manager.SetListOfEnvironmentDescriptors(
-            build_env.plugins)
+            build_env.plugins
+        )
         if failedPlugins:
             logging.critical("One or more plugins failed to load. Halting build.")
             for a in failedPlugins:
@@ -229,13 +246,13 @@ class BaseAbstractInvocable(object):
             raise Exception("One or more plugins failed to load.")
 
         self.helper = HelperFunctions()
-        if (self.helper.LoadFromPluginManager(self.plugin_manager) > 0):
+        if self.helper.LoadFromPluginManager(self.plugin_manager) > 0:
             raise Exception("One or more helper plugins failed to load.")
 
         logging.log(edk2_logging.SECTION, "Start Invocable Tool")
         retcode = self.Go()
         logging.log(edk2_logging.SECTION, "Summary")
-        if (retcode != 0):
+        if retcode != 0:
             logging.error("Error")
         else:
             edk2_logging.log_progress("Success")

--- a/edk2toolext/bin/nuget.py
+++ b/edk2toolext/bin/nuget.py
@@ -38,7 +38,9 @@ def DownloadNuget(unpack_folder: str = None) -> list:
     if not os.path.isfile(out_file_name):
         try:
             # Download the file and save it locally under `temp_file_name`
-            with urllib.request.urlopen(URL) as response, open(out_file_name, 'wb') as out_file:
+            with urllib.request.urlopen(URL) as response, open(
+                out_file_name, "wb"
+            ) as out_file:
                 out_file.write(response.read())
         except urllib.error.HTTPError as e:
             logging.error("We ran into an issue when getting NuGet")
@@ -47,7 +49,10 @@ def DownloadNuget(unpack_folder: str = None) -> list:
     # do the hash to make sure the file is good
     with open(out_file_name, "rb") as file:
         import hashlib
+
         temp_file_sha256 = hashlib.sha256(file.read()).hexdigest()
     if temp_file_sha256.lower() != SHA256.lower():
         os.remove(out_file_name)
-        raise RuntimeError(f"Nuget.exe download - sha256 does not match\n\tdownloaded:\t{temp_file_sha256}\n\t")
+        raise RuntimeError(
+            f"Nuget.exe download - sha256 does not match\n\tdownloaded:\t{temp_file_sha256}\n\t"
+        )

--- a/edk2toolext/capsule/capsule_helper.py
+++ b/edk2toolext/capsule/capsule_helper.py
@@ -25,12 +25,15 @@ from dataclasses import field
 
 from edk2toollib.windows.capsule import inf_generator2, cat_generator
 from edk2toollib.uefi.uefi_capsule_header import UefiCapsuleHeaderClass
-from edk2toollib.uefi.fmp_capsule_header import FmpCapsuleHeaderClass, FmpCapsuleImageHeaderClass
+from edk2toollib.uefi.fmp_capsule_header import (
+    FmpCapsuleHeaderClass,
+    FmpCapsuleImageHeaderClass,
+)
 from edk2toollib.uefi.fmp_auth_header import FmpAuthHeaderClass
 from edk2toollib.uefi.edk2.fmp_payload_header import FmpPayloadHeaderClass
 
 # https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.pkcs.contentinfo.-ctor?view=netframework-4.8
-PKCS7_SIGNED_DATA_OID = '1.2.840.113549.1.7.2'
+PKCS7_SIGNED_DATA_OID = "1.2.840.113549.1.7.2"
 
 
 @dataclass
@@ -48,6 +51,7 @@ class CapsulePayload:
         integrity_data (bytes):  integrity data for this payload. optional.
         integrity_filename (str): integrity filename. optional if integrity_data is None, required otherwise.
     """
+
     payload: UefiCapsuleHeaderClass
     payload_filename: str
     esrt_guid: uuid.UUID
@@ -73,6 +77,7 @@ class Capsule:
         date (datetime.date): when the capsule was built. optional, defaults to datetime.date.today().
         payloads (List[CapsulePayload]): a list of capsule payloads. optional, defaults to empty list
     """
+
     version_string: str
     name: str
     provider_name: str
@@ -91,23 +96,27 @@ def get_capsule_file_name(capsule_options: dict) -> str:
 def get_normalized_version_string(version_string: str) -> str:
     """Normalizes a version string that is compatible with INF and CAT files."""
     # 19H1 HLK requires a 4 digit version string, or it will fail
-    while (version_string.count('.') < 3):
-        version_string += '.0'
+    while version_string.count(".") < 3:
+        version_string += ".0"
     return version_string
 
 
 def get_default_arch() -> str:
     """Consistently return the default architecture for windows files."""
-    return 'amd64'
+    return "amd64"
 
 
 def get_default_os_string() -> str:
     """Consistently return the default os for windows files."""
-    return 'Win10'
+    return "Win10"
 
 
-def build_capsule(capsule_data: bytes, capsule_options: dict, signer_module: object,
-                  signer_options: dict) -> UefiCapsuleHeaderClass:
+def build_capsule(
+    capsule_data: bytes,
+    capsule_options: dict,
+    signer_module: object,
+    signer_options: dict,
+) -> UefiCapsuleHeaderClass:
     """Goes through all steps of capsule generation for a single-payload FMP capsule.
 
     takes in capsule_data as a byte string, a signer module, and capsule and signer options,
@@ -131,8 +140,8 @@ def build_capsule(capsule_data: bytes, capsule_options: dict, signer_module: obj
     # Start building the capsule as we go.
     # Create the FMP Payload and set all the necessary options.
     fmp_payload_header = FmpPayloadHeaderClass()
-    fmp_payload_header.FwVersion = int(capsule_options['fw_version'], 16)
-    fmp_payload_header.LowestSupportedVersion = int(capsule_options['lsv_version'], 16)
+    fmp_payload_header.FwVersion = int(capsule_options["fw_version"], 16)
+    fmp_payload_header.LowestSupportedVersion = int(capsule_options["lsv_version"], 16)
     fmp_payload_header.Payload = capsule_data
 
     # Create the auth header and get ready to sign the data.
@@ -144,16 +153,15 @@ def build_capsule(capsule_data: bytes, capsule_options: dict, signer_module: obj
     data_to_sign = data_to_sign + struct.pack("<Q", fmp_auth_header.MonotonicCount)
 
     # Sign the data and assign it to the cert data.
-    signature_options = {
-        'sign_alg': 'pkcs12',
-        'hash_alg': 'sha256'
-    }
+    signature_options = {"sign_alg": "pkcs12", "hash_alg": "sha256"}
     # Set or override OID.
-    signer_options['oid'] = PKCS7_SIGNED_DATA_OID
-    fmp_auth_header.AuthInfo.CertData = signer_module.sign(data_to_sign, signature_options, signer_options)
+    signer_options["oid"] = PKCS7_SIGNED_DATA_OID
+    fmp_auth_header.AuthInfo.CertData = signer_module.sign(
+        data_to_sign, signature_options, signer_options
+    )
 
     fmp_capsule_image_header = FmpCapsuleImageHeaderClass()
-    fmp_capsule_image_header.UpdateImageTypeId = uuid.UUID(capsule_options['esrt_guid'])
+    fmp_capsule_image_header.UpdateImageTypeId = uuid.UUID(capsule_options["esrt_guid"])
     fmp_capsule_image_header.UpdateImageIndex = 1
     fmp_capsule_image_header.FmpAuthHeader = fmp_auth_header
 
@@ -168,7 +176,9 @@ def build_capsule(capsule_data: bytes, capsule_options: dict, signer_module: obj
     return uefi_capsule_header
 
 
-def save_capsule(uefi_capsule_header: UefiCapsuleHeaderClass, capsule_options: dict, save_path: str) -> str:
+def save_capsule(
+    uefi_capsule_header: UefiCapsuleHeaderClass, capsule_options: dict, save_path: str
+) -> str:
     """Serializes the capsule object to the target directory.
 
     takes in a UefiCapsuleHeaderClass object, a dictionary of capsule_options, and a filesystem directory path
@@ -183,14 +193,16 @@ def save_capsule(uefi_capsule_header: UefiCapsuleHeaderClass, capsule_options: d
         (str): path the file was saved to.
     """
     # Expand the version string prior to creating the payload file.
-    capsule_options['fw_version_string'] = get_normalized_version_string(capsule_options['fw_version_string'])
+    capsule_options["fw_version_string"] = get_normalized_version_string(
+        capsule_options["fw_version_string"]
+    )
 
     # First, create the entire save path.
     os.makedirs(save_path, exist_ok=True)
 
     # Then save the file.
     capsule_file_path = os.path.join(save_path, get_capsule_file_name(capsule_options))
-    with open(capsule_file_path, 'wb') as capsule_file:
+    with open(capsule_file_path, "wb") as capsule_file:
         capsule_file.write(uefi_capsule_header.Encode())
 
     return capsule_file_path
@@ -211,14 +223,18 @@ def save_multinode_capsule(capsule: Capsule, save_path: str) -> str:
     os.makedirs(save_path, exist_ok=True)
     for capsule_payload in capsule.payloads:
         payload_file_path = os.path.join(save_path, capsule_payload.payload_filename)
-        with open(payload_file_path, 'wb') as payload_file:
+        with open(payload_file_path, "wb") as payload_file:
             payload_file.write(capsule_payload.payload.Encode())
 
         if capsule_payload.integrity_data is not None:
-            if (capsule_payload.integrity_filename is None):
-                raise ValueError("Integrity data specified, but no integrity filename specified.")
-            integrity_file_path = os.path.join(save_path, capsule_payload.integrity_filename)
-            with open(integrity_file_path, 'wb') as integrity_file:
+            if capsule_payload.integrity_filename is None:
+                raise ValueError(
+                    "Integrity data specified, but no integrity filename specified."
+                )
+            integrity_file_path = os.path.join(
+                save_path, capsule_payload.integrity_filename
+            )
+            with open(integrity_file_path, "wb") as integrity_file:
                 integrity_file.write(capsule_payload.integrity_data)
     return save_path
 
@@ -239,30 +255,34 @@ def create_inf_file(capsule_options: dict, save_path: str) -> str:
     NOTE: will save the final file to the save_path with a name determined from the capsule_options
     """
     # Expand the version string prior to creating INF file.
-    capsule_options['fw_version_string'] = get_normalized_version_string(capsule_options['fw_version_string'])
+    capsule_options["fw_version_string"] = get_normalized_version_string(
+        capsule_options["fw_version_string"]
+    )
 
     # Deal with optional parameters when creating the INF file.
-    capsule_options['is_rollback'] = capsule_options.get('is_rollback', False)
-    capsule_options['arch'] = capsule_options.get('arch', get_default_arch())
-    capsule_options['mfg_name'] = capsule_options.get('mfg_name', capsule_options['provider_name'])
+    capsule_options["is_rollback"] = capsule_options.get("is_rollback", False)
+    capsule_options["arch"] = capsule_options.get("arch", get_default_arch())
+    capsule_options["mfg_name"] = capsule_options.get(
+        "mfg_name", capsule_options["provider_name"]
+    )
 
     inf_file = inf_generator2.InfFile(
-        capsule_options['fw_name'],
-        capsule_options['fw_version_string'],
+        capsule_options["fw_name"],
+        capsule_options["fw_version_string"],
         datetime.date.today().strftime("%m/%d/%Y"),
-        capsule_options['provider_name'],
-        capsule_options['mfg_name'],
-        capsule_options['arch']
+        capsule_options["provider_name"],
+        capsule_options["mfg_name"],
+        capsule_options["arch"],
     )
 
     inf_file.AddFirmware(
         "Firmware",
-        capsule_options['fw_description'],
-        capsule_options['esrt_guid'],
-        capsule_options['fw_version'],
+        capsule_options["fw_description"],
+        capsule_options["esrt_guid"],
+        capsule_options["fw_version"],
         get_capsule_file_name(capsule_options),
-        Rollback=capsule_options['is_rollback'],
-        IntegrityFile=capsule_options.get('fw_integrity_file', None)
+        Rollback=capsule_options["is_rollback"],
+        IntegrityFile=capsule_options.get("fw_integrity_file", None),
     )
 
     inf_file_path = os.path.join(save_path, f"{capsule_options['fw_name']}.inf")
@@ -288,9 +308,9 @@ def create_multinode_inf_file(capsule: Capsule, save_path: str) -> str:
     capsule.version_string = get_normalized_version_string(capsule.version_string)
 
     # set defaults for non-specified fields
-    if (capsule.arch is None):
+    if capsule.arch is None:
         capsule.arch = get_default_arch()
-    if (capsule.manufacturer_name is None):
+    if capsule.manufacturer_name is None:
         capsule.manufacturer_name = capsule.provider_name
 
     inf_file = inf_generator2.InfFile(
@@ -299,7 +319,7 @@ def create_multinode_inf_file(capsule: Capsule, save_path: str) -> str:
         capsule.date.strftime("%m/%d/%Y"),
         capsule.provider_name,
         capsule.manufacturer_name,
-        capsule.arch
+        capsule.arch,
     )
 
     idx = 0
@@ -314,7 +334,7 @@ def create_multinode_inf_file(capsule: Capsule, save_path: str) -> str:
             str(payload.version),
             payload.payload_filename,
             Rollback=payload.rollback,
-            IntegrityFile=payload.integrity_filename
+            IntegrityFile=payload.integrity_filename,
         )
 
     inf_file_path = os.path.join(save_path, f"{capsule.name}.inf")
@@ -340,17 +360,18 @@ def create_cat_file(capsule_options: dict, save_path: str) -> str:
     NOTE: will save the final file to the save_path with a name determined from the capsule_options
     """
     # Deal with optional parameters when creating the CAT file.
-    capsule_options['arch'] = capsule_options.get('arch', get_default_arch())
-    capsule_options['os_string'] = capsule_options.get('os_string', get_default_os_string())
+    capsule_options["arch"] = capsule_options.get("arch", get_default_arch())
+    capsule_options["os_string"] = capsule_options.get(
+        "os_string", get_default_os_string()
+    )
 
     # Create the CAT.
     catgenerator = cat_generator.CatGenerator(
-        capsule_options['arch'],
-        capsule_options['os_string']
+        capsule_options["arch"], capsule_options["os_string"]
     )
     cat_file_path = os.path.join(save_path, f"{capsule_options['fw_name']}.cat")
     ret = catgenerator.MakeCat(cat_file_path)
-    if (ret != 0):
+    if ret != 0:
         raise RuntimeError("MakeCat Failed with errorcode %d!" % ret)
 
     return cat_file_path

--- a/edk2toolext/capsule/capsule_tool.py
+++ b/edk2toolext/capsule/capsule_tool.py
@@ -27,43 +27,84 @@ infrastructure.
 An example call might look like:
 %s -o /path/to/config.yaml -ds key_file="/other/signer/key/file.pfx"
     /path/to/payload.bin /path/to/output
-""" % (os.path.basename(sys.argv[0]),)
+""" % (
+    os.path.basename(sys.argv[0]),
+)
 
 
 def get_cli_options(args=None):
     """Parse the primary options from the command line."""
-    parser = argparse.ArgumentParser(description=TOOL_DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=TOOL_DESCRIPTION,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
 
     # Add the group for the signer specifier.
     # NOTE: At least one signer type is required!
     signer_group = parser.add_mutually_exclusive_group(required=True)
     signer_group.add_argument(
-        '--builtin_signer', choices=[signing_helper.PYOPENSSL_SIGNER, signing_helper.SIGNTOOL_SIGNER])
+        "--builtin_signer",
+        choices=[signing_helper.PYOPENSSL_SIGNER, signing_helper.SIGNTOOL_SIGNER],
+    )
     signer_group.add_argument(
-        '--local_signer', help='a filesystem path to a python module that can be loaded as the active signer')
+        "--local_signer",
+        help="a filesystem path to a python module that can be loaded as the active signer",
+    )
     signer_group.add_argument(
-        '--module_signer', help='a python dot-path to a signer module that can be loaded from the current pypath')
+        "--module_signer",
+        help="a python dot-path to a signer module that can be loaded from the current pypath",
+    )
 
-    options_help = 'add an option to the corresponding set. format is <option_name>=<option_value>'
-    parser.add_argument('-dc', action='append', dest='capsule_options', type=str, default=[], help=options_help)
-    parser.add_argument('-ds', action='append', dest='signer_options', type=str, default=[], help=options_help)
+    options_help = (
+        "add an option to the corresponding set. format is <option_name>=<option_value>"
+    )
+    parser.add_argument(
+        "-dc",
+        action="append",
+        dest="capsule_options",
+        type=str,
+        default=[],
+        help=options_help,
+    )
+    parser.add_argument(
+        "-ds",
+        action="append",
+        dest="signer_options",
+        type=str,
+        default=[],
+        help=options_help,
+    )
 
-    parser.add_argument('-o', dest='options_file', type=argparse.FileType('r'),
-                        help='a filesystem path to a json/yaml file to load with default options. will be overriden by any options parameters') # noqa
-    parser.add_argument('-f', dest='save_final_options', default=False, action='store_true',
-                        help='optional flag to request that final tool options be saved in a file in the output directory')                     # noqa
+    parser.add_argument(
+        "-o",
+        dest="options_file",
+        type=argparse.FileType("r"),
+        help="a filesystem path to a json/yaml file to load with default options. will be overriden by any options parameters",
+    )  # noqa
+    parser.add_argument(
+        "-f",
+        dest="save_final_options",
+        default=False,
+        action="store_true",
+        help="optional flag to request that final tool options be saved in a file in the output directory",
+    )  # noqa
 
-    parser.add_argument('capsule_payload', type=argparse.FileType('rb'),
-                        help='a filesystem path to the binary payload for the capsule')
-    parser.add_argument('output_dir',
-                        help='a filesystem path to the directory to save output files. if directory does not exist, entire directory path will be created. if directory does exist, contents will be updated based on the capsule_options') # noqa
+    parser.add_argument(
+        "capsule_payload",
+        type=argparse.FileType("rb"),
+        help="a filesystem path to the binary payload for the capsule",
+    )
+    parser.add_argument(
+        "output_dir",
+        help="a filesystem path to the directory to save output files. if directory does not exist, entire directory path will be created. if directory does exist, contents will be updated based on the capsule_options",
+    )  # noqa
 
     return parser.parse_args(args=args)
 
 
 def load_options_file(in_file):
     """Loads a yaml file into a dictionary and returns it."""
-    if not hasattr(in_file, 'read'):
+    if not hasattr(in_file, "read"):
         return None
 
     return yaml.safe_load(in_file)
@@ -79,17 +120,17 @@ def update_options(file_options, capsule_options, signer_options):
     if file_options is not None:
         updated_options = copy.copy(file_options)
     else:
-        updated_options = {'capsule': {}, 'signer': {}}
+        updated_options = {"capsule": {}, "signer": {}}
 
     # Update all the capsule options.
     for option in capsule_options:
-        (key, value) = option.split('=')
-        updated_options['capsule'][key] = value
+        (key, value) = option.split("=")
+        updated_options["capsule"][key] = value
 
     # Update all the signer options.
     for option in signer_options:
-        (key, value) = option.split('=')
-        updated_options['signer'][key] = value
+        (key, value) = option.split("=")
+        updated_options["signer"][key] = value
 
     return updated_options
 
@@ -97,49 +138,73 @@ def update_options(file_options, capsule_options, signer_options):
 def main():
     """Main entry point into the Capsule Tool."""
     args = get_cli_options()
-    final_options = update_options(load_options_file(args.options_file), args.capsule_options, args.signer_options)
+    final_options = update_options(
+        load_options_file(args.options_file), args.capsule_options, args.signer_options
+    )
 
     # Verify minimum capsule options.
-    required_capsule_options = ('fw_name', 'fw_version', 'lsv_version', 'fw_version_string',
-                                'provider_name', 'fw_description', 'esrt_guid')
-    missing_capsule_options = tuple(option for option in required_capsule_options
-                                    if option not in final_options['capsule'])
+    required_capsule_options = (
+        "fw_name",
+        "fw_version",
+        "lsv_version",
+        "fw_version_string",
+        "provider_name",
+        "fw_description",
+        "esrt_guid",
+    )
+    missing_capsule_options = tuple(
+        option
+        for option in required_capsule_options
+        if option not in final_options["capsule"]
+    )
     if len(missing_capsule_options) > 0:
-        logging.error("Missing required capsule options: " + ", ".join(missing_capsule_options) + "!")
-        logging.error("Options MUST be provided in either the options file or on the command line.")
+        logging.error(
+            "Missing required capsule options: "
+            + ", ".join(missing_capsule_options)
+            + "!"
+        )
+        logging.error(
+            "Options MUST be provided in either the options file or on the command line."
+        )
         sys.exit(1)
 
     # Next, we're gonna need a signer.
     if args.builtin_signer is not None:
         signer = signing_helper.get_signer(args.builtin_signer)
     elif args.module_signer is not None:
-        signer = signing_helper.get_signer(signing_helper.PYPATH_MODULE_SIGNER, args.module_signer)
+        signer = signing_helper.get_signer(
+            signing_helper.PYPATH_MODULE_SIGNER, args.module_signer
+        )
     elif args.local_signer is not None:
-        signer = signing_helper.get_signer(signing_helper.LOCAL_MODULE_SIGNER, args.local_signer)
+        signer = signing_helper.get_signer(
+            signing_helper.LOCAL_MODULE_SIGNER, args.local_signer
+        )
 
     # Now, build the capsule.
     uefi_capsule_header = capsule_helper.build_capsule(
         args.capsule_payload.read(),
-        final_options['capsule'],
+        final_options["capsule"],
         signer,
-        final_options['signer']
+        final_options["signer"],
     )
 
     # Save the capsule.
-    capsule_helper.save_capsule(uefi_capsule_header, final_options['capsule'], args.output_dir)
+    capsule_helper.save_capsule(
+        uefi_capsule_header, final_options["capsule"], args.output_dir
+    )
 
     # Build the INF file.
-    capsule_helper.create_inf_file(final_options['capsule'], args.output_dir)
+    capsule_helper.create_inf_file(final_options["capsule"], args.output_dir)
 
     # Build the CAT file.
-    capsule_helper.create_cat_file(final_options['capsule'], args.output_dir)
+    capsule_helper.create_cat_file(final_options["capsule"], args.output_dir)
 
     # If requested, save the final options for provenance.
     if args.save_final_options:
-        final_options_file = os.path.join(args.output_dir, 'Final_Capsule_Options.yaml')
-        with open(final_options_file, 'w') as options_file:
+        final_options_file = os.path.join(args.output_dir, "Final_Capsule_Options.yaml")
+        with open(final_options_file, "w") as options_file:
             yaml.dump(final_options, options_file, indent=2)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/edk2toolext/capsule/pyopenssl_signer.py
+++ b/edk2toolext/capsule/pyopenssl_signer.py
@@ -39,47 +39,57 @@ def sign(data: bytes, signature_options: dict, signer_options: dict) -> bytes:
     """
     # The following _if_ clause handles the deprecated signature_option 'sign_alg' for backwards compatibility
     # when the deprecated option is supplied, this code adds the new, required options based on prior code behavior
-    if 'sign_alg' in signature_options:
-        warnings.warn('Signature_option "sign_alg" is deprecated, use "type"', DeprecationWarning)
-        if signature_options['sign_alg'] == 'pkcs12':
+    if "sign_alg" in signature_options:
+        warnings.warn(
+            'Signature_option "sign_alg" is deprecated, use "type"', DeprecationWarning
+        )
+        if signature_options["sign_alg"] == "pkcs12":
             # map legacy behavior to new options and backwards-compatible values
-            signature_options['type'] = 'bare'
-            signature_options['encoding'] = 'binary'
-            signer_options['key_file_format'] = 'pkcs12'
+            signature_options["type"] = "bare"
+            signature_options["encoding"] = "binary"
+            signer_options["key_file_format"] = "pkcs12"
         else:
-            raise ValueError(f"Unsupported signature algorithm: {signature_options['sign_alg']}!")
+            raise ValueError(
+                f"Unsupported signature algorithm: {signature_options['sign_alg']}!"
+            )
 
-    ''' signature type 'bare' is just a binary signed digest, no PEM headers/footers or ASN '''
-    if signature_options['type'] != 'bare':
+    """ signature type 'bare' is just a binary signed digest, no PEM headers/footers or ASN """
+    if signature_options["type"] != "bare":
         raise ValueError(f"Unsupported signature type: {signature_options['type']}")
-    if 'type_options' in signature_options:
+    if "type_options" in signature_options:
         raise ValueError("Signature type options not supported")
-    if signature_options['encoding'] != 'binary':
-        raise ValueError(f"Unsupported signature encoding: {signature_options['encoding']}")
-    if signature_options['hash_alg'] != 'sha256':
-        raise ValueError(f"Unsupported hashing algorithm: {signature_options['hash_alg']}")
-    if signer_options['key_file_format'] != 'pkcs12':
-        raise ValueError(f"Unsupported signer key file format: {signer_options['key_file_format']}")
+    if signature_options["encoding"] != "binary":
+        raise ValueError(
+            f"Unsupported signature encoding: {signature_options['encoding']}"
+        )
+    if signature_options["hash_alg"] != "sha256":
+        raise ValueError(
+            f"Unsupported hashing algorithm: {signature_options['hash_alg']}"
+        )
+    if signer_options["key_file_format"] != "pkcs12":
+        raise ValueError(
+            f"Unsupported signer key file format: {signer_options['key_file_format']}"
+        )
 
     logging.debug("Executing PKCS1 Signing")
 
     # If a key file is provided, use it for signing.
-    if 'key_file' in signer_options:
-        with open(signer_options['key_file'], 'rb') as key_file:
-            signer_options['key_data'] = key_file.read()
+    if "key_file" in signer_options:
+        with open(signer_options["key_file"], "rb") as key_file:
+            signer_options["key_data"] = key_file.read()
 
-    if type(signer_options['key_data']) is not bytes:
-        signer_options['key_data'] = signer_options['key_data'].encode()
+    if type(signer_options["key_data"]) is not bytes:
+        signer_options["key_data"] = signer_options["key_data"].encode()
 
     password = None
-    if 'key_file_password' in signer_options:
-        password = signer_options['key_file_password']
+    if "key_file_password" in signer_options:
+        password = signer_options["key_file_password"]
         if type(password) is not bytes:
             password = password.encode()
 
     # TODO: Figure out OIDs.
     # TODO: Figure out EKU.
 
-    pkcs12 = load_pkcs12(signer_options['key_data'], password)
+    pkcs12 = load_pkcs12(signer_options["key_data"], password)
     pkey = crypto.PKey.from_cryptography_key(pkcs12.key)
-    return crypto.sign(pkey, data, signature_options['hash_alg'])
+    return crypto.sign(pkey, data, signature_options["hash_alg"])

--- a/edk2toolext/capsule/signing_helper.py
+++ b/edk2toolext/capsule/signing_helper.py
@@ -22,10 +22,10 @@ from edk2toolext.capsule import signtool_signer
 from edk2toollib.utility_functions import import_module_by_file_name
 
 # Valid types.
-PYOPENSSL_SIGNER = 'pyopenssl'
-SIGNTOOL_SIGNER = 'signtool'
-PYPATH_MODULE_SIGNER = 'pymodule'
-LOCAL_MODULE_SIGNER = 'local_module'
+PYOPENSSL_SIGNER = "pyopenssl"
+SIGNTOOL_SIGNER = "signtool"
+PYPATH_MODULE_SIGNER = "pymodule"
+LOCAL_MODULE_SIGNER = "local_module"
 
 
 def get_signer(type, specifier=None):
@@ -44,9 +44,12 @@ def get_signer(type, specifier=None):
     if type == PYOPENSSL_SIGNER:
         try:
             from edk2toolext.capsule import pyopenssl_signer
+
             return pyopenssl_signer
         except ModuleNotFoundError:
-            raise RuntimeError('PyOpenSsl Signer failed to load. Do you have pyopenssl installed?')
+            raise RuntimeError(
+                "PyOpenSsl Signer failed to load. Do you have pyopenssl installed?"
+            )
     elif type == SIGNTOOL_SIGNER:
         return signtool_signer
     elif type == PYPATH_MODULE_SIGNER:

--- a/edk2toolext/capsule/signtool_signer.py
+++ b/edk2toolext/capsule/signtool_signer.py
@@ -28,7 +28,7 @@ from edk2toollib.utility_functions import RunCmd
 
 GLOBAL_SIGNTOOL_PATH = None
 SUPPORTED_SIGNATURE_TYPE_OPTIONS = {
-    'pkcs7': {'detachedSignedData', 'embedded', 'pkcs7DetachedSignedData'}
+    "pkcs7": {"detachedSignedData", "embedded", "pkcs7DetachedSignedData"}
 }
 
 
@@ -41,7 +41,7 @@ def get_signtool_path():
     global GLOBAL_SIGNTOOL_PATH
 
     if GLOBAL_SIGNTOOL_PATH is None:
-        GLOBAL_SIGNTOOL_PATH = locate_tools.FindToolInWinSdk('signtool.exe')
+        GLOBAL_SIGNTOOL_PATH = locate_tools.FindToolInWinSdk("signtool.exe")
 
     return GLOBAL_SIGNTOOL_PATH
 
@@ -65,71 +65,92 @@ def sign(data: bytes, signature_options: dict, signer_options: dict) -> bytes:
     """
     # The following _if_ clause handles the deprecated signature_option 'sign_alg' for backwards compatibility
     # when the deprecated option is supplied, this code adds the new, required options based on prior code behavior
-    if 'sign_alg' in signature_options:
-        warnings.warn('Signature_option "sign_alg" is deprecated, use "type"', DeprecationWarning)
-        if signature_options['sign_alg'] == 'pkcs12':
+    if "sign_alg" in signature_options:
+        warnings.warn(
+            'Signature_option "sign_alg" is deprecated, use "type"', DeprecationWarning
+        )
+        if signature_options["sign_alg"] == "pkcs12":
             # map legacy behavior to new options and backwards-compatible values
-            signature_options['type'] = 'pkcs7'
-            signature_options['type_options'] = {'detachedSignedData'}
-            signature_options['encoding'] = 'DER'
-            signer_options['key_file_format'] = 'pkcs12'
+            signature_options["type"] = "pkcs7"
+            signature_options["type_options"] = {"detachedSignedData"}
+            signature_options["encoding"] = "DER"
+            signer_options["key_file_format"] = "pkcs12"
         else:
-            raise ValueError(f"Unsupported signature algorithm: {signature_options['sign_alg']}!")
+            raise ValueError(
+                f"Unsupported signature algorithm: {signature_options['sign_alg']}!"
+            )
 
-    if signature_options['type'] != 'pkcs7':
+    if signature_options["type"] != "pkcs7":
         raise ValueError(f"Unsupported signature type: {signature_options['type']}!")
-    for opt in signature_options['type_options']:
-        if opt not in SUPPORTED_SIGNATURE_TYPE_OPTIONS[signature_options['type']]:
-            raise ValueError(f"Unsupported type option: {opt}!  Ensure you have provied a set")
+    for opt in signature_options["type_options"]:
+        if opt not in SUPPORTED_SIGNATURE_TYPE_OPTIONS[signature_options["type"]]:
+            raise ValueError(
+                f"Unsupported type option: {opt}!  Ensure you have provied a set"
+            )
 
-    mutually_exclusive_options = ('embedded', 'detachedSignedData', 'pkcs7DetachedSignedData')
+    mutually_exclusive_options = (
+        "embedded",
+        "detachedSignedData",
+        "pkcs7DetachedSignedData",
+    )
     option_found = None
     for option in mutually_exclusive_options:
-        if option in signature_options['type_options']:
+        if option in signature_options["type_options"]:
             if option_found is None:
                 option_found = option
             else:
-                raise ValueError("type_options '%s' and '%s' are mutually exclusive" % (option_found, option))
+                raise ValueError(
+                    "type_options '%s' and '%s' are mutually exclusive"
+                    % (option_found, option)
+                )
 
-    if signature_options['encoding'] != 'DER':
-        raise ValueError(f"Unsupported signature encoding: {signature_options['type']}!")
-    if signature_options['hash_alg'] != 'sha256':
-        raise ValueError(f"Unsupported hashing algorithm: {signature_options['hash_alg']}!")
-    if 'key_file' not in signer_options:
+    if signature_options["encoding"] != "DER":
+        raise ValueError(
+            f"Unsupported signature encoding: {signature_options['type']}!"
+        )
+    if signature_options["hash_alg"] != "sha256":
+        raise ValueError(
+            f"Unsupported hashing algorithm: {signature_options['hash_alg']}!"
+        )
+    if "key_file" not in signer_options:
         raise ValueError("Must supply a key_file in signer_options for Signtool!")
-    if signer_options['key_file_format'] != 'pkcs12':
-        raise ValueError(f"Unsupported key file format: {signer_options['key_file_format']}!")
+    if signer_options["key_file_format"] != "pkcs12":
+        raise ValueError(
+            f"Unsupported key file format: {signer_options['key_file_format']}!"
+        )
 
     # Set up a temp directory to hold input and output files.
     temp_folder = tempfile.mkdtemp()
     in_file_path = os.path.join(temp_folder, "data_to_sign.bin")
 
     # Create the input file for Signtool.
-    in_file = open(in_file_path, 'wb')
+    in_file = open(in_file_path, "wb")
     in_file.write(data)
     in_file.close()
 
     # Start building the parameters for the call.
-    signtool_params = ['sign']
-    signtool_params += ['/fd', signature_options['hash_alg']]
-    if 'detachedSignedData' in signature_options['type_options']:
-        signtool_params += ['/p7ce', 'DetachedSignedData']
-    elif 'pkcs7DetachedSignedData' in signature_options['type_options']:
-        signtool_params += ['/p7ce', 'PKCS7DetachedSignedData']
-    elif 'embedded' in signature_options['type_options']:
-        signtool_params += ['/p7ce', 'Embedded']
+    signtool_params = ["sign"]
+    signtool_params += ["/fd", signature_options["hash_alg"]]
+    if "detachedSignedData" in signature_options["type_options"]:
+        signtool_params += ["/p7ce", "DetachedSignedData"]
+    elif "pkcs7DetachedSignedData" in signature_options["type_options"]:
+        signtool_params += ["/p7ce", "PKCS7DetachedSignedData"]
+    elif "embedded" in signature_options["type_options"]:
+        signtool_params += ["/p7ce", "Embedded"]
     else:
-        raise ValueError("For pkcs7, type_options must include either embedded or detachedSignedData")
-    signtool_params += ['/p7', f'"{temp_folder}"']
-    signtool_params += ['/f', f"\"{signer_options['key_file']}\""]
-    if 'oid' in signer_options:
-        signtool_params += ['/p7co', signer_options['oid']]
-    if 'eku' in signer_options:
-        signtool_params += ['/u', signer_options['eku']]
-    if 'key_pass' in signer_options:
-        signtool_params += ['/p', signer_options['key_pass']]
+        raise ValueError(
+            "For pkcs7, type_options must include either embedded or detachedSignedData"
+        )
+    signtool_params += ["/p7", f'"{temp_folder}"']
+    signtool_params += ["/f", f"\"{signer_options['key_file']}\""]
+    if "oid" in signer_options:
+        signtool_params += ["/p7co", signer_options["oid"]]
+    if "eku" in signer_options:
+        signtool_params += ["/u", signer_options["eku"]]
+    if "key_pass" in signer_options:
+        signtool_params += ["/p", signer_options["key_pass"]]
     # Add basic options.
-    signtool_params += ['/debug', '/v', f'"{in_file_path}"']
+    signtool_params += ["/debug", "/v", f'"{in_file_path}"']
 
     # Make the call to Signtool.
     ret = RunCmd(get_signtool_path(), " ".join(signtool_params))
@@ -138,7 +159,7 @@ def sign(data: bytes, signature_options: dict, signer_options: dict) -> bytes:
 
     # Load the data from the output file and return it.
     out_file_path = os.path.join(temp_folder, "data_to_sign.bin.p7")
-    out_file = open(out_file_path, 'rb')
+    out_file = open(out_file_path, "rb")
     out_data = out_file.read()
     out_file.close()
 
@@ -163,25 +184,29 @@ def sign_in_place(sign_file_path, signature_options, signer_options):
 
     """
     # NOTE: Currently, we only support the necessary algorithms for capsules.
-    if signature_options['sign_alg'] != 'pkcs12':
-        raise ValueError(f"Unsupported signature algorithm: {signature_options['sign_alg']}!")
-    if signature_options['hash_alg'] != 'sha256':
-        raise ValueError(f"Unsupported hashing algorithm: {signature_options['hash_alg']}!")
-    if 'key_file' not in signer_options:
+    if signature_options["sign_alg"] != "pkcs12":
+        raise ValueError(
+            f"Unsupported signature algorithm: {signature_options['sign_alg']}!"
+        )
+    if signature_options["hash_alg"] != "sha256":
+        raise ValueError(
+            f"Unsupported hashing algorithm: {signature_options['hash_alg']}!"
+        )
+    if "key_file" not in signer_options:
         raise ValueError("Must supply a key_file in signer_options for Signtool!")
 
     # Start building the parameters for the call.
-    signtool_params = ['sign', '/a']
-    signtool_params += ['/fd', signature_options['hash_alg']]
-    signtool_params += ['/f', f"\"{signer_options['key_file']}\""]
+    signtool_params = ["sign", "/a"]
+    signtool_params += ["/fd", signature_options["hash_alg"]]
+    signtool_params += ["/f", f"\"{signer_options['key_file']}\""]
     # if 'oid' in signer_options:
     #     signtool_params += ['/p7co', signer_options['oid']]
     # if 'eku' in signer_options:
     #     signtool_params += ['/u', signer_options['eku']]
-    if 'key_pass' in signer_options:
-        signtool_params += ['/p', signer_options['key_pass']]
+    if "key_pass" in signer_options:
+        signtool_params += ["/p", signer_options["key_pass"]]
     # Add basic options.
-    signtool_params += ['/debug', '/v', f'"{sign_file_path}"']
+    signtool_params += ["/debug", "/v", f'"{sign_file_path}"']
 
     # Make the call to Signtool.
     ret = RunCmd(get_signtool_path(), " ".join(signtool_params))

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -34,7 +34,7 @@ from edk2toollib.utility_functions import import_module_by_file_name
 from edk2toolext.base_abstract_invocable import BaseAbstractInvocable
 
 
-class Edk2InvocableSettingsInterface():
+class Edk2InvocableSettingsInterface:
     """Settings APIs to support an Edk2Invocable.
 
     This is an interface definition only to show which functions are
@@ -196,7 +196,9 @@ class Edk2Invocable(BaseAbstractInvocable):
         for package in pip_packages:
             version = pkg_resources.get_distribution(package).version
             logging.info("{0} version: {1}".format(package.project_name, version))
-            ver_agg.ReportVersion(package.project_name, version, version_aggregator.VersionTypes.PIP)
+            ver_agg.ReportVersion(
+                package.project_name, version, version_aggregator.VersionTypes.PIP
+            )
 
     def GetWorkspaceRoot(self) -> os.PathLike:
         """Returns the absolute path to the workspace root.
@@ -210,7 +212,9 @@ class Edk2Invocable(BaseAbstractInvocable):
         try:
             return self.PlatformSettings.GetWorkspaceRoot()
         except AttributeError:
-            raise RuntimeError("Can't call this before PlatformSettings has been set up!")
+            raise RuntimeError(
+                "Can't call this before PlatformSettings has been set up!"
+            )
 
     def GetPackagesPath(self) -> Iterable[os.PathLike]:
         """Returns an iterable of packages path.
@@ -222,9 +226,15 @@ class Edk2Invocable(BaseAbstractInvocable):
             Packages path
         """
         try:
-            return [x for x in self.PlatformSettings.GetPackagesPath() if x not in self.GetSkippedDirectories()]
+            return [
+                x
+                for x in self.PlatformSettings.GetPackagesPath()
+                if x not in self.GetSkippedDirectories()
+            ]
         except AttributeError:
-            raise RuntimeError("Can't call this before PlatformSettings has been set up!")
+            raise RuntimeError(
+                "Can't call this before PlatformSettings has been set up!"
+            )
 
     def GetActiveScopes(self) -> Tuple[str]:
         """Returns an iterable of Active scopes.
@@ -240,15 +250,17 @@ class Edk2Invocable(BaseAbstractInvocable):
         try:
             scopes = self.PlatformSettings.GetActiveScopes()
         except AttributeError:
-            raise RuntimeError("Can't call this before PlatformSettings has been set up!")
+            raise RuntimeError(
+                "Can't call this before PlatformSettings has been set up!"
+            )
 
         # Add any OS-specific scope.
         if GetHostInfo().os == "Windows":
-            scopes += ('global-win',)
+            scopes += ("global-win",)
         elif GetHostInfo().os == "Linux":
-            scopes += ('global-nix',)
+            scopes += ("global-nix",)
         # Add the global scope. To be deprecated.
-        scopes += ('global',)
+        scopes += ("global",)
         return scopes
 
     def GetLoggingLevel(self, loggerType):
@@ -302,7 +314,9 @@ class Edk2Invocable(BaseAbstractInvocable):
         try:
             return self.PlatformSettings.GetSkippedDirectories()
         except AttributeError:
-            raise RuntimeError("Can't call this before PlatformSettings has been set up!")
+            raise RuntimeError(
+                "Can't call this before PlatformSettings has been set up!"
+            )
 
     def GetSettingsClass(self):
         """The required settings manager for the invocable.
@@ -325,7 +339,8 @@ class Edk2Invocable(BaseAbstractInvocable):
         Returns:
             (str): The string to be added to the end of the argument parser.
         """
-        epilog = dedent('''\
+        epilog = dedent(
+            """\
             CLI Env Guide:
               <key>=<value>              - Set an env variable for the pre/post build process
               <key>                      - Set a non-valued env variable for the pre/post build process
@@ -335,7 +350,8 @@ class Edk2Invocable(BaseAbstractInvocable):
               BLD_<TARGET>_<key>=<value> - Set a build flag for build type of <target>
                                            (key=value will get passed to build process for given build type)
               BLD_<TARGET>_<key>         - Set a non-valued build flag for a build type of <target>
-            ''')
+            """
+        )
         return epilog
 
     def ParseCommandLineOptions(self):
@@ -348,18 +364,26 @@ class Edk2Invocable(BaseAbstractInvocable):
         # first argparser will only get settings manager and help will be disabled
         settingsParserObj = argparse.ArgumentParser(add_help=False)
 
-        settingsParserObj.add_argument('-c', '--platform_module', dest='platform_module',
-                                       default="PlatformBuild.py", type=str,
-                                       help='Provide the Platform Module relative to the current working directory.'
-                                            f'This should contain a {self.GetSettingsClass().__name__} instance.')
+        settingsParserObj.add_argument(
+            "-c",
+            "--platform_module",
+            dest="platform_module",
+            default="PlatformBuild.py",
+            type=str,
+            help="Provide the Platform Module relative to the current working directory."
+            f"This should contain a {self.GetSettingsClass().__name__} instance.",
+        )
 
         # get the settings manager from the provided file and load an instance
         settingsArg, unknown_args = settingsParserObj.parse_known_args()
         try:
-            self.PlatformModule = import_module_by_file_name(os.path.abspath(settingsArg.platform_module))
+            self.PlatformModule = import_module_by_file_name(
+                os.path.abspath(settingsArg.platform_module)
+            )
             self.PlatformSettings = locate_class_in_module(
-                self.PlatformModule, self.GetSettingsClass())()
-        except (TypeError):
+                self.PlatformModule, self.GetSettingsClass()
+            )()
+        except TypeError:
             # Gracefully exit if the file we loaded isn't the right type
             class_name = self.GetSettingsClass().__name__
             print(f"Unable to use {settingsArg.platform_module} as a {class_name}")
@@ -371,7 +395,11 @@ class Edk2Invocable(BaseAbstractInvocable):
                 Module = self.PlatformModule
                 module_contents = dir(Module)
                 # Filter through the Module, we're only looking for classes.
-                classList = [getattr(Module, obj) for obj in module_contents if inspect.isclass(getattr(Module, obj))]
+                classList = [
+                    getattr(Module, obj)
+                    for obj in module_contents
+                    if inspect.isclass(getattr(Module, obj))
+                ]
                 # Get the name of all the classes
                 classNameList = [obj.__name__ for obj in classList]
                 # TODO improve filter to no longer catch imports as well as declared classes
@@ -383,21 +411,25 @@ class Edk2Invocable(BaseAbstractInvocable):
             settingsParserObj.print_help()
             sys.exit(1)
 
-        except (FileNotFoundError):
+        except FileNotFoundError:
             # Gracefully exit if we can't find the file
             print(f"We weren't able to find {settingsArg.platform_module}")
             settingsParserObj.print_help()
             sys.exit(2)
 
         except Exception as e:
-            print(f"Error: We had trouble loading {settingsArg.platform_module}. Is the path correct?")
+            print(
+                f"Error: We had trouble loading {settingsArg.platform_module}. Is the path correct?"
+            )
             # Gracefully exit if setup doesn't go well.
             settingsParserObj.print_help()
             print(e)
             sys.exit(2)
 
         # instantiate the second argparser that will get passed around
-        parserObj = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,)
+        parserObj = argparse.ArgumentParser(
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+        )
 
         # first pass it to the subclass
         self.AddCommandLineOptions(parserObj)
@@ -405,13 +437,27 @@ class Edk2Invocable(BaseAbstractInvocable):
         # next pass it to the settings manager
         self.PlatformSettings.AddCommandLineOptions(parserObj)
 
-        default_build_config_path = os.path.join(self.GetWorkspaceRoot(), "BuildConfig.conf")
+        default_build_config_path = os.path.join(
+            self.GetWorkspaceRoot(), "BuildConfig.conf"
+        )
 
         # add the common stuff that everyone will need
-        parserObj.add_argument('--build-config', dest='build_config', default=default_build_config_path, type=str,
-                               help='Provide shell variables in a file')
-        parserObj.add_argument('--verbose', '--VERBOSE', '-v', dest="verbose", action='store_true', default=False,
-                               help='verbose')
+        parserObj.add_argument(
+            "--build-config",
+            dest="build_config",
+            default=default_build_config_path,
+            type=str,
+            help="Provide shell variables in a file",
+        )
+        parserObj.add_argument(
+            "--verbose",
+            "--VERBOSE",
+            "-v",
+            dest="verbose",
+            action="store_true",
+            default=False,
+            help="verbose",
+        )
 
         # set the epilog to display with --help, -h
         parserObj.epilog = self.AddParserEpilog()
@@ -444,11 +490,15 @@ class Edk2Invocable(BaseAbstractInvocable):
         for argument in unknown_args:
             if argument.count("=") == 1:
                 tokens = argument.strip().split("=")
-                env.SetValue(tokens[0].strip().upper(), tokens[1].strip(), "From CmdLine")
+                env.SetValue(
+                    tokens[0].strip().upper(), tokens[1].strip(), "From CmdLine"
+                )
             elif argument.count("=") == 0:
-                env.SetValue(argument.strip().upper(),
-                             ''.join(choice(ascii_letters) for _ in range(20)),
-                             "Non valued variable set From cmdLine")
+                env.SetValue(
+                    argument.strip().upper(),
+                    "".join(choice(ascii_letters) for _ in range(20)),
+                    "Non valued variable set From cmdLine",
+                )
             else:
                 raise RuntimeError(f"Unknown variable passed in via CLI: {argument}")
 
@@ -465,10 +515,16 @@ class Edk2Invocable(BaseAbstractInvocable):
         for argument in unknown_args:
             if argument.count("=") == 1:
                 tokens = argument.strip().split("=")
-                env.SetValue(tokens[0].strip().upper(), tokens[1].strip(), "From BuildConf")
+                env.SetValue(
+                    tokens[0].strip().upper(), tokens[1].strip(), "From BuildConf"
+                )
             elif argument.count("=") == 0:
-                env.SetValue(argument.strip().upper(),
-                             ''.join(choice(ascii_letters) for _ in range(20)),
-                             "Non valued variable set from BuildConfig")
+                env.SetValue(
+                    argument.strip().upper(),
+                    "".join(choice(ascii_letters) for _ in range(20)),
+                    "Non valued variable set from BuildConfig",
+                )
             else:
-                raise RuntimeError(f"Unknown variable passed in via BuildConfig: {argument}")
+                raise RuntimeError(
+                    f"Unknown variable passed in via BuildConfig: {argument}"
+                )

--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -94,8 +94,14 @@ def setup_section_level():
 
 
 # creates the the plaintext logger
-def setup_txt_logger(directory, filename="log", logging_level=logging.INFO,
-                     formatter=None, logging_namespace='', isVerbose=False):
+def setup_txt_logger(
+    directory,
+    filename="log",
+    logging_level=logging.INFO,
+    formatter=None,
+    logging_namespace="",
+    isVerbose=False,
+):
     """Configures a text logger."""
     logger = logging.getLogger(logging_namespace)
     log_formatter = formatter
@@ -107,7 +113,7 @@ def setup_txt_logger(directory, filename="log", logging_level=logging.INFO,
 
     # Create file logger
     logfile_path = os.path.join(directory, filename + ".txt")
-    filelogger = file_handler.FileHandler(filename=(logfile_path), mode='w+')
+    filelogger = file_handler.FileHandler(filename=(logfile_path), mode="w+")
     filelogger.setLevel(logging_level)
     filelogger.setFormatter(log_formatter)
     logger.addHandler(filelogger)
@@ -118,8 +124,14 @@ def setup_txt_logger(directory, filename="log", logging_level=logging.INFO,
 
 
 # sets up a colored console logger
-def setup_console_logging(logging_level=logging.INFO, formatter=None, logging_namespace='',
-                          isVerbose=False, use_azure_colors=False, use_color=True):
+def setup_console_logging(
+    logging_level=logging.INFO,
+    formatter=None,
+    logging_namespace="",
+    isVerbose=False,
+    use_azure_colors=False,
+    use_color=True,
+):
     """Configures a console logger."""
     if formatter is None and isVerbose:
         formatter_msg = "%(name)s: %(levelname)s - %(message)s"
@@ -140,7 +152,9 @@ def setup_console_logging(logging_level=logging.INFO, formatter=None, logging_na
 
     # create the ansi logger if needed
     if use_azure_colors or use_color and ansi_handler:
-        formatter = ansi_handler.ColoredFormatter(formatter_msg, use_azure=use_azure_colors)
+        formatter = ansi_handler.ColoredFormatter(
+            formatter_msg, use_azure=use_azure_colors
+        )
         coloredHandler = ansi_handler.ColoredStreamHandler()
         coloredHandler.setLevel(logging_level)
         coloredHandler.addFilter(get_edk2_filter(isVerbose))
@@ -153,7 +167,7 @@ def setup_console_logging(logging_level=logging.INFO, formatter=None, logging_na
     return safeHandler
 
 
-def stop_logging(loghandle, logging_namespace=''):
+def stop_logging(loghandle, logging_namespace=""):
     """Stops logging on a log handle."""
     logger = logging.getLogger(logging_namespace)
     if loghandle is None:
@@ -168,7 +182,7 @@ def stop_logging(loghandle, logging_namespace=''):
         logger.removeHandler(loghandle)
 
 
-def create_output_stream(level=logging.INFO, logging_namespace=''):
+def create_output_stream(level=logging.INFO, logging_namespace=""):
     """Creates an output stream to log to."""
     # creates an output stream that is in memory
     if string_handler:
@@ -181,7 +195,7 @@ def create_output_stream(level=logging.INFO, logging_namespace=''):
     return handler
 
 
-def remove_output_stream(handler, logging_namespace=''):
+def remove_output_stream(handler, logging_namespace=""):
     """Removes an output stream to log to."""
     logger = logging.getLogger(logging_namespace)
     if isinstance(handler, list):
@@ -198,6 +212,7 @@ def scan_compiler_output(output_stream):
         (list[Tuple[logging.Type, str]]): list of tuples containing the type
             of issue (Error, warning) and the description.
     """
+
     # seek to the start of the output stream
     def output_compiler_error(match, line, start_txt="Compiler"):
         start, end = match.span()
@@ -205,6 +220,7 @@ def scan_compiler_output(output_stream):
         error = line[end:].strip()
         num = match.group(1)
         return f"{start_txt} #{num} from {source} {error}"
+
     problems = []
     output_stream.seek(0, 0)
     error_exp = re.compile(r"error [A-EG-Z]?(\d+):")
@@ -247,6 +263,7 @@ def scan_compiler_output(output_stream):
 
 class Edk2LogFilter(logging.Filter):
     """Subclass of logging.Filter."""
+
     _allowedLoggers = ["root"]
 
     def __init__(self):
@@ -260,7 +277,9 @@ class Edk2LogFilter(logging.Filter):
             r"gh[pousr]_[A-Za-z0-9_]+",  # Github PAT
         ]
 
-        self.secrets_regex = re.compile(r"{}".format("|".join(secrets_regex_strings)), re.IGNORECASE)
+        self.secrets_regex = re.compile(
+            r"{}".format("|".join(secrets_regex_strings)), re.IGNORECASE
+        )
 
     def setVerbose(self, isVerbose=True):
         """Sets the filter verbosity."""
@@ -275,7 +294,11 @@ class Edk2LogFilter(logging.Filter):
     def filter(self, record):
         """Adds a filter for a record if it doesn't already exist."""
         # check to make sure we haven't already filtered this record
-        if record.name not in Edk2LogFilter._allowedLoggers and record.levelno < logging.WARNING and not self._verbose:
+        if (
+            record.name not in Edk2LogFilter._allowedLoggers
+            and record.levelno < logging.WARNING
+            and not self._verbose
+        ):
             return False
         record.msg = self.secrets_regex.sub("*******", str(record.msg))
         return True

--- a/edk2toolext/environment/conf_mgmt.py
+++ b/edk2toolext/environment/conf_mgmt.py
@@ -17,8 +17,9 @@ import time
 from edk2toolext.environment import version_aggregator
 
 
-class ConfMgmt():
+class ConfMgmt:
     """Handles Edk2 Conf Management."""
+
     def __init__(self):
         """Init an empty ConfMgmt object."""
         self.Logger = logging.getLogger("ConfMgmt")
@@ -28,7 +29,12 @@ class ConfMgmt():
         """Allow changing the warning time for out of date templates."""
         self.delay_time_in_seconds = time_in_seconds
 
-    def populate_conf_dir(self, conf_folder_path: str, override_conf: bool, conf_template_source_list: list) -> None:
+    def populate_conf_dir(
+        self,
+        conf_folder_path: str,
+        override_conf: bool,
+        conf_template_source_list: list,
+    ) -> None:
         """Compare the conf dir files to the template files.
 
         Copy files if they are not present in the conf dir or the override parameter is set.
@@ -51,7 +57,9 @@ class ConfMgmt():
         outfiles = [os.path.join(conf_folder_path, f) for f in files]
 
         # make template list based on files
-        templatefiles = [os.path.join("Conf", os.path.splitext(f)[0] + ".template") for f in files]
+        templatefiles = [
+            os.path.join("Conf", os.path.splitext(f)[0] + ".template") for f in files
+        ]
 
         # loop thru each Conf file needed
         for x in range(0, len(outfiles)):
@@ -64,19 +72,25 @@ class ConfMgmt():
                     template_file_path = p
                     break
 
-            if (template_file_path is None):
+            if template_file_path is None:
                 self.Logger.critical(
-                    "Failed to find Template file for %s" % outfiles[x])
+                    "Failed to find Template file for %s" % outfiles[x]
+                )
                 raise Exception("Template File Missing", outfiles[x])
             else:
                 self.Logger.debug(f"Conf file template: {template_file_path}")
 
             # have template now - now copy if needed
-            self._copy_conf_file_if_necessary(outfiles[x], template_file_path, override_conf)
+            self._copy_conf_file_if_necessary(
+                outfiles[x], template_file_path, override_conf
+            )
 
             # Log Version for reporting
-            version_aggregator.GetVersionAggregator().ReportVersion(outfiles[x], self._get_version(outfiles[x]),
-                                                                    version_aggregator.VersionTypes.INFO)
+            version_aggregator.GetVersionAggregator().ReportVersion(
+                outfiles[x],
+                self._get_version(outfiles[x]),
+                version_aggregator.VersionTypes.INFO,
+            )
 
     def _get_version(self, conf_file: str) -> str:
         """Parse the version from the conf_file.
@@ -89,7 +103,7 @@ class ConfMgmt():
         version = "0.0"
         with open(conf_file, "r") as f:
             for line in f.readlines():
-                if (line.startswith("#!VERSION=")):
+                if line.startswith("#!VERSION="):
                     try:
                         version = str(float(line.split("=")[1].split()[0].strip()))
                         break
@@ -119,9 +133,11 @@ class ConfMgmt():
         except Exception:
             logging.error("Failed to get version from file")
         finally:
-            return (conf < template)
+            return conf < template
 
-    def _copy_conf_file_if_necessary(self, conf_file: str, template_file: str, override_conf: bool) -> None:
+    def _copy_conf_file_if_necessary(
+        self, conf_file: str, template_file: str, override_conf: bool
+    ) -> None:
         """Copy template_file to conf_file if policy applies.
 
         Args:
@@ -131,19 +147,23 @@ class ConfMgmt():
         """
         if not os.path.isfile(conf_file):
             # file doesn't exist.  copy template
-            self.Logger.debug(f"{conf_file} file not found.  Creating from Template file {template_file}")
+            self.Logger.debug(
+                f"{conf_file} file not found.  Creating from Template file {template_file}"
+            )
             shutil.copy2(template_file, conf_file)
 
-        elif (override_conf):
+        elif override_conf:
             # caller requested override even for existing file
             self.Logger.debug(f"{conf_file} file replaced as requested")
             shutil.copy2(template_file, conf_file)
 
         else:
             # Both file exists.  Do a quick version check
-            if (self._is_older_version(conf_file, template_file)):
+            if self._is_older_version(conf_file, template_file):
                 # Conf dir file is older.  Warn user.
-                self.Logger.critical(f"{conf_file} file is out-of-date.  Please update your conf files!")
+                self.Logger.critical(
+                    f"{conf_file} file is out-of-date.  Please update your conf files!"
+                )
                 self.Logger.critical("Sleeping 30 seconds to encourage update....")
                 time.sleep(self.delay_time_in_seconds)
             else:

--- a/edk2toolext/environment/environment_descriptor_files.py
+++ b/edk2toolext/environment/environment_descriptor_files.py
@@ -26,6 +26,7 @@ class PathEnv(object):
         descriptor_location (string): location of the PathEnv
         published_path (string): location of the PathEnv
     """
+
     def __init__(self, descriptor):
         """Init with the descriptor information."""
         super(PathEnv, self).__init__()
@@ -33,12 +34,11 @@ class PathEnv(object):
         #
         # Set the data for this object.
         #
-        self.scope = descriptor['scope']
-        self.flags = descriptor['flags']
-        self.var_name = descriptor.get('var_name', None)
+        self.scope = descriptor["scope"]
+        self.flags = descriptor["flags"]
+        self.var_name = descriptor.get("var_name", None)
 
-        self.descriptor_location = os.path.dirname(
-            descriptor['descriptor_file'])
+        self.descriptor_location = os.path.dirname(descriptor["descriptor_file"])
         self.published_path = self.descriptor_location
 
 
@@ -49,6 +49,7 @@ class DescriptorFile(object):
         file_path (str): descriptor file path
         descriptor_contents (Dict): Contents of the descriptor file
     """
+
     def __init__(self, file_path):
         """Loads the contents of the descriptor file and validates.
 
@@ -63,7 +64,7 @@ class DescriptorFile(object):
         self.file_path = file_path
         self.descriptor_contents = None
 
-        with open(file_path, 'r') as file:
+        with open(file_path, "r") as file:
             try:
                 self.descriptor_contents = yaml.safe_load(file)
             except Exception:
@@ -74,28 +75,32 @@ class DescriptorFile(object):
         #
         if self.descriptor_contents is None:
             raise ValueError(
-                "Could not load contents of descriptor file '%s'!" % file_path)
+                "Could not load contents of descriptor file '%s'!" % file_path
+            )
 
         # The file path is an implicit descriptor field.
-        self.descriptor_contents['descriptor_file'] = self.file_path
+        self.descriptor_contents["descriptor_file"] = self.file_path
 
         # All files require a scope.
-        if 'scope' not in self.descriptor_contents:
-            raise ValueError("File '%s' missing required field '%s'!" %
-                             (self.file_path, 'scope'))
+        if "scope" not in self.descriptor_contents:
+            raise ValueError(
+                "File '%s' missing required field '%s'!" % (self.file_path, "scope")
+            )
 
         # If a file has flags, make sure they're sane.
-        if 'flags' in self.descriptor_contents:
+        if "flags" in self.descriptor_contents:
             # If a flag requires a name, make sure a name is provided.
-            for name_required in ('set_shell_var', 'set_build_var'):
-                if name_required in self.descriptor_contents['flags']:
-                    if 'var_name' not in self.descriptor_contents:
+            for name_required in ("set_shell_var", "set_build_var"):
+                if name_required in self.descriptor_contents["flags"]:
+                    if "var_name" not in self.descriptor_contents:
                         raise ValueError(
-                            "File '%s' has a flag requesting a var, but does not provide 'var_name'!" % self.file_path)
+                            "File '%s' has a flag requesting a var, but does not provide 'var_name'!"
+                            % self.file_path
+                        )
 
         # clean up each string item for more reliable processing
-        for (k, v) in self.descriptor_contents.items():
-            if (isinstance(v, str)):
+        for k, v in self.descriptor_contents.items():
+            if isinstance(v, str):
                 self.descriptor_contents[k] = self.sanitize_string(v)
 
     def sanitize_string(self, s):
@@ -106,6 +111,7 @@ class DescriptorFile(object):
 
 class PathEnvDescriptor(DescriptorFile):
     """Descriptor File for a PATH ENV."""
+
     def __init__(self, file_path):
         """Inits the descriptor as a PathEnvDescriptor from the provided path.
 
@@ -120,10 +126,12 @@ class PathEnvDescriptor(DescriptorFile):
         # Validate file contents.
         #
         # Make sure that the required fields are present.
-        for required_field in ('flags',):
+        for required_field in ("flags",):
             if required_field not in self.descriptor_contents:
-                raise ValueError("File '%s' missing required field '%s'!" % (
-                    self.file_path, required_field))
+                raise ValueError(
+                    "File '%s' missing required field '%s'!"
+                    % (self.file_path, required_field)
+                )
 
 
 class ExternDepDescriptor(DescriptorFile):
@@ -133,6 +141,7 @@ class ExternDepDescriptor(DescriptorFile):
             descriptor_contents (Dict): Contents of the Descriptor yaml file
             file_path (PathLike): path to the descriptor file
     """
+
     def __init__(self, file_path):
         """Inits the descriptor as a ExternDepDescriptor from the provided path.
 
@@ -147,10 +156,12 @@ class ExternDepDescriptor(DescriptorFile):
         # Validate file contents.
         #
         # Make sure that the required fields are present.
-        for required_field in ('scope', 'type', 'name', 'source', 'version'):
+        for required_field in ("scope", "type", "name", "source", "version"):
             if required_field not in self.descriptor_contents:
-                raise ValueError("File '%s' missing required field '%s'!" % (
-                    self.file_path, required_field))
+                raise ValueError(
+                    "File '%s' missing required field '%s'!"
+                    % (self.file_path, required_field)
+                )
 
 
 class PluginDescriptor(DescriptorFile):
@@ -160,6 +171,7 @@ class PluginDescriptor(DescriptorFile):
         descriptor_contents (Dict): Contents of the Descriptor yaml file
         file_path (PathLike): path to the descriptor file
     """
+
     def __init__(self, file_path):
         """Inits the descriptor as a PluginDescriptor from the provided path.
 
@@ -174,12 +186,14 @@ class PluginDescriptor(DescriptorFile):
         # Validate file contents.
         #
         # Make sure that the required fields are present.
-        for required_field in ('scope', 'name', 'module'):
+        for required_field in ("scope", "name", "module"):
             if required_field not in self.descriptor_contents:
-                raise ValueError("File '%s' missing required field '%s'!" % (
-                    self.file_path, required_field))
+                raise ValueError(
+                    "File '%s' missing required field '%s'!"
+                    % (self.file_path, required_field)
+                )
 
         # Make sure the module item doesn't have .py on the end
-        if (self.descriptor_contents["module"].lower().endswith(".py")):
+        if self.descriptor_contents["module"].lower().endswith(".py"):
             # remove last 3 chars
             self.descriptor_contents["module"] = self.descriptor_contents["module"][:-3]

--- a/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
+++ b/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
@@ -35,6 +35,7 @@ class AzureCliUniversalDependency(ExternalDependency):
     !!! tip
         The attributes are what must be described in the ext_dep yaml file!
     """
+
     TypeString = "az-universal"
 
     # https://docs.microsoft.com/en-us/azure/devops/cli/log-in-via-pat?view=azure-devops&tabs=windows
@@ -68,15 +69,17 @@ class AzureCliUniversalDependency(ExternalDependency):
                     break
 
         # Log the versions found
-        for (k, v) in found.items():
-            version_aggregator.GetVersionAggregator().ReportVersion(k, v, version_aggregator.VersionTypes.TOOL)
+        for k, v in found.items():
+            version_aggregator.GetVersionAggregator().ReportVersion(
+                k, v, version_aggregator.VersionTypes.TOOL
+            )
 
         # Check requirements
 
         # 1 - az cli tool missing will raise exception on call to az --version earlier in function
 
         # 2 - Check for azure-devops extension
-        if 'azure-devops' not in found.keys():
+        if "azure-devops" not in found.keys():
             logging.critical("Missing required Azure-cli extension azure-devops")
             raise EnvironmentError("Missing required Azure-cli extension azure-devops")
 
@@ -87,10 +90,10 @@ class AzureCliUniversalDependency(ExternalDependency):
         super().__init__(descriptor)
         self.global_cache_path = None
         self.organization = self.source
-        self.feed = descriptor.get('feed')
-        self.project = descriptor.get('project', None)
-        self.file_filter = descriptor.get('file-filter', None)
-        _pat_var = descriptor.get('pat_var', None)
+        self.feed = descriptor.get("feed")
+        self.project = descriptor.get("project", None)
+        self.file_filter = descriptor.get("file-filter", None)
+        _pat_var = descriptor.get("pat_var", None)
         self._pat = None
 
         if _pat_var is not None:
@@ -129,16 +132,24 @@ class AzureCliUniversalDependency(ExternalDependency):
             e[self.AZURE_CLI_DEVOPS_ENV_VAR] = self._pat
 
         results = StringIO()
-        RunCmd(cmd[0], " ".join(cmd[1:]), outstream=results, environ=e, raise_exception_on_nonzero=True)
+        RunCmd(
+            cmd[0],
+            " ".join(cmd[1:]),
+            outstream=results,
+            environ=e,
+            raise_exception_on_nonzero=True,
+        )
         # az tool returns json data that includes the downloaded version
         # lets check it to double confirm
         result_data = json.loads(results.getvalue())
         results.close()
-        downloaded_version = result_data['Version']
+        downloaded_version = result_data["Version"]
         if self.version != downloaded_version:
             self.version = downloaded_version  # set it so state file is accurate and will fail on verify
-            raise Exception("Download Universal Package version (%s) different than requested (%s)." %
-                            (downloaded_version, self.version))
+            raise Exception(
+                "Download Universal Package version (%s) different than requested (%s)."
+                % (downloaded_version, self.version)
+            )
 
     def fetch(self):
         """Fetches the dependency using internal state from the init."""

--- a/edk2toolext/environment/extdeptypes/nuget_dependency.py
+++ b/edk2toolext/environment/extdeptypes/nuget_dependency.py
@@ -29,6 +29,7 @@ class NugetDependency(ExternalDependency):
     !!! tip
         The attributes are what must be described in the ext_dep yaml file!
     """
+
     TypeString = "nuget"
 
     # Env variable name for path to folder containing NuGet.exe
@@ -69,7 +70,9 @@ class NugetDependency(ExternalDependency):
         nuget_path = os.path.join(nuget_path, file_name)
 
         if not os.path.isfile(nuget_path):
-            logging.error("We weren't able to find Nuget! Please reinstall your pip environment")
+            logging.error(
+                "We weren't able to find Nuget! Please reinstall your pip environment"
+            )
             return None
 
         # Make sure quoted string if it has spaces
@@ -91,8 +94,7 @@ class NugetDependency(ExternalDependency):
         """
         # 1. NuGetVersion requires the major segment to be defined
         if not version:
-            raise ValueError("String is empty. At least major version is "
-                             "required.")
+            raise ValueError("String is empty. At least major version is " "required.")
 
         # 2. NuGetVersion uses case insensitive string comparisons for
         #    pre-release components
@@ -109,8 +111,7 @@ class NugetDependency(ExternalDependency):
 
         # 4. A maximum of 4 version segments are allowed
         if len(int_parts) > 4:
-            raise ValueError(f"Maximum of 4 version segments allowed: "
-                             f"'{version}'!")
+            raise ValueError(f"Maximum of 4 version segments allowed: " f"'{version}'!")
 
         # 5. Allow a fourth version segment - "Revision" normally not
         #    allowed in Semantic versions but allowed in NuGet versions.
@@ -138,19 +139,22 @@ class NugetDependency(ExternalDependency):
             nuget_ver = semantic_version.Version.coerce(reformed_ver)
 
             # A ValueError will be raised if the version string is invalid
-            major, minor, patch, prerelease, build = \
-                semantic_version.Version.parse(str(nuget_ver))
+            major, minor, patch, prerelease, build = semantic_version.Version.parse(
+                str(nuget_ver)
+            )
         else:
             # A ValueError will be raised if the version string is invalid
             nuget_ver = semantic_version.Version(reformed_ver)
             major, minor, patch, prerelease, build = tuple(nuget_ver)
 
-        logging.info(f"NuGet version parts:\n"
-                     f"  Major Version: {major}\n"
-                     f"  Minor Version: {minor}\n"
-                     f"  Patch Version: {patch}\n"
-                     f"  Pre-Release Version {prerelease}\n"
-                     f"  Revision (Build) Version: {build}")
+        logging.info(
+            f"NuGet version parts:\n"
+            f"  Major Version: {major}\n"
+            f"  Minor Version: {minor}\n"
+            f"  Patch Version: {patch}\n"
+            f"  Pre-Release Version {prerelease}\n"
+            f"  Revision (Build) Version: {build}"
+        )
 
         return reformed_ver
 
@@ -165,7 +169,7 @@ class NugetDependency(ExternalDependency):
             cmd = NugetDependency.GetNugetCmd()
             cmd += ["locals", "global-packages", "-list"]
             return_buffer = StringIO()
-            if (RunCmd(cmd[0], " ".join(cmd[1:]), outstream=return_buffer) == 0):
+            if RunCmd(cmd[0], " ".join(cmd[1:]), outstream=return_buffer) == 0:
                 # Seek to the beginning of the output buffer and capture the output.
                 return_buffer.seek(0)
                 return_string = return_buffer.read()
@@ -187,24 +191,31 @@ class NugetDependency(ExternalDependency):
         try:
             nuget_version = NugetDependency.normalize_version(self.version)
         except ValueError:
-            logging.error(f"NuGet dependency {self.name} has an invalid "
-                          f"version string: {self.version}")
+            logging.error(
+                f"NuGet dependency {self.name} has an invalid "
+                f"version string: {self.version}"
+            )
 
         cache_search_path = os.path.join(
-            self.nuget_cache_path, package_name.lower(), nuget_version)
+            self.nuget_cache_path, package_name.lower(), nuget_version
+        )
         inner_cache_search_path = os.path.join(cache_search_path, package_name)
         if os.path.isdir(cache_search_path):
             # If we found a cache for this version, let's use it.
             if os.path.isdir(inner_cache_search_path):
                 logging.info(self.nuget_cache_path)
                 logging.info(
-                    "Local Cache found for Nuget package '%s'. Skipping fetch.", package_name)
+                    "Local Cache found for Nuget package '%s'. Skipping fetch.",
+                    package_name,
+                )
                 shutil.copytree(inner_cache_search_path, self.contents_dir)
                 result = True
             # If this cache doesn't match our heuristic, let's warn the user.
             else:
                 logging.warning(
-                    "Local Cache found for Nuget package '%s', but could not find contents. Malformed?", package_name)
+                    "Local Cache found for Nuget package '%s', but could not find contents. Malformed?",
+                    package_name,
+                )
 
         return result
 
@@ -234,7 +245,9 @@ class NugetDependency(ExternalDependency):
         found_cred_provider = False
         for out_line in output_stream:
             line = out_line.strip()
-            if line.startswith("CredentialProvider") or line.startswith("[CredentialProvider"):
+            if line.startswith("CredentialProvider") or line.startswith(
+                "[CredentialProvider"
+            ):
                 found_cred_provider = True
             if line.endswith("as a credential provider plugin."):
                 found_cred_provider = True
@@ -243,10 +256,14 @@ class NugetDependency(ExternalDependency):
         # this gives cred providers a chance to prompt for input since they don't use stdin
         if ret != 0:
             # If we're in non interactive and we have a credential provider
-            if non_interactive and found_cred_provider:  # we should be interactive next time
+            if (
+                non_interactive and found_cred_provider
+            ):  # we should be interactive next time
                 self._attempt_nuget_install(install_dir, False)
             else:
-                raise RuntimeError(f"[Nuget] We failed to install this version {self.version} of {package_name}")
+                raise RuntimeError(
+                    f"[Nuget] We failed to install this version {self.version} of {package_name}"
+                )
 
     def fetch(self):
         """Fetches the dependency using internal state from the init."""

--- a/edk2toolext/environment/external_dependency.py
+++ b/edk2toolext/environment/external_dependency.py
@@ -50,22 +50,21 @@ class ExternalDependency(object):
         #
         # Set the data for this object.
         #
-        self.scope = descriptor['scope']
-        self.type = descriptor['type']
-        self.name = descriptor['name']
-        self.source = descriptor['source']
-        self.version = descriptor['version']
-        self.flags = descriptor.get('flags', None)
-        self.var_name = descriptor.get('var_name', None)
-        self.error_msg = descriptor.get('error_msg', None)
+        self.scope = descriptor["scope"]
+        self.type = descriptor["type"]
+        self.name = descriptor["name"]
+        self.source = descriptor["source"]
+        self.version = descriptor["version"]
+        self.flags = descriptor.get("flags", None)
+        self.var_name = descriptor.get("var_name", None)
+        self.error_msg = descriptor.get("error_msg", None)
         self.global_cache_path = None
 
-        self.descriptor_location = os.path.dirname(
-            descriptor['descriptor_file'])
+        self.descriptor_location = os.path.dirname(descriptor["descriptor_file"])
         self.contents_dir = os.path.join(
-            self.descriptor_location, self.name + "_extdep")
-        self.state_file_path = os.path.join(
-            self.contents_dir, "extdep_state.yaml")
+            self.descriptor_location, self.name + "_extdep"
+        )
+        self.state_file_path = os.path.join(self.contents_dir, "extdep_state.yaml")
         self.published_path = self.compute_published_path()
 
     def set_global_cache_path(self, global_cache_path):
@@ -84,9 +83,11 @@ class ExternalDependency(object):
         if self.flags and "host_specific" in self.flags and self.verify():
             host = GetHostInfo()
 
-            logging.info("Computing path for {0} located at {1} on {2}".format(self.name,
-                                                                               self.contents_dir,
-                                                                               str(host)))
+            logging.info(
+                "Computing path for {0} located at {1} on {2}".format(
+                    self.name, self.contents_dir, str(host)
+                )
+            )
 
             acceptable_names = []
 
@@ -111,7 +112,11 @@ class ExternalDependency(object):
                 logging.debug("{0} does not exist".format(dirname))
 
             if new_published_path is None:
-                logging.error("Could not find appropriate folder for {0}. {1}".format(self.name, str(host)))
+                logging.error(
+                    "Could not find appropriate folder for {0}. {1}".format(
+                        self.name, str(host)
+                    )
+                )
                 new_published_path = self.contents_dir
 
         if self.flags and "include_separator" in self.flags:
@@ -130,8 +135,8 @@ class ExternalDependency(object):
         result = None
         if self.global_cache_path is not None and os.path.isdir(self.global_cache_path):
             subpath_calc = hashlib.sha1()
-            subpath_calc.update(self.version.encode('utf-8'))
-            subpath_calc.update(self.source.encode('utf-8'))
+            subpath_calc.update(self.version.encode("utf-8"))
+            subpath_calc.update(self.source.encode("utf-8"))
             subpath = subpath_calc.hexdigest()
             result = os.path.join(self.global_cache_path, self.type, self.name, subpath)
         return result
@@ -183,7 +188,7 @@ class ExternalDependency(object):
             result = False
 
         # If loaded, check the version.
-        if result and state_data['version'] != self.version:
+        if result and state_data["version"] != self.version:
             result = False
 
         logging.debug("Verify '%s' returning '%s'." % (self.name, result))
@@ -193,22 +198,24 @@ class ExternalDependency(object):
         """Reports the version of the external dependency."""
         state_data = self.get_state_file_data()
         version = self.version
-        if state_data and state_data['verify'] is False:
+        if state_data and state_data["verify"] is False:
             version = "UNVERIFIED"
-        version_aggregator.GetVersionAggregator().ReportVersion(self.name,
-                                                                version,
-                                                                version_aggregator.VersionTypes.INFO,
-                                                                self.descriptor_location)
+        version_aggregator.GetVersionAggregator().ReportVersion(
+            self.name,
+            version,
+            version_aggregator.VersionTypes.INFO,
+            self.descriptor_location,
+        )
 
     def update_state_file(self):
         """Updates the file representing the state of the dependency."""
-        with open(self.state_file_path, 'w+') as file:
-            yaml.dump({'version': self.version, 'verify': True}, file)
+        with open(self.state_file_path, "w+") as file:
+            yaml.dump({"version": self.version, "verify": True}, file)
 
     def get_state_file_data(self):
         """Loads the state file data into a json file and returns it."""
         try:
-            with open(self.state_file_path, 'r') as file:
+            with open(self.state_file_path, "r") as file:
                 return yaml.safe_load(file)
         except Exception:
             return None
@@ -223,15 +230,18 @@ def ExtDepFactory(descriptor):
     from edk2toolext.environment.extdeptypes.web_dependency import WebDependency
     from edk2toolext.environment.extdeptypes.nuget_dependency import NugetDependency
     from edk2toolext.environment.extdeptypes.git_dependency import GitDependency
-    from edk2toolext.environment.extdeptypes.az_cli_universal_dependency import AzureCliUniversalDependency
-    if descriptor['type'] == NugetDependency.TypeString:
+    from edk2toolext.environment.extdeptypes.az_cli_universal_dependency import (
+        AzureCliUniversalDependency,
+    )
+
+    if descriptor["type"] == NugetDependency.TypeString:
         return NugetDependency(descriptor)
-    elif descriptor['type'] == WebDependency.TypeString:
+    elif descriptor["type"] == WebDependency.TypeString:
         return WebDependency(descriptor)
-    elif descriptor['type'] == GitDependency.TypeString:
+    elif descriptor["type"] == GitDependency.TypeString:
         return GitDependency(descriptor)
-    elif descriptor['type'] == AzureCliUniversalDependency.TypeString:
+    elif descriptor["type"] == AzureCliUniversalDependency.TypeString:
         AzureCliUniversalDependency.VerifyToolDependencies()
         return AzureCliUniversalDependency(descriptor)
 
-    raise ValueError("Unknown extdep type '%s' requested!" % descriptor['type'])
+    raise ValueError("Unknown extdep type '%s' requested!" % descriptor["type"])

--- a/edk2toolext/environment/multiple_workspace.py
+++ b/edk2toolext/environment/multiple_workspace.py
@@ -26,7 +26,8 @@ class MultipleWorkspace(object):
         WORKSPACE (str): defined the current workspace
         PACKAGES_PATH (str): defined the other WORKSPACE
     """
-    WORKSPACE = ''
+
+    WORKSPACE = ""
     PACKAGES_PATH = None
 
     @classmethod
@@ -42,7 +43,7 @@ class MultipleWorkspace(object):
             (str): Converted path.
         """
         if str(os.path.normcase(Path)).startswith(Ws):
-            return os.path.join(Ws, Path[len(Ws) + 1:])
+            return os.path.join(Ws, Path[len(Ws) + 1 :])
         return Path
 
     @classmethod
@@ -56,8 +57,10 @@ class MultipleWorkspace(object):
         """
         cls.WORKSPACE = Ws
         if PackagesPath:
-            cls.PACKAGES_PATH = [cls.convertPackagePath(Ws, os.path.normpath(
-                Path.strip())) for Path in PackagesPath.split(os.pathsep)]
+            cls.PACKAGES_PATH = [
+                cls.convertPackagePath(Ws, os.path.normpath(Path.strip()))
+                for Path in PackagesPath.split(os.pathsep)
+            ]
         else:
             cls.PACKAGES_PATH = []
 
@@ -134,7 +137,7 @@ class MultipleWorkspace(object):
         Returns:
             (Str): Path string including the $(WORKSPACE)
         """
-        TAB_WORKSPACE = '$(WORKSPACE)'
+        TAB_WORKSPACE = "$(WORKSPACE)"
         if TAB_WORKSPACE in PathStr:
             PathList = PathStr.split()
             if PathList:
@@ -149,7 +152,7 @@ class MultipleWorkspace(object):
                                 if os.path.exists(Path):
                                     break
                         PathList[i] = str[0:MacroStartPos] + Path
-            PathStr = ' '.join(PathList)
+            PathStr = " ".join(PathList)
         return PathStr
 
     @classmethod

--- a/edk2toolext/environment/plugin_manager.py
+++ b/edk2toolext/environment/plugin_manager.py
@@ -23,6 +23,7 @@ class PluginDescriptor(object):
         Name (str): name attribute from descriptor
         Module (obj): module attribute from descriptor
     """
+
     def __init__(self, t):
         """Inits the Plugin descriptor with the Descriptor."""
         self.descriptor = t
@@ -41,6 +42,7 @@ class PluginManager(object):
     Attributes:
         Descriptors (List[PluginDescriptor]): list of plugin descriptors
     """
+
     def __init__(self):
         """Inits an empty plugin manager."""
         self.Descriptors = []
@@ -53,7 +55,7 @@ class PluginManager(object):
             return []
         for a in newlist:
             b = PluginDescriptor(a)
-            if (self._load(b) == 0):
+            if self._load(b) == 0:
                 val = env.GetValue(b.Module.upper())
                 if val and val == "skip":
                     logging.info(f"{b.Module} turned off by environment variable")
@@ -67,7 +69,7 @@ class PluginManager(object):
         """Return list of all plugins of a given class."""
         temp = []
         for a in self.Descriptors:
-            if (isinstance(a.Obj, classobj)):
+            if isinstance(a.Obj, classobj):
                 temp.append(a)
         return temp
 
@@ -84,15 +86,20 @@ class PluginManager(object):
         PluginDescriptor.Obj = None
 
         py_file_path = PluginDescriptor.descriptor["module"] + ".py"
-        py_module_path = os.path.join(os.path.dirname(os.path.abspath(
-            PluginDescriptor.descriptor["descriptor_file"])), py_file_path)
+        py_module_path = os.path.join(
+            os.path.dirname(
+                os.path.abspath(PluginDescriptor.descriptor["descriptor_file"])
+            ),
+            py_file_path,
+        )
         py_module_name = "UefiBuild_Plugin_" + PluginDescriptor.descriptor["module"]
 
         logging.debug("Loading Plugin from %s", py_module_path)
 
         try:
             spec = importlib.util.spec_from_file_location(
-                py_module_name, py_module_path)
+                py_module_name, py_module_path
+            )
             module = importlib.util.module_from_spec(spec)
             sys.modules[py_module_name] = module
 
@@ -103,8 +110,9 @@ class PluginManager(object):
             spec.loader.exec_module(module)
         except Exception:
             exc_info = sys.exc_info()
-            logging.error("Failed to import plugin: %s",
-                          py_module_path, exc_info=exc_info)
+            logging.error(
+                "Failed to import plugin: %s", py_module_path, exc_info=exc_info
+            )
             return -1
 
         # Instantiate the plugin
@@ -113,8 +121,9 @@ class PluginManager(object):
             PluginDescriptor.Obj = obj()
         except AttributeError:
             exc_info = sys.exc_info()
-            logging.error("Failed to instantiate plugin: %s",
-                          py_module_path, exc_info=exc_info)
+            logging.error(
+                "Failed to instantiate plugin: %s", py_module_path, exc_info=exc_info
+            )
             return -1
 
         return 0

--- a/edk2toolext/environment/plugintypes/ci_build_plugin.py
+++ b/edk2toolext/environment/plugintypes/ci_build_plugin.py
@@ -14,7 +14,18 @@ from typing import List, Tuple
 
 class ICiBuildPlugin(object):
     """Plugin that supports adding tests or operations to the ci environment."""
-    def RunBuildPlugin(self, packagename, Edk2pathObj, pkgconfig, environment, PLM, PLMHelper, tc, output_stream):
+
+    def RunBuildPlugin(
+        self,
+        packagename,
+        Edk2pathObj,
+        pkgconfig,
+        environment,
+        PLM,
+        PLMHelper,
+        tc,
+        output_stream,
+    ):
         """External function of plugin.
 
         This function is used to perform the task of the CiBuild Plugin
@@ -63,8 +74,12 @@ class ICiBuildPlugin(object):
         """
         return ["NO-TARGET"]
 
-    def WalkDirectoryForExtension(self, extensionlist: List[str], directory: os.PathLike,
-                                  ignorelist: List[str] = None) -> List[os.PathLike]:
+    def WalkDirectoryForExtension(
+        self,
+        extensionlist: List[str],
+        directory: os.PathLike,
+        ignorelist: List[str] = None,
+    ) -> List[os.PathLike]:
         """Walks a file directory recursively for all items ending in certain extension.
 
         Args:
@@ -110,9 +125,9 @@ class ICiBuildPlugin(object):
                 for Extension in extensionlist_lower:
                     if File.lower().endswith(Extension):
                         ignoreIt = False
-                        if (ignorelist is not None):
+                        if ignorelist is not None:
                             for c in ignorelist_lower:
-                                if (File.lower().startswith(c)):
+                                if File.lower().startswith(c):
                                     ignoreIt = True
                                     break
                         if not ignoreIt:

--- a/edk2toolext/environment/plugintypes/uefi_helper_plugin.py
+++ b/edk2toolext/environment/plugintypes/uefi_helper_plugin.py
@@ -31,6 +31,7 @@ class HelperFunctions(object):
     Attributes:
         RegisteredFunctions(dict): registered functions
     """
+
     def __init__(self):
         """Initializes instance."""
         self.RegisteredFunctions = {}
@@ -43,8 +44,7 @@ class HelperFunctions(object):
         logging.debug("Logging all Registered Helper Functions:")
         for name, file in self.RegisteredFunctions.items():
             logging.debug("  Function %s registered from file %s", name, file)
-        logging.debug("Finished logging %d functions",
-                      len(self.RegisteredFunctions))
+        logging.debug("Finished logging %d functions", len(self.RegisteredFunctions))
 
     def Register(self, name, function, filepath):
         """Registers a plugin.
@@ -60,9 +60,11 @@ class HelperFunctions(object):
         !!! tip
             ```os.path.abspath(__file__)```
         """
-        if (name in self.RegisteredFunctions.keys()):
-            raise Exception("Function %s already registered from plugin file %s.  Can't register again from %s" % (
-                name, self.RegisteredFunctions[name], filepath))
+        if name in self.RegisteredFunctions.keys():
+            raise Exception(
+                "Function %s already registered from plugin file %s.  Can't register again from %s"
+                % (name, self.RegisteredFunctions[name], filepath)
+            )
         setattr(self, name, function)
         self.RegisteredFunctions[name] = filepath
 
@@ -75,7 +77,7 @@ class HelperFunctions(object):
         Returns:
             (bool): if the function is registered or not.
         """
-        if (name in self.RegisteredFunctions.keys()):
+        if name in self.RegisteredFunctions.keys():
             return True
         else:
             return False
@@ -99,8 +101,7 @@ class HelperFunctions(object):
             try:
                 Descriptor.Obj.RegisterHelpers(self)
             except Exception as e:
-                logging.warning(
-                    "Unable to register {0}".format(Descriptor.Name))
+                logging.warning("Unable to register {0}".format(Descriptor.Name))
                 logging.info(e)
                 error += 1
         return error

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -43,7 +43,9 @@ def resolve(file_system_path, dependency, force=False, ignore=False, update_ok=F
     git_path = os.path.abspath(file_system_path)
 
     # check if we have a path in our dependency
-    if "Path" in dependency and not git_path.endswith(os.path.relpath(dependency["Path"])):
+    if "Path" in dependency and not git_path.endswith(
+        os.path.relpath(dependency["Path"])
+    ):
         # if we don't already the the path from the dependency at the end of the path we've been giving
         git_path = os.path.join(git_path, dependency["Path"])
     logger.info(f"Resolving at {git_path}")
@@ -79,21 +81,25 @@ def resolve(file_system_path, dependency, force=False, ignore=False, update_ok=F
         if force:
             clear_folder(git_path)
             logger.warning(
-                f"Folder {git_path} is not a git repo and is being overwritten!")
+                f"Folder {git_path} is not a git repo and is being overwritten!"
+            )
             clone_repo(git_path, dependency)
             checkout(git_path, dependency, True, False)
             return
         else:
-            if (ignore):
+            if ignore:
                 logger.warning(
                     f"Folder {git_path} is not a git repo but Force parameter not used.  "
-                    "Ignore State Allowed.")
+                    "Ignore State Allowed."
+                )
                 return
             else:
                 logger.critical(
-                    f"Folder {git_path} is not a git repo and it is not empty.")
+                    f"Folder {git_path} is not a git repo and it is not empty."
+                )
                 raise Exception(
-                    f"Folder {git_path} is not a git repo and it is not empty")
+                    f"Folder {git_path} is not a git repo and it is not empty"
+                )
 
     ##########################################################################
     # 4. A git repo exists, but it is dirty. Only re-clone and checkout if   #
@@ -103,21 +109,21 @@ def resolve(file_system_path, dependency, force=False, ignore=False, update_ok=F
         if force:
             clear_folder(git_path)
             logger.warning(
-                f"Folder {git_path} is a git repo but is dirty and is being overwritten as requested!")
+                f"Folder {git_path} is a git repo but is dirty and is being overwritten as requested!"
+            )
             clone_repo(git_path, dependency)
             checkout(git_path, dependency, True, False)
             return
         else:
-            if (ignore):
+            if ignore:
                 logger.warning(
                     f"Folder {git_path} is a git repo but is dirty and Force parameter not used.  "
-                    "Ignore State Allowed.")
+                    "Ignore State Allowed."
+                )
                 return
             else:
-                logger.critical(
-                    f"Folder {git_path} is a git repo and is dirty.")
-                raise Exception(
-                    f"Folder {git_path} is a git repo and is dirty.")
+                logger.critical(f"Folder {git_path} is a git repo and is dirty.")
+                raise Exception(f"Folder {git_path} is a git repo and is dirty.")
 
     ##########################################################################
     # 5. The origin of the repo does not match. Only re-clone from the       #
@@ -128,7 +134,8 @@ def resolve(file_system_path, dependency, force=False, ignore=False, update_ok=F
             clear_folder(git_path)
             logger.warning(
                 f"Folder {git_path} is a git repo but it is at a different repo and is "
-                "being overwritten as requested!")
+                "being overwritten as requested!"
+            )
             clone_repo(git_path, dependency)
             checkout(git_path, dependency, True, False)
             return
@@ -136,13 +143,20 @@ def resolve(file_system_path, dependency, force=False, ignore=False, update_ok=F
             if ignore:
                 logger.warning(
                     f"Folder {git_path} is a git repo pointed at a different remote.  "
-                    "Can't checkout or sync state")
+                    "Can't checkout or sync state"
+                )
                 return
             else:
-                logger.critical("The URL of the git Repo {2} in the folder {0} does not match {1}".format(
-                    git_path, dependency["Url"], repo_details(git_path).url))
-                raise Exception("The URL of the git Repo {2} in the folder {0} does not match {1}".format(
-                    git_path, dependency["Url"], repo_details(git_path).url))
+                logger.critical(
+                    "The URL of the git Repo {2} in the folder {0} does not match {1}".format(
+                        git_path, dependency["Url"], repo_details(git_path).url
+                    )
+                )
+                raise Exception(
+                    "The URL of the git Repo {2} in the folder {0} does not match {1}".format(
+                        git_path, dependency["Url"], repo_details(git_path).url
+                    )
+                )
 
     ##########################################################################
     # 6. The repo is normal, Perform a regular checkout.                     #
@@ -151,7 +165,14 @@ def resolve(file_system_path, dependency, force=False, ignore=False, update_ok=F
     return
 
 
-def resolve_all(workspace_path, dependencies, force=False, ignore=False, update_ok=False, omnicache_dir=None):
+def resolve_all(
+    workspace_path,
+    dependencies,
+    force=False,
+    ignore=False,
+    update_ok=False,
+    omnicache_dir=None,
+):
     """Resolves all repos.
 
     Args:
@@ -175,8 +196,12 @@ def resolve_all(workspace_path, dependencies, force=False, ignore=False, update_
         logger.log(edk2_logging.PROGRESS, f"Syncing {dep_path}")
         if "ReferencePath" not in dependency and omnicache_dir:
             dependency["ReferencePath"] = omnicache_dir
-        if "ReferencePath" in dependency:  # make sure that the omnicache dir is relative to the working directory
-            dependency["ReferencePath"] = os.path.join(workspace_path, dependency["ReferencePath"])
+        if (
+            "ReferencePath" in dependency
+        ):  # make sure that the omnicache dir is relative to the working directory
+            dependency["ReferencePath"] = os.path.join(
+                workspace_path, dependency["ReferencePath"]
+            )
         git_path = os.path.join(workspace_path, dep_path)
         repos.append(git_path)
         resolve(git_path, dependency, force, ignore, update_ok)
@@ -186,8 +211,14 @@ def resolve_all(workspace_path, dependencies, force=False, ignore=False, update_
         git_path = os.path.join(workspace_path, dependency["Path"])
         details = repo_details(git_path)
         # print out details
-        logger.info("{3} = Git Details: Url: {0} Branch {1} Commit {2}".format(
-            details["Url"], details["Branch"], details["Head"]["HexSha"], dependency["Path"]))
+        logger.info(
+            "{3} = Git Details: Url: {0} Branch {1} Commit {2}".format(
+                details["Url"],
+                details["Branch"],
+                details["Head"]["HexSha"],
+                dependency["Path"],
+            )
+        )
 
     return repos
 
@@ -216,23 +247,30 @@ def repo_details(abs_file_system_path):
         "Branch": None,
         "Submodules": [],
         "Remotes": [],
-        "Worktrees": []
+        "Worktrees": [],
     }
 
     try:
         with Repo(abs_file_system_path) as repo:
             # Active Branch
-            details["Branch"] = 'HEAD' if repo.head.is_detached else repo.active_branch.name
+            details["Branch"] = (
+                "HEAD" if repo.head.is_detached else repo.active_branch.name
+            )
 
             # Worktrees
             worktree_list = []
             worktrees = repo.git.worktree("list", "--porcelain", "-z")
-            for worktree in filter(lambda worktree: worktree.startswith("worktree"), worktrees.split('\0')):
+            for worktree in filter(
+                lambda worktree: worktree.startswith("worktree"), worktrees.split("\0")
+            ):
                 worktree_list.append(Path(worktree.split(" ")[1]))
                 details["Worktrees"] = worktree_list
 
             # head information
-            details["Head"] = {"HexSha": str(repo.head.commit.hexsha), "HexShaShort": str(repo.head.commit.hexsha[:7])}
+            details["Head"] = {
+                "HexSha": str(repo.head.commit.hexsha),
+                "HexShaShort": str(repo.head.commit.hexsha[:7]),
+            }
             details["Valid"] = True
             details["Bare"] = repo.bare
             details["Dirty"] = repo.is_dirty(untracked_files=True)
@@ -249,8 +287,11 @@ def clear_folder(abs_file_system_path):
     Args:
         abs_file_system_path (PathLike): Directory to delete.
     """
-    logger.warning("WARNING: Deleting contents of folder {0} to make way for Git repo".format(
-        abs_file_system_path))
+    logger.warning(
+        "WARNING: Deleting contents of folder {0} to make way for Git repo".format(
+            abs_file_system_path
+        )
+    )
     rmtree(abs_file_system_path)
 
 
@@ -290,20 +331,26 @@ def clone_repo(abs_file_system_path, DepObj):
         params = []
         if branch:
             shallow = True
-            params.append('--branch')
+            params.append("--branch")
             params.append(branch)
-            params.append('--single-branch')
+            params.append("--single-branch")
         if shallow:
-            params.append('--depth=5')
+            params.append("--depth=5")
         if reference:
-            params.append('--reference')
-            params.append('reference')
+            params.append("--reference")
+            params.append("reference")
         else:
-            params.append("--recurse-submodules")  # if we don't have a reference we can just recurse the submodules
+            params.append(
+                "--recurse-submodules"
+            )  # if we don't have a reference we can just recurse the submodules
 
     # Run the command
     try:
-        repo = Repo.clone_from(DepObj["Url"], dest, multi_options=_build_params_list(branch, shallow, reference))
+        repo = Repo.clone_from(
+            DepObj["Url"],
+            dest,
+            multi_options=_build_params_list(branch, shallow, reference),
+        )
     except GitCommandError:
         repo = None
 
@@ -312,21 +359,31 @@ def clone_repo(abs_file_system_path, DepObj):
             return (dest, False)
 
         # attempt a retry without the reference
-        logger.warning("Reattempting to clone without a reference. {0}".format(DepObj["Url"]))
+        logger.warning(
+            "Reattempting to clone without a reference. {0}".format(DepObj["Url"])
+        )
 
         try:
-            repo = Repo.clone_from(DepObj["Url"], dest, multi_options=_build_params_list(branch, shallow))
+            repo = Repo.clone_from(
+                DepObj["Url"], dest, multi_options=_build_params_list(branch, shallow)
+            )
         except GitCommandError:
             return (dest, False)
 
     # Repo cloned, perform submodule update if necessary
     if reference:
-        repo.git.submodule('update', '--init', '--recursive', '--reference', reference)
+        repo.git.submodule("update", "--init", "--recursive", "--reference", reference)
     repo.close()
     return (dest, True)
 
 
-def checkout(abs_file_system_path, dep, update_ok=False, ignore_dep_state_mismatch=False, force=False):
+def checkout(
+    abs_file_system_path,
+    dep,
+    update_ok=False,
+    ignore_dep_state_mismatch=False,
+    force=False,
+):
     """Checks out a commit or branch.
 
     Args:
@@ -355,16 +412,18 @@ def checkout(abs_file_system_path, dep, update_ok=False, ignore_dep_state_mismat
             else:
                 head = details["Head"]
                 if commit in [head["HexSha"], head["HexShaShort"]]:
-                    logger.debug(
-                        f"Dependency {dep['Path']} state ok without update")
+                    logger.debug(f"Dependency {dep['Path']} state ok without update")
                 elif ignore_dep_state_mismatch:
                     logger.warning(
-                        f"Dependency {dep['Path']} is not in sync with requested commit.  Ignore state allowed")
+                        f"Dependency {dep['Path']} is not in sync with requested commit.  Ignore state allowed"
+                    )
                 else:
                     logger.critical(
-                        f"Dependency {dep['Path']} is not in sync with requested commit.  Fail.")
+                        f"Dependency {dep['Path']} is not in sync with requested commit.  Fail."
+                    )
                     raise Exception(
-                        f"Dependency {dep['Path']} is not in sync with requested commit.  Fail.")
+                        f"Dependency {dep['Path']} is not in sync with requested commit.  Fail."
+                    )
             return
 
         elif "Branch" in dep:
@@ -381,20 +440,23 @@ def checkout(abs_file_system_path, dep, update_ok=False, ignore_dep_state_mismat
                 repo.git.submodule("update", "--init", "--recursive")
             else:
                 if details["Branch"] == dep["Branch"]:
-                    logger.debug(
-                        f"Dependency {dep['Path']} state ok without update")
+                    logger.debug(f"Dependency {dep['Path']} state ok without update")
                 elif ignore_dep_state_mismatch:
                     logger.warning(
-                        f"Dependency {dep['Path']} is not in sync with requested branch.  Ignore state allowed")
+                        f"Dependency {dep['Path']} is not in sync with requested branch.  Ignore state allowed"
+                    )
                 else:
                     error = "Dependency {0} is not in sync with requested branch. Expected: {1}. Got {2} Fail.".format(
-                        dep["Path"], dep["Branch"], details["Branch"])
+                        dep["Path"], dep["Branch"], details["Branch"]
+                    )
                     logger.critical(error)
                     raise Exception(error)
             return
 
         else:
-            raise Exception("Branch or Commit must be specified for {0}".format(dep["Path"]))
+            raise Exception(
+                "Branch or Commit must be specified for {0}".format(dep["Path"])
+            )
 
 
 def clean(abs_file_system_path, ignore_files=[]):
@@ -434,19 +496,18 @@ def submodule_resolve(abs_file_system_path, submodule, omnicache_path=None):
         (NoSuchPathError): The path does not exist
     """
     with Repo(abs_file_system_path) as repo:
+        logger.debug(f"Syncing {submodule.path}")
+        repo.git.submodule("sync", "--", submodule.path)
 
-        logger.debug(f'Syncing {submodule.path}')
-        repo.git.submodule('sync', '--', submodule.path)
-
-        params = ['update', '--init']
+        params = ["update", "--init"]
         if submodule.recursive:
             params.append("--recursive")
         if omnicache_path:
-            params.append('--reference')
+            params.append("--reference")
             params.append(omnicache_path)
         params.append(submodule.path)
-        logger.debug(f'Updating {submodule.path}')
+        logger.debug(f"Updating {submodule.path}")
         repo.git.submodule(*params)
 
     with Repo(Path(abs_file_system_path, submodule.path)) as _:
-        logger.debug(f'{submodule.path} is valid and resolved.')
+        logger.debug(f"{submodule.path} is valid and resolved.")

--- a/edk2toolext/environment/shell_environment.py
+++ b/edk2toolext/environment/shell_environment.py
@@ -24,10 +24,10 @@ MY_LOGGER = logging.getLogger(LOGGING_GROUP)
 # Copy the Singleton pattern from...
 #   https://stackoverflow.com/a/6798042
 #
-class Singleton(type): # noqa
+class Singleton(type):  # noqa
     _instances = {}
 
-    def __call__(cls, *args, **kwargs): # noqa
+    def __call__(cls, *args, **kwargs):  # noqa
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
@@ -40,6 +40,7 @@ class ShellEnvironment(metaclass=Singleton):
     screenshots (checkpoints) that are stored and can be accessed
     later.
     """
+
     # Easy definition for the very first checkpoint
     # when the environment is first created.
     INITIAL_CHECKPOINT = 0
@@ -74,7 +75,7 @@ class ShellEnvironment(metaclass=Singleton):
             self.active_environ[key] = value
 
         # Record the PATH elements of the current environment.
-        path = self.active_environ.get('PATH', "")
+        path = self.active_environ.get("PATH", "")
 
         # Filter removes empty elements.
         # List creates an actual list rather than a generator.
@@ -130,12 +131,14 @@ class ShellEnvironment(metaclass=Singleton):
         4. active_buildvars
         """
         new_index = len(self.checkpoints)
-        self.checkpoints.append({
-            'environ': copy.copy(self.active_environ),
-            'path': self.active_path,
-            'pypath': self.active_pypath,
-            'buildvars': copy.copy(self.active_buildvars)
-        })
+        self.checkpoints.append(
+            {
+                "environ": copy.copy(self.active_environ),
+                "path": self.active_path,
+                "pypath": self.active_pypath,
+                "buildvars": copy.copy(self.active_buildvars),
+            }
+        )
 
         return new_index
 
@@ -143,10 +146,10 @@ class ShellEnvironment(metaclass=Singleton):
         """Restore a specific checkpoint."""
         if index < len(self.checkpoints):
             check_point = self.checkpoints[index]
-            self.active_environ = copy.copy(check_point['environ'])
-            self.active_path = check_point['path']
-            self.active_pypath = check_point['pypath']
-            self.active_buildvars = copy.copy(check_point['buildvars'])
+            self.active_environ = copy.copy(check_point["environ"])
+            self.active_path = check_point["path"]
+            self.active_pypath = check_point["pypath"]
+            self.active_buildvars = copy.copy(check_point["buildvars"])
 
             self.export_environment()
 
@@ -267,8 +270,14 @@ class ShellEnvironment(metaclass=Singleton):
             new_path_element (str): element to replace with
 
         """
-        self.logger.debug("Replacing PATH element {0} with {1}".format(old_path_element, new_path_element))
-        self._internal_set_path([x if x != old_path_element else new_path_element for x in self.active_path])
+        self.logger.debug(
+            "Replacing PATH element {0} with {1}".format(
+                old_path_element, new_path_element
+            )
+        )
+        self._internal_set_path(
+            [x if x != old_path_element else new_path_element for x in self.active_path]
+        )
 
     def replace_pypath_element(self, old_pypath_element, new_pypath_element):
         """Replaces the PYPATH element.
@@ -281,8 +290,17 @@ class ShellEnvironment(metaclass=Singleton):
             new_pypath_element (str): element to replace with
 
         """
-        self.logger.debug("Replacing PYPATH element {0} with {1}".format(old_pypath_element, new_pypath_element))
-        self._internal_set_pypath([x if x != old_pypath_element else new_pypath_element for x in self.active_pypath])
+        self.logger.debug(
+            "Replacing PYPATH element {0} with {1}".format(
+                old_pypath_element, new_pypath_element
+            )
+        )
+        self._internal_set_pypath(
+            [
+                x if x != old_pypath_element else new_pypath_element
+                for x in self.active_pypath
+            ]
+        )
 
     def remove_path_element(self, path_element):
         """Removes the PATH element.
@@ -306,7 +324,9 @@ class ShellEnvironment(metaclass=Singleton):
             pypath_element (str): pypath element to remove
         """
         self.logger.debug("Removing PYPATH element {0}".format(pypath_element))
-        self._internal_set_pypath([x for x in self.active_pypath if x != pypath_element])
+        self._internal_set_pypath(
+            [x for x in self.active_pypath if x != pypath_element]
+        )
 
     def get_build_var(self, var_name):
         """Gets the build variable.
@@ -334,8 +354,9 @@ class ShellEnvironment(metaclass=Singleton):
             var_data (obj): data to set
         """
         self.logger.debug(
-            "Updating BUILD VAR element '%s': '%s'." % (var_name, var_data))
-        self.active_buildvars.SetValue(var_name, var_data, '', overridable=True)
+            "Updating BUILD VAR element '%s': '%s'." % (var_name, var_data)
+        )
+        self.active_buildvars.SetValue(var_name, var_data, "", overridable=True)
 
     def get_shell_var(self, var_name):
         """Gets the shell variable.
@@ -361,13 +382,14 @@ class ShellEnvironment(metaclass=Singleton):
         # Check for the "special" shell vars.
         if var_data is None:
             raise ValueError("Unexpected var_data: None")
-        if var_name.upper() == 'PATH':
+        if var_name.upper() == "PATH":
             self.set_path(var_data)
-        elif var_name.upper() == 'PYTHONPATH':
+        elif var_name.upper() == "PYTHONPATH":
             self.set_pypath(var_data)
         else:
             self.logger.debug(
-                "Updating SHELL VAR element '%s': '%s'." % (var_name, var_data))
+                "Updating SHELL VAR element '%s': '%s'." % (var_name, var_data)
+            )
             self.active_environ[var_name] = var_data
             os.environ[var_name] = var_data
 
@@ -387,6 +409,7 @@ def GetBuildVars():
     Returns:
         (VarDict): A special dictionary containing build vars
     """
+
     #
     # Tricky!
     # Define a wrapper class that always forwards commands to the
@@ -424,7 +447,9 @@ def RevertBuildVars():
     global checkpoint_list
     if len(checkpoint_list) > 0:
         last_checkpoint = checkpoint_list.pop()
-        MY_LOGGER.debug("Reverting to checkpoint {0} for build vars".format(last_checkpoint))
+        MY_LOGGER.debug(
+            "Reverting to checkpoint {0} for build vars".format(last_checkpoint)
+        )
         ShellEnvironment().restore_checkpoint(last_checkpoint)
     else:
         MY_LOGGER.getLogger("No more checkpoints!")

--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -76,28 +76,87 @@ class UefiBuilder(object):
         Args:
             parserObj (argparser): argparser object
         """
-        parserObj.add_argument("--SKIPBUILD", "--skipbuild", "--SkipBuild", dest="SKIPBUILD",
-                               action='store_true', default=False, help="Skip the build process")
-        parserObj.add_argument("--SKIPPREBUILD", "--skipprebuild", "--SkipPrebuild", dest="SKIPPREBUILD",
-                               action='store_true', default=False, help="Skip prebuild process")
-        parserObj.add_argument("--SKIPPOSTBUILD", "--skippostbuild", "--SkipPostBuild", dest="SKIPPOSTBUILD",
-                               action='store_true', default=False, help="Skip postbuild process")
-        parserObj.add_argument("--FLASHONLY", "--flashonly", "--FlashOnly", dest="FLASHONLY",
-                               action='store_true', default=False, help="Flash rom after build.")
-        parserObj.add_argument("--FLASHROM", "--flashrom", "--FlashRom", dest="FLASHROM",
-                               action='store_true', default=False, help="Flash rom.  Rom must be built previously.")
-        parserObj.add_argument("--UPDATECONF", "--updateconf", "--UpdateConf",
-                               dest="UPDATECONF", action='store_true', default=False,
-                               help="Update Conf. Builders Conf files will be replaced with latest template files")
-        parserObj.add_argument("--CLEAN", "--clean", "--CLEAN", dest="CLEAN",
-                               action='store_true', default=False,
-                               help="Clean. Remove all old build artifacts and intermediate files")
-        parserObj.add_argument("--CLEANONLY", "--cleanonly", "--CleanOnly", dest="CLEANONLY",
-                               action='store_true', default=False,
-                               help="Clean Only. Do clean operation and don't build just exit.")
-        parserObj.add_argument("--OUTPUTCONFIG", "--outputconfig", "--OutputConfig",
-                               dest='OutputConfig', required=False, type=str,
-                               help='Provide shell variables in a file')
+        parserObj.add_argument(
+            "--SKIPBUILD",
+            "--skipbuild",
+            "--SkipBuild",
+            dest="SKIPBUILD",
+            action="store_true",
+            default=False,
+            help="Skip the build process",
+        )
+        parserObj.add_argument(
+            "--SKIPPREBUILD",
+            "--skipprebuild",
+            "--SkipPrebuild",
+            dest="SKIPPREBUILD",
+            action="store_true",
+            default=False,
+            help="Skip prebuild process",
+        )
+        parserObj.add_argument(
+            "--SKIPPOSTBUILD",
+            "--skippostbuild",
+            "--SkipPostBuild",
+            dest="SKIPPOSTBUILD",
+            action="store_true",
+            default=False,
+            help="Skip postbuild process",
+        )
+        parserObj.add_argument(
+            "--FLASHONLY",
+            "--flashonly",
+            "--FlashOnly",
+            dest="FLASHONLY",
+            action="store_true",
+            default=False,
+            help="Flash rom after build.",
+        )
+        parserObj.add_argument(
+            "--FLASHROM",
+            "--flashrom",
+            "--FlashRom",
+            dest="FLASHROM",
+            action="store_true",
+            default=False,
+            help="Flash rom.  Rom must be built previously.",
+        )
+        parserObj.add_argument(
+            "--UPDATECONF",
+            "--updateconf",
+            "--UpdateConf",
+            dest="UPDATECONF",
+            action="store_true",
+            default=False,
+            help="Update Conf. Builders Conf files will be replaced with latest template files",
+        )
+        parserObj.add_argument(
+            "--CLEAN",
+            "--clean",
+            "--CLEAN",
+            dest="CLEAN",
+            action="store_true",
+            default=False,
+            help="Clean. Remove all old build artifacts and intermediate files",
+        )
+        parserObj.add_argument(
+            "--CLEANONLY",
+            "--cleanonly",
+            "--CleanOnly",
+            dest="CLEANONLY",
+            action="store_true",
+            default=False,
+            help="Clean Only. Do clean operation and don't build just exit.",
+        )
+        parserObj.add_argument(
+            "--OUTPUTCONFIG",
+            "--outputconfig",
+            "--OutputConfig",
+            dest="OutputConfig",
+            required=False,
+            type=str,
+            help="Provide shell variables in a file",
+        )
 
     def RetrievePlatformCommandLineOptions(self, args):
         """Retrieve command line options from the argparser.
@@ -105,7 +164,9 @@ class UefiBuilder(object):
         Args:
             args (Namespace): namespace containing gathered args from argparser
         """
-        self.OutputConfig = os.path.abspath(args.OutputConfig) if args.OutputConfig else None
+        self.OutputConfig = (
+            os.path.abspath(args.OutputConfig) if args.OutputConfig else None
+        )
 
         self.SkipBuild = args.SKIPBUILD
         self.SkipPreBuild = args.SKIPPREBUILD
@@ -114,12 +175,12 @@ class UefiBuilder(object):
         self.FlashImage = args.FLASHROM
         self.UpdateConf = args.UPDATECONF
 
-        if (args.FLASHONLY):
+        if args.FLASHONLY:
             self.SkipPostBuild = True
             self.SkipBuild = True
             self.SkipPreBuild = True
             self.FlashImage = True
-        elif (args.CLEANONLY):
+        elif args.CLEANONLY:
             self.Clean = True
             self.SkipBuild = True
             self.SkipPreBuild = True
@@ -143,67 +204,71 @@ class UefiBuilder(object):
             self.Helper.DebugLogRegisteredFunctions()
 
             ret = self.SetEnv()
-            if (ret != 0):
+            if ret != 0:
                 logging.critical("SetEnv failed")
                 return ret
 
             # clean
-            if (self.Clean):
+            if self.Clean:
                 edk2_logging.log_progress("Cleaning")
                 ret = self.CleanTree()
-                if (ret != 0):
+                if ret != 0:
                     logging.critical("Clean failed")
                     return ret
 
             # prebuild
-            if (self.SkipPreBuild):
+            if self.SkipPreBuild:
                 edk2_logging.log_progress("Skipping Pre Build")
             else:
                 ret = self.PreBuild()
-                if (ret != 0):
+                if ret != 0:
                     logging.critical("Pre Build failed")
                     return ret
 
             # Output Build Environment to File - this is mostly for debug of build
             # issues or adding other build features using existing variables
-            if (self.OutputConfig is not None):
+            if self.OutputConfig is not None:
                 edk2_logging.log_progress("Writing Build Env Info out to File")
                 logging.debug("Found an Output Build Env File: " + self.OutputConfig)
                 self.env.PrintAll(self.OutputConfig)
 
-            if (self.env.GetValue("GATEDBUILD") is not None) and (self.env.GetValue("GATEDBUILD").upper() == "TRUE"):
+            if (self.env.GetValue("GATEDBUILD") is not None) and (
+                self.env.GetValue("GATEDBUILD").upper() == "TRUE"
+            ):
                 ShouldGatedBuildRun = self.PlatformGatedBuildShouldHappen()
-                logging.debug("Platform Gated Build Should Run returned: %s" % str(
-                    ShouldGatedBuildRun))
-                if (not self.SkipBuild):
+                logging.debug(
+                    "Platform Gated Build Should Run returned: %s"
+                    % str(ShouldGatedBuildRun)
+                )
+                if not self.SkipBuild:
                     self.SkipBuild = not ShouldGatedBuildRun
-                if (not self.SkipPostBuild):
+                if not self.SkipPostBuild:
                     self.SkipPostBuild = not ShouldGatedBuildRun
 
             # build
-            if (self.SkipBuild):
+            if self.SkipBuild:
                 edk2_logging.log_progress("Skipping Build")
             else:
                 ret = self.Build()
 
-                if (ret != 0):
+                if ret != 0:
                     logging.critical("Build failed")
                     return ret
 
             # postbuild
-            if (self.SkipPostBuild):
+            if self.SkipPostBuild:
                 edk2_logging.log_progress("Skipping Post Build")
             else:
                 ret = self.PostBuild()
-                if (ret != 0):
+                if ret != 0:
                     logging.critical("Post Build failed")
                     return ret
 
             # flash
-            if (self.FlashImage):
+            if self.FlashImage:
                 edk2_logging.log_progress("Flashing Image")
                 ret = self.FlashRomImage()
-                if (ret != 0):
+                if ret != 0:
                     logging.critical("Flash Image failed")
                     return ret
 
@@ -224,8 +289,11 @@ class UefiBuilder(object):
         finally:
             end_time = time.perf_counter()
             elapsed_time_s = int((end_time - start_time))
-            edk2_logging.log_progress("End time: {0}\t Total time Elapsed: {1}".format(
-                datetime.datetime.now(), datetime.timedelta(seconds=elapsed_time_s)))
+            edk2_logging.log_progress(
+                "End time: {0}\t Total time Elapsed: {1}".format(
+                    datetime.datetime.now(), datetime.timedelta(seconds=elapsed_time_s)
+                )
+            )
 
         return 0
 
@@ -240,7 +308,7 @@ class UefiBuilder(object):
         edk2_logging.log_progress("Cleaning All Output for Build")
 
         d = self.env.GetValue("BUILD_OUTPUT_BASE")
-        if (os.path.isdir(d)):
+        if os.path.isdir(d):
             logging.debug("Removing [%s]", d)
             # if the folder is opened in Explorer do not fail the entire Rebuild
             try:
@@ -254,14 +322,14 @@ class UefiBuilder(object):
         # delete the conf .dbcache
         # this needs to be removed in case build flags changed
         d = os.path.join(self.ws, "Conf", ".cache")
-        if (os.path.isdir(d)):
+        if os.path.isdir(d):
             logging.debug("Removing [%s]" % d)
             RemoveTree(d)
 
-        if (RemoveConfTemplateFilesToo):
+        if RemoveConfTemplateFilesToo:
             for a in ["target.txt", "build_rule.txt", "tools_def.txt"]:
                 d = os.path.join(self.ws, "Conf", a)
-                if (os.path.isfile(d)):
+                if os.path.isfile(d):
                     logging.debug("Removing [%s]" % d)
                     os.remove(d)
 
@@ -286,7 +354,7 @@ class UefiBuilder(object):
             params += " -a " + t
 
         # get the report options and setup the build command
-        if (self.env.GetValue("BUILDREPORTING") == "TRUE"):
+        if self.env.GetValue("BUILDREPORTING") == "TRUE":
             params += " -y " + self.env.GetValue("BUILDREPORT_FILE")
             rt = self.env.GetValue("BUILDREPORT_TYPES").split(" ")
             for t in rt:
@@ -294,7 +362,7 @@ class UefiBuilder(object):
 
         # add special processing to handle building a single module
         mod = self.env.GetValue("BUILDMODULE")
-        if (mod is not None and len(mod.strip()) > 0):
+        if mod is not None and len(mod.strip()) > 0:
             params += " -m " + mod
             edk2_logging.log_progress("Single Module Build: " + mod)
             self.SkipPostBuild = True
@@ -310,7 +378,7 @@ class UefiBuilder(object):
         # WORKAROUND - Pin the PYTHONHASHSEED so that TianoCore build tools
         #               have consistent ordering. Addresses incremental builds.
         pre_build_env_chk = env.checkpoint()
-        env.set_shell_var('PYTHONHASHSEED', '0')
+        env.set_shell_var("PYTHONHASHSEED", "0")
         env.log_environment()
 
         edk2_build_cmd = self.env.GetValue("EDK_BUILD_CMD")
@@ -332,7 +400,7 @@ class UefiBuilder(object):
         for level, problem in problems:
             logging.log(level, problem)
 
-        if (ret != 0):
+        if ret != 0:
             return ret
 
         return 0
@@ -348,7 +416,7 @@ class UefiBuilder(object):
         #
         ret = self.PlatformPreBuild()
 
-        if (ret != 0):
+        if ret != 0:
             logging.critical("PlatformPreBuild failed %d" % ret)
             return ret
         #
@@ -356,14 +424,16 @@ class UefiBuilder(object):
         #
         for Descriptor in self.pm.GetPluginsOfClass(IUefiBuildPlugin):
             rc = Descriptor.Obj.do_pre_build(self)
-            if (rc != 0):
-                if (rc is None):
+            if rc != 0:
+                if rc is None:
                     logging.error(
-                        "Plugin Failed: %s returned NoneType" % Descriptor.Name)
+                        "Plugin Failed: %s returned NoneType" % Descriptor.Name
+                    )
                     ret = -1
                 else:
-                    logging.error("Plugin Failed: %s returned %d" %
-                                  (Descriptor.Name, rc))
+                    logging.error(
+                        "Plugin Failed: %s returned %d" % (Descriptor.Name, rc)
+                    )
                     ret = rc
                 break  # fail on plugin error
             else:
@@ -381,7 +451,7 @@ class UefiBuilder(object):
         #
         ret = self.PlatformPostBuild()
 
-        if (ret != 0):
+        if ret != 0:
             logging.critical("PlatformPostBuild failed %d" % ret)
             return ret
 
@@ -390,14 +460,16 @@ class UefiBuilder(object):
         #
         for Descriptor in self.pm.GetPluginsOfClass(IUefiBuildPlugin):
             rc = Descriptor.Obj.do_post_build(self)
-            if (rc != 0):
-                if (rc is None):
+            if rc != 0:
+                if rc is None:
                     logging.error(
-                        "Plugin Failed: %s returned NoneType" % Descriptor.Name)
+                        "Plugin Failed: %s returned NoneType" % Descriptor.Name
+                    )
                     ret = -1
                 else:
-                    logging.error("Plugin Failed: %s returned %d" %
-                                  (Descriptor.Name, rc))
+                    logging.error(
+                        "Plugin Failed: %s returned %d" % (Descriptor.Name, rc)
+                    )
                     ret = rc
                 break  # fail on plugin error
             else:
@@ -414,14 +486,15 @@ class UefiBuilder(object):
         shell_environment.GetEnvironment().set_shell_var("WORKSPACE", self.ws)
         shell_environment.GetBuildVars().SetValue("WORKSPACE", self.ws, "Set in SetEnv")
 
-        if (self.pp is not None):
+        if self.pp is not None:
             shell_environment.GetEnvironment().set_shell_var("PACKAGES_PATH", self.pp)
             shell_environment.GetBuildVars().SetValue(
-                "PACKAGES_PATH", self.pp, "Set in SetEnv")
+                "PACKAGES_PATH", self.pp, "Set in SetEnv"
+            )
 
         # process platform parameters defined in platform build file
         ret = self.SetPlatformEnv()
-        if (ret != 0):
+        if ret != 0:
             logging.critical("Set Platform Env failed")
             return ret
 
@@ -430,69 +503,92 @@ class UefiBuilder(object):
 
         # Handle all the template files for workspace/conf/ Allow override
         TemplateDirList = [self.env.GetValue("EDK_TOOLS_PATH")]  # set to edk2 BaseTools
-        PlatTemplatesForConf = self.env.GetValue("CONF_TEMPLATE_DIR")  # get platform defined additional path
-        if (PlatTemplatesForConf is not None):
+        PlatTemplatesForConf = self.env.GetValue(
+            "CONF_TEMPLATE_DIR"
+        )  # get platform defined additional path
+        if PlatTemplatesForConf is not None:
             PlatTemplatesForConf = self.mws.join(self.ws, PlatTemplatesForConf)
             TemplateDirList.insert(0, PlatTemplatesForConf)
-            logging.debug(f"Platform defined override for Template Conf Files: {PlatTemplatesForConf}")
+            logging.debug(
+                f"Platform defined override for Template Conf Files: {PlatTemplatesForConf}"
+            )
 
         conf_dir = os.path.join(self.ws, "Conf")
-        conf_mgmt.ConfMgmt().populate_conf_dir(conf_dir, self.UpdateConf, TemplateDirList)
+        conf_mgmt.ConfMgmt().populate_conf_dir(
+            conf_dir, self.UpdateConf, TemplateDirList
+        )
 
         # parse target file
         ret = self.ParseTargetFile()
-        if (ret != 0):
+        if ret != 0:
             logging.critical("ParseTargetFile failed")
             return ret
 
         # parse tools_def file
         ret = self.ParseToolsDefFile()
-        if (ret != 0):
+        if ret != 0:
             logging.critical("ParseToolsDefFile failed")
             return ret
 
         # parse DSC file
         ret = self.ParseDscFile()
-        if (ret != 0):
+        if ret != 0:
             logging.critical("ParseDscFile failed")
             return ret
 
         # parse FDF file
         ret = self.ParseFdfFile()
-        if (ret != 0):
+        if ret != 0:
             logging.critical("ParseFdfFile failed")
             return ret
 
         # set build output base envs for all builds
         if self.env.GetValue("OUTPUT_DIRECTORY") is None:
             logging.warn("OUTPUT_DIRECTORY was not found, defaulting to Build")
-            self.env.SetValue("OUTPUT_DIRECTORY", "Build", "default from uefi_build", True)
+            self.env.SetValue(
+                "OUTPUT_DIRECTORY", "Build", "default from uefi_build", True
+            )
 
         # BUILD_OUT_TEMP is a path so the value should use native directory separators
-        self.env.SetValue("BUILD_OUT_TEMP",
-                          os.path.normpath(os.path.join(self.ws, self.env.GetValue("OUTPUT_DIRECTORY"))),
-                          "Computed in SetEnv")
+        self.env.SetValue(
+            "BUILD_OUT_TEMP",
+            os.path.normpath(
+                os.path.join(self.ws, self.env.GetValue("OUTPUT_DIRECTORY"))
+            ),
+            "Computed in SetEnv",
+        )
 
         target = self.env.GetValue("TARGET")
-        self.env.SetValue("BUILD_OUTPUT_BASE", os.path.join(self.env.GetValue(
-            "BUILD_OUT_TEMP"), target + "_" + self.env.GetValue("TOOL_CHAIN_TAG")), "Computed in SetEnv")
+        self.env.SetValue(
+            "BUILD_OUTPUT_BASE",
+            os.path.join(
+                self.env.GetValue("BUILD_OUT_TEMP"),
+                target + "_" + self.env.GetValue("TOOL_CHAIN_TAG"),
+            ),
+            "Computed in SetEnv",
+        )
 
         # We have our build target now.  Give platform build one more chance for target specific settings.
         ret = self.SetPlatformEnvAfterTarget()
-        if (ret != 0):
+        if ret != 0:
             logging.critical("SetPlatformEnvAfterTarget failed")
             return ret
 
         # set the build report file
-        self.env.SetValue("BUILDREPORT_FILE", os.path.join(
-            self.env.GetValue("BUILD_OUTPUT_BASE"), "BUILD_REPORT.TXT"), True)
+        self.env.SetValue(
+            "BUILDREPORT_FILE",
+            os.path.join(self.env.GetValue("BUILD_OUTPUT_BASE"), "BUILD_REPORT.TXT"),
+            True,
+        )
 
         # set environment variables for the build process
         os.environ["EFI_SOURCE"] = self.ws
 
         # set critical platform Env Defaults if not set anywhere else in the build.
         for env_var in self.SetPlatformDefaultEnv():
-            self.env.SetValue(env_var.name, env_var.default, "Default Critical Platform Env Value.")
+            self.env.SetValue(
+                env_var.name, env_var.default, "Default Critical Platform Env Value."
+            )
 
         return 0
 
@@ -602,7 +698,7 @@ class UefiBuilder(object):
 
         "Sets them so they can be overriden.
         """
-        if (os.path.isfile(self.mws.join(self.ws, "Conf", "target.txt"))):
+        if os.path.isfile(self.mws.join(self.ws, "Conf", "target.txt")):
             # parse TargetTxt File
             logging.debug("Parse Target.txt file")
             ttp = TargetTxtParser()
@@ -613,10 +709,17 @@ class UefiBuilder(object):
 
             # Set the two additional edk2 common macros.  These will be resolved by now as
             # target.txt will set them if they aren't already set.
-            self.env.SetValue("TOOLCHAIN", self.env.GetValue("TOOL_CHAIN_TAG"),
-                              "DSC Spec macro - set based on tool_Chain_tag")
+            self.env.SetValue(
+                "TOOLCHAIN",
+                self.env.GetValue("TOOL_CHAIN_TAG"),
+                "DSC Spec macro - set based on tool_Chain_tag",
+            )
             # need to check how multiple arch are handled
-            self.env.SetValue("ARCH", self.env.GetValue("TARGET_ARCH"), "DSC Spec macro - set based on target_arch")
+            self.env.SetValue(
+                "ARCH",
+                self.env.GetValue("TARGET_ARCH"),
+                "DSC Spec macro - set based on target_arch",
+            )
 
         else:
             logging.error("Failed to find target.txt file")
@@ -629,7 +732,7 @@ class UefiBuilder(object):
 
         "Sets them so they can be overriden.
         """
-        if (os.path.isfile(self.mws.join(self.ws, "Conf", "tools_def.txt"))):
+        if os.path.isfile(self.mws.join(self.ws, "Conf", "tools_def.txt")):
             # parse ToolsdefTxt File
             logging.debug("Parse tools_def.txt file")
             tdp = TargetTxtParser()
@@ -640,7 +743,9 @@ class UefiBuilder(object):
             # Example:  *_VS2019_*_*_FAMILY        = MSFT
             tag = "*_" + self.env.GetValue("TOOL_CHAIN_TAG") + "_*_*_FAMILY"
             tool_chain_family = tdp.Dict.get(tag, "UNKNOWN")
-            self.env.SetValue("FAMILY", tool_chain_family, "DSC Spec macro - from tools_def.txt")
+            self.env.SetValue(
+                "FAMILY", tool_chain_family, "DSC Spec macro - from tools_def.txt"
+            )
 
         else:
             logging.error("Failed to find tools_def.txt file")
@@ -657,20 +762,22 @@ class UefiBuilder(object):
         if self.env.GetValue("ACTIVE_PLATFORM") is None:
             logging.error("The DSC file was not set. Please set ACTIVE_PLATFORM")
             return -1
-        dsc_file_path = self.mws.join(
-            self.ws, self.env.GetValue("ACTIVE_PLATFORM"))
-        if (os.path.isfile(dsc_file_path)):
+        dsc_file_path = self.mws.join(self.ws, self.env.GetValue("ACTIVE_PLATFORM"))
+        if os.path.isfile(dsc_file_path):
             # parse DSC File
-            logging.debug(
-                "Parse Active Platform DSC file: {0}".format(dsc_file_path))
+            logging.debug("Parse Active Platform DSC file: {0}".format(dsc_file_path))
 
             # Get the vars from the environment that are not build keys
             input_vars = self.env.GetAllNonBuildKeyValues()
             # Update with special environment set build keys
             input_vars.update(self.env.GetAllBuildKeyValues())
 
-            dscp = DscParser().SetBaseAbsPath(self.ws).SetPackagePaths(
-                self.pp.split(os.pathsep)).SetInputVars(input_vars)
+            dscp = (
+                DscParser()
+                .SetBaseAbsPath(self.ws)
+                .SetPackagePaths(self.pp.split(os.pathsep))
+                .SetInputVars(input_vars)
+            )
             dscp.ParseFile(dsc_file_path)
             for key, value in dscp.LocalVars.items():
                 # set env as overrideable
@@ -688,10 +795,12 @@ class UefiBuilder(object):
         it so we don't have to define things twice the FDF file usually comes
         from the Active Platform DSC file so it needs to be parsed first.
         """
-        if (self.env.GetValue("FLASH_DEFINITION") is None):
+        if self.env.GetValue("FLASH_DEFINITION") is None:
             logging.debug("No flash definition set")
             return 0
-        if (os.path.isfile(self.mws.join(self.ws, self.env.GetValue("FLASH_DEFINITION")))):
+        if os.path.isfile(
+            self.mws.join(self.ws, self.env.GetValue("FLASH_DEFINITION"))
+        ):
             # parse the FDF file- fdf files have similar syntax to DSC and therefore parser works for both.
             logging.debug("Parse Active Flash Definition (FDF) file")
 
@@ -700,8 +809,12 @@ class UefiBuilder(object):
             # Update with special environment set build keys
             input_vars.update(self.env.GetAllBuildKeyValues())
 
-            fdf_parser = FdfParser().SetBaseAbsPath(self.ws).SetPackagePaths(
-                self.pp.split(os.pathsep)).SetInputVars(input_vars)
+            fdf_parser = (
+                FdfParser()
+                .SetBaseAbsPath(self.ws)
+                .SetPackagePaths(self.pp.split(os.pathsep))
+                .SetInputVars(input_vars)
+            )
             pa = self.mws.join(self.ws, self.env.GetValue("FLASH_DEFINITION"))
             fdf_parser.ParseFile(pa)
             for key, value in fdf_parser.LocalVars.items():
@@ -716,6 +829,6 @@ class UefiBuilder(object):
     def SetBasicDefaults(self):
         """Sets default values for numerous build control flow variables."""
         self.env.SetValue("WORKSPACE", self.ws, "DEFAULT")
-        if (self.pp is not None):
+        if self.pp is not None:
             self.env.SetValue("PACKAGES_PATH", self.pp, "DEFAULT")
         return 0

--- a/edk2toolext/environment/var_dict.py
+++ b/edk2toolext/environment/var_dict.py
@@ -42,9 +42,10 @@ class EnvEntry(object):
         """
         print("Value: %s" % self.Value, file=f)
         print("Comment: %s" % self.Comment, file=f)
-        if (self.Overrideable):
+        if self.Overrideable:
             print("Value overridable", file=f)
         print("**********************", file=f)
+
     #
     # Function used to override the value if option allows it
     #
@@ -64,9 +65,11 @@ class EnvEntry(object):
         if (value == self.Value) and (overridable == self.Overrideable):
             return True
 
-        if (not self.Overrideable):
-            logging.debug("Can't set value [%s] as it isn't overrideable. Previous comment %s" % (
-                value, self.Comment))
+        if not self.Overrideable:
+            logging.debug(
+                "Can't set value [%s] as it isn't overrideable. Previous comment %s"
+                % (value, self.Comment)
+            )
             return False
 
         self.Value = value
@@ -123,14 +126,13 @@ class VarDict(object):
         Returns:
             (varied): The value of the key, if present, else default value
         """
-        if (k is None):
-            logging.debug(
-                "GetValue - Invalid Parameter key is None.")
+        if k is None:
+            logging.debug("GetValue - Invalid Parameter key is None.")
             return None
 
         key = k.upper()
         en = self.GetEntry(key)
-        if (en is not None):
+        if en is not None:
             self.Logger.debug("Key %s found.  Value %s" % (key, en.GetValue()))
             return en.GetValue()
         else:
@@ -155,11 +157,11 @@ class VarDict(object):
         key = k.upper()
         en = self.GetEntry(key)
         if v is None:
-            value = ''.join(choice(ascii_letters) for _ in range(20))
+            value = "".join(choice(ascii_letters) for _ in range(20))
         else:
             value = str(v)
         self.Logger.debug("Trying to set key %s to value %s" % (k, v))
-        if (en is None):
+        if en is None:
             # new entry
             en = EnvEntry(value, comment, overridable)
             self.Dstore[key] = en
@@ -181,7 +183,7 @@ class VarDict(object):
         """
         key = k.upper()
         en = self.GetEntry(key)
-        if (en is not None):
+        if en is not None:
             self.Logger.warning("Allowing Override for key %s" % k)
             en.AllowOverride()
             return True
@@ -210,17 +212,21 @@ class VarDict(object):
         """
         rv = None
 
-        if (BuildType is None):
+        if BuildType is None:
             BuildType = self.GetValue("TARGET")
 
-        if (BuildType is None):
+        if BuildType is None:
             logging.debug(
-                "GetBuildValue - Invalid Parameter BuildType is None and Target Not set. Key is: " + key)
+                "GetBuildValue - Invalid Parameter BuildType is None and Target Not set. Key is: "
+                + key
+            )
             return None
 
-        if (key is None):
+        if key is None:
             logging.debug(
-                "GetBuildValue - Invalid Parameter key is None. BuildType is: " + BuildType)
+                "GetBuildValue - Invalid Parameter key is None. BuildType is: "
+                + BuildType
+            )
             return None
 
         ty = BuildType.upper().strip()
@@ -228,7 +234,7 @@ class VarDict(object):
         # see if specific
         k = "BLD_" + ty + "_" + tk
         rv = self.GetValue(k)
-        if (rv is None):
+        if rv is None:
             # didn't fine build type specific so check for generic
             k = "BLD_*_" + tk
             rv = self.GetValue(k)
@@ -258,12 +264,13 @@ class VarDict(object):
 
         """
         returndict = {}
-        if (BuildType is None):
+        if BuildType is None:
             BuildType = self.GetValue("TARGET")
 
-        if (BuildType is None):
+        if BuildType is None:
             logging.debug(
-                "GetAllBuildKeyValues - Invalid Parameter BuildType is None and Target Not Set.")
+                "GetAllBuildKeyValues - Invalid Parameter BuildType is None and Target Not Set."
+            )
             return returndict
 
         ty = BuildType.upper().strip()
@@ -271,7 +278,7 @@ class VarDict(object):
 
         # get all the generic build options
         for key, value in self.Dstore.items():
-            if (key.startswith("BLD_*_")):
+            if key.startswith("BLD_*_"):
                 k = key[6:]
                 returndict[k] = value.GetValue()
 
@@ -279,7 +286,7 @@ class VarDict(object):
         # figure out offset part of key name to strip
         ks = len(ty) + 5
         for key, value in self.Dstore.items():
-            if (key.startswith("BLD_" + ty + "_")):
+            if key.startswith("BLD_" + ty + "_"):
                 k = key[ks:]
                 returndict[k] = value.GetValue()
 
@@ -294,7 +301,7 @@ class VarDict(object):
         returndict = {}
         # get all the generic build options
         for key, value in self.Dstore.items():
-            if (not key.startswith("BLD_")):
+            if not key.startswith("BLD_"):
                 returndict[key] = value.GetValue()
         return returndict
 
@@ -307,10 +314,10 @@ class VarDict(object):
             fp (str): file pointer to print to
         """
         f = None
-        if (fp is not None):
-            f = open(fp, 'a+')
+        if fp is not None:
+            f = open(fp, "a+")
         for key, value in self.Dstore.items():
             print("Key = %s" % key, file=f)
             value.PrintEntry(f)
-        if (f):
+        if f:
             f.close()

--- a/edk2toolext/environment/version_aggregator.py
+++ b/edk2toolext/environment/version_aggregator.py
@@ -24,6 +24,7 @@ class version_aggregator(object):
     Used to facilitate the collection of information regarding the tools,
     binaries, submodule configuration used in a build.
     """
+
     def __init__(self):
         """Inits an empty verion aggregator."""
         super(version_aggregator, self).__init__()
@@ -44,9 +45,12 @@ class version_aggregator(object):
             if old_version["version"] == value and old_version["path"] == path:
                 self._logger.info(f"version_aggregator: {key} re-registered at {path}")
             else:
-                error = "version_aggregator: {0} key registered with a different value\n\t" \
-                        "Old:{1}@{3}\n\tNew:{2}@{4}\n".format(
-                            key, old_version["version"], value, old_version["path"], path)
+                error = (
+                    "version_aggregator: {0} key registered with a different value\n\t"
+                    "Old:{1}@{3}\n\tNew:{2}@{4}\n".format(
+                        key, old_version["version"], value, old_version["path"], path
+                    )
+                )
                 self._logger.error(error)
                 raise ValueError(error)
             return
@@ -55,9 +59,11 @@ class version_aggregator(object):
             "name": key,
             "version": value,
             "type": versionType.name,
-            "path": path
+            "path": path,
         }
-        self._logger.debug("version_aggregator logging version: {0}".format(str(self._Versions[key])))
+        self._logger.debug(
+            "version_aggregator logging version: {0}".format(str(self._Versions[key]))
+        )
 
     def Print(self):
         """Prints out the current information from the version aggregator."""
@@ -86,6 +92,7 @@ class VersionTypes(Enum):
         INFO: miscellaneous information.
         PIP: a python pip package.
     """
+
     TOOL = 1
     COMMIT = 2
     BINARY = 3

--- a/edk2toolext/image_validation.py
+++ b/edk2toolext/image_validation.py
@@ -26,7 +26,7 @@ from edk2toolext import edk2_logging
 
 def has_characteristic(data, mask):
     """Checks if data has a specific mask."""
-    return ((data & mask) == mask)
+    return (data & mask) == mask
 
 
 def set_bit(data, bit):
@@ -53,10 +53,10 @@ def get_nx_compat_flag(pe):
     dllchar = pe.OPTIONAL_HEADER.DllCharacteristics
 
     if has_characteristic(dllchar, 256):  # 256 (8th bit) is the mask
-        logging.info('True')
+        logging.info("True")
         return 1
     else:
-        logging.info('False')
+        logging.info("False")
         return 0
 
 
@@ -84,14 +84,16 @@ def fill_missing_requirements(default, target):
 
 class Result:
     """Test results."""
-    PASS = '[PASS]'
-    WARN = '[WARNING]'
-    SKIP = '[SKIP]'
-    FAIL = '[FAIL]'
+
+    PASS = "[PASS]"
+    WARN = "[WARNING]"
+    SKIP = "[SKIP]"
+    FAIL = "[FAIL]"
 
 
 class TestInterface:
     """Interface for creating tests to execute on parsed PE/COFF files."""
+
     def name(self):
         """Returns the name of the test.
 
@@ -116,6 +118,7 @@ class TestInterface:
 
 class TestManager(object):
     """Manager responsible for executing all tests on all parsed PE/COFF files."""
+
     def __init__(self, config_data=None):
         """Inits the TestManager with configuration data.
 
@@ -132,32 +135,23 @@ class TestManager(object):
                     "X64": "IMAGE_FILE_MACHINE_AMD64",
                     "IA32": "IMAGE_FILE_MACHINE_I386",
                     "AARCH64": "IMAGE_FILE_MACHINE_ARM64",
-                    "ARM": "IMAGE_FILE_MACHINE_ARM"
+                    "ARM": "IMAGE_FILE_MACHINE_ARM",
                 },
                 "IMAGE_FILE_MACHINE_AMD64": {
                     "DEFAULT": {
                         "DATA_CODE_SEPARATION": True,
                         "ALLOWED_SUBSYSTEMS": [
                             "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
-                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                            "IMAGE_SUBSYSTEM_EFI_ROM",
                         ],
-                        "ALIGNMENT": [
-                            {
-                                "COMPARISON": "==",
-                                "VALUE": 4096
-                            }
-                        ]
+                        "ALIGNMENT": [{"COMPARISON": "==", "VALUE": 4096}],
                     },
-                    "APP": {
-                        "ALLOWED_SUBSYSTEMS": [
-                            "IMAGE_SUBSYSTEM_EFI_APPLICATION"
-                        ]
-                    },
+                    "APP": {"ALLOWED_SUBSYSTEMS": ["IMAGE_SUBSYSTEM_EFI_APPLICATION"]},
                     "DRIVER": {
                         "ALLOWED_SUBSYSTEMS": [
                             "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
                             "IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER"
-                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                            "IMAGE_SUBSYSTEM_EFI_ROM",
                         ]
                     },
                 },
@@ -166,81 +160,57 @@ class TestManager(object):
                         "DATA_CODE_SEPARATION": True,
                         "ALLOWED_SUBSYSTEMS": [
                             "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
-                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                            "IMAGE_SUBSYSTEM_EFI_ROM",
                         ],
-                        "ALIGNMENT": [
-                            {
-                                "COMPARISON": "==",
-                                "VALUE": 4096
-                            }
-                        ]
+                        "ALIGNMENT": [{"COMPARISON": "==", "VALUE": 4096}],
                     },
                     "APP": {
-                        "ALLOWED_SUBSYSTEMS": [
-                            "IMAGE_SUBSYSTEM_EFI_APPLICATION"
-                        ],
+                        "ALLOWED_SUBSYSTEMS": ["IMAGE_SUBSYSTEM_EFI_APPLICATION"],
                     },
                     "DRIVER": {
                         "ALLOWED_SUBSYSTEMS": [
                             "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
                             "IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER",
-                            "IMAGE_SUBSYSTEM_EFI_ROM"
-                        ]}
+                            "IMAGE_SUBSYSTEM_EFI_ROM",
+                        ]
+                    },
                 },
                 "IMAGE_FILE_MACHINE_ARM64": {
                     "DEFAULT": {
                         "DATA_CODE_SEPARATION": True,
                         "ALLOWED_SUBSYSTEMS": [
                             "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
-                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                            "IMAGE_SUBSYSTEM_EFI_ROM",
                         ],
-                        "ALIGNMENT": [
-                            {
-                                "COMPARISON": "==",
-                                "VALUE": 4096
-                            }
-                        ]
+                        "ALIGNMENT": [{"COMPARISON": "==", "VALUE": 4096}],
                     },
-                    "APP": {
-                        "ALLOWED_SUBSYSTEMS": [
-                            "IMAGE_SUBSYSTEM_EFI_APPLICATION"
-                        ]
-                    },
+                    "APP": {"ALLOWED_SUBSYSTEMS": ["IMAGE_SUBSYSTEM_EFI_APPLICATION"]},
                     "DRIVER": {
                         "ALLOWED_SUBSYSTEMS": [
                             "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
                             "IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER",
-                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                            "IMAGE_SUBSYSTEM_EFI_ROM",
                         ]
-                    }
+                    },
                 },
                 "IMAGE_FILE_MACHINE_I386": {
                     "DEFAULT": {
                         "DATA_CODE_SEPARATION": True,
                         "ALLOWED_SUBSYSTEMS": [
                             "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
-                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                            "IMAGE_SUBSYSTEM_EFI_ROM",
                         ],
-                        "ALIGNMENT": [
-                            {
-                                "COMPARISON": "==",
-                                "VALUE": 4096
-                            }
-                        ]
+                        "ALIGNMENT": [{"COMPARISON": "==", "VALUE": 4096}],
                     },
-                    "APP": {
-                        "ALLOWED_SUBSYSTEMS": [
-                            "IMAGE_SUBSYSTEM_EFI_APPLICATION"
-                        ]
-                    },
+                    "APP": {"ALLOWED_SUBSYSTEMS": ["IMAGE_SUBSYSTEM_EFI_APPLICATION"]},
                     "DRIVER": {
                         "ALLOWED_SUBSYSTEMS": [
                             "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
                             "IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER"
-                            "IMAGE_SUBSYSTEM_EFI_ROM"
+                            "IMAGE_SUBSYSTEM_EFI_ROM",
                         ]
-                    }
-                }
+                    },
+                },
             }
 
     def add_test(self, test):
@@ -282,7 +252,7 @@ class TestManager(object):
         # Catch any invalid profiles
         machine_type = MACHINE_TYPE[pe.FILE_HEADER.Machine]
         if not self.config_data[machine_type].get(profile):
-            logging.error(f'Profile type {profile} is invalid. Exiting...')
+            logging.error(f"Profile type {profile} is invalid. Exiting...")
             return Result.FAIL
 
         # Fill any missing configurations for the specific module type with the default
@@ -290,27 +260,26 @@ class TestManager(object):
         target = self.config_data[machine_type][profile]
         target_requirements = fill_missing_requirements(default, target)
 
-        target_info = {
-            "MACHINE_TYPE": machine_type,
-            "PROFILE": profile
-        }
+        target_info = {"MACHINE_TYPE": machine_type, "PROFILE": profile}
         test_config_data = {
             "TARGET_INFO": target_info,
-            "TARGET_REQUIREMENTS": target_requirements
+            "TARGET_REQUIREMENTS": target_requirements,
         }
 
-        logging.debug(f'Executing tests with settings [{machine_type}][{profile}]')
+        logging.debug(f"Executing tests with settings [{machine_type}][{profile}]")
         overall_result = Result.PASS
         for test in self.tests:
-            logging.debug(f'Starting test: [{test.name()}]')
+            logging.debug(f"Starting test: [{test.name()}]")
 
             result = test.execute(pe, test_config_data)
 
             # Overall Result can only go lower (Pass -> Warn -> Fail)
             if result == Result.PASS:
-                logging.debug(f'{result}')
+                logging.debug(f"{result}")
             elif result == Result.SKIP:
-                logging.debug(f'{result}: No Requirements for [{machine_type}][{profile}]')
+                logging.debug(
+                    f"{result}: No Requirements for [{machine_type}][{profile}]"
+                )
             elif overall_result == Result.PASS:
                 overall_result = result
             elif overall_result == Result.WARN and result == Result.FAIL:
@@ -345,7 +314,7 @@ class TestWriteExecuteFlags(TestInterface):
 
     def name(self):
         """Returns the name of the test."""
-        return 'Section data / code separation verification'
+        return "Section data / code separation verification"
 
     def execute(self, pe, config_data):
         """Executes the test on the pefile.
@@ -363,11 +332,16 @@ class TestWriteExecuteFlags(TestInterface):
             return Result.SKIP
 
         for section in pe.sections:
-            if (has_characteristic(section.Characteristics, SECTION_CHARACTERISTICS["IMAGE_SCN_MEM_EXECUTE"])
-               and has_characteristic(section.Characteristics, SECTION_CHARACTERISTICS["IMAGE_SCN_MEM_WRITE"])):
-
-                logging.error(f'[{Result.FAIL}]: Section [{section.Name.decode().strip()}] \
-                              should not be both Write and Execute')
+            if has_characteristic(
+                section.Characteristics,
+                SECTION_CHARACTERISTICS["IMAGE_SCN_MEM_EXECUTE"],
+            ) and has_characteristic(
+                section.Characteristics, SECTION_CHARACTERISTICS["IMAGE_SCN_MEM_WRITE"]
+            ):
+                logging.error(
+                    f"[{Result.FAIL}]: Section [{section.Name.decode().strip()}] \
+                              should not be both Write and Execute"
+                )
                 return Result.FAIL
         return Result.PASS
 
@@ -395,7 +369,7 @@ class TestSectionAlignment(TestInterface):
 
     def name(self):
         """Returns the name of the test."""
-        return 'Section alignment verification'
+        return "Section alignment verification"
 
     def execute(self, pe, config_data):
         """Executes the test on the pefile.
@@ -427,16 +401,22 @@ class TestSectionAlignment(TestInterface):
             logical_separator = target_requirements.get("ALIGNMENT_LOGIC_SEP")
 
             if logical_separator is None:
-                logging.error("Multiple alignment requirements exist, but no logical separator provided")
+                logging.error(
+                    "Multiple alignment requirements exist, but no logical separator provided"
+                )
                 return Result.FAIL
             elif logical_separator == "AND":
                 result = True
                 for reqs in alignments:
-                    result = result and eval(f'{alignment} {reqs["COMPARISON"]} {reqs["VALUE"]}')
+                    result = result and eval(
+                        f'{alignment} {reqs["COMPARISON"]} {reqs["VALUE"]}'
+                    )
             elif logical_separator == "OR":
                 result = False
                 for reqs in alignments:
-                    result = result or eval(f'{alignment} {reqs["COMPARISON"]} {reqs["VALUE"]}')
+                    result = result or eval(
+                        f'{alignment} {reqs["COMPARISON"]} {reqs["VALUE"]}'
+                    )
             else:
                 logging.error("Invalid logical separator provided")
                 return Result.FAIL
@@ -444,10 +424,12 @@ class TestSectionAlignment(TestInterface):
             req = alignments[0]
             result = eval(f'{alignment} {req["COMPARISON"]} {req["VALUE"]}')
         if result is False:
-            logging.error(f'[{Result.FAIL}: Section Alignment Required: \
+            logging.error(
+                f'[{Result.FAIL}: Section Alignment Required: \
                             [{target_info["MACHINE_TYPE"]}] \
                             [{target_info["PROFILE"]}]: \
-                            [(Detected): {alignment}]')
+                            [(Detected): {alignment}]'
+            )
             return Result.FAIL
 
         return Result.PASS
@@ -474,7 +456,7 @@ class TestSubsystemValue(TestInterface):
 
     def name(self):
         """Returns the name of the test."""
-        return 'Subsystem type verification'
+        return "Subsystem type verification"
 
     def execute(self, pe, config_data):
         """Executes the test on the pefile.
@@ -499,20 +481,26 @@ class TestSubsystemValue(TestInterface):
             return Result.WARN
 
         if subsystem is None:
-            logging.warning(f'[{Result.WARN}]: Subsystem type is not present in the optional header.')
+            logging.warning(
+                f"[{Result.WARN}]: Subsystem type is not present in the optional header."
+            )
             return Result.WARN
 
         actual_subsystem = SUBSYSTEM_TYPE.get(subsystem)
 
         if actual_subsystem is None:
-            logging.error(f'[{Result.WARN}]: Invalid Subsystem present')
+            logging.error(f"[{Result.WARN}]: Invalid Subsystem present")
             return Result.FAIL
 
         if actual_subsystem in subsystems:
             return Result.PASS
         else:
-            logging.error(f'{Result.FAIL}: Submodule Type [{actual_subsystem}] not allowed.')
+            logging.error(
+                f"{Result.FAIL}: Submodule Type [{actual_subsystem}] not allowed."
+            )
             return Result.FAIL
+
+
 ###########################
 #        TESTS END        #
 ###########################
@@ -520,38 +508,50 @@ class TestSubsystemValue(TestInterface):
 
 def get_cli_args(args):
     """Adds CLI arguments for using the image validation tool."""
-    parser = argparse.ArgumentParser(description='A Image validation tool for memory mitigation')
+    parser = argparse.ArgumentParser(
+        description="A Image validation tool for memory mitigation"
+    )
 
-    parser.add_argument('-i', '--file',
-                        type=str,
-                        required=True,
-                        help='path to the image that needs validated.')
-    parser.add_argument('-d', '--debug',
-                        action='store_true',
-                        default=False)
+    parser.add_argument(
+        "-i",
+        "--file",
+        type=str,
+        required=True,
+        help="path to the image that needs validated.",
+    )
+    parser.add_argument("-d", "--debug", action="store_true", default=False)
 
-    parser.add_argument('-p', '--profile',
-                        type=str,
-                        default=None,
-                        help='the profile config to be verified against. \
-                            Will use the default, if not provided')
+    parser.add_argument(
+        "-p",
+        "--profile",
+        type=str,
+        default=None,
+        help="the profile config to be verified against. \
+                            Will use the default, if not provided",
+    )
 
     group = parser.add_mutually_exclusive_group()
 
-    group.add_argument('--set-nx-compat',
-                       action='store_true',
-                       default=False,
-                       help='sets the NX_COMPAT flag')
+    group.add_argument(
+        "--set-nx-compat",
+        action="store_true",
+        default=False,
+        help="sets the NX_COMPAT flag",
+    )
 
-    group.add_argument('--clear-nx-compat',
-                       action='store_true',
-                       default=False,
-                       help='clears the NX_COMPAT flag')
+    group.add_argument(
+        "--clear-nx-compat",
+        action="store_true",
+        default=False,
+        help="clears the NX_COMPAT flag",
+    )
 
-    group.add_argument('--get-nx-compat',
-                       action='store_true',
-                       default=False,
-                       help='returns the value of the NX_COMPAT flag')
+    group.add_argument(
+        "--get-nx-compat",
+        action="store_true",
+        default=False,
+        help="returns the value of the NX_COMPAT flag",
+    )
 
     return parser.parse_args(args)
 
@@ -559,7 +559,7 @@ def get_cli_args(args):
 def main():
     """Main entry point into the image validation tool."""
     # setup main console as logger
-    logger = logging.getLogger('')
+    logger = logging.getLogger("")
     logger.setLevel(logging.INFO)
     console = edk2_logging.setup_console_logging(False)
     logger.addHandler(console)
@@ -601,14 +601,14 @@ def main():
     else:
         result = test_manager.run_tests(pe, args.profile)
 
-    logging.info(f'Overall Result: {result}')
+    logging.info(f"Overall Result: {result}")
     if result == Result.SKIP:
-        logging.info('No Test requirements in the config file for this file.')
+        logging.info("No Test requirements in the config file for this file.")
     elif result == Result.PASS or result == Result.WARN:
         sys.exit(0)
     else:
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/edk2toolext/invocables/edk2_ci_setup.py
+++ b/edk2toolext/invocables/edk2_ci_setup.py
@@ -15,8 +15,12 @@ while allowing the invocable itself to remain platform agnostic.
 import os
 import logging
 
-from edk2toolext.invocables.edk2_multipkg_aware_invocable import Edk2MultiPkgAwareInvocable
-from edk2toolext.invocables.edk2_multipkg_aware_invocable import MultiPkgAwareSettingsInterface
+from edk2toolext.invocables.edk2_multipkg_aware_invocable import (
+    Edk2MultiPkgAwareInvocable,
+)
+from edk2toolext.invocables.edk2_multipkg_aware_invocable import (
+    MultiPkgAwareSettingsInterface,
+)
 from edk2toolext.environment import repo_resolver
 
 
@@ -67,16 +71,39 @@ class Edk2CiBuildSetup(Edk2MultiPkgAwareInvocable):
 
     Edk2CiBuildSetup sets up the necessary environment for Edk2CiBuild by preparing all necessary submodules.
     """
+
     def AddCommandLineOptions(self, parser):
         """Adds command line arguments to Edk2CiBuild."""
-        parser.add_argument('-ignore', '--ignore-git', dest="git_ignore", action="store_true",
-                            help="Whether to ignore errors in the git cloning process", default=False)
-        parser.add_argument('--omnicache', '--reference', dest='omnicache_path',
-                            default=os.environ.get('OMNICACHE_PATH'))
-        parser.add_argument('-force', '--force-git', dest="git_force", action="store_true",
-                            help="Whether to force git repos to clone in the git cloning process", default=False)
-        parser.add_argument('-update-git', '--update-git', dest="git_update", action="store_true",
-                            help="Whether to update git repos as needed in the git cloning process", default=False)
+        parser.add_argument(
+            "-ignore",
+            "--ignore-git",
+            dest="git_ignore",
+            action="store_true",
+            help="Whether to ignore errors in the git cloning process",
+            default=False,
+        )
+        parser.add_argument(
+            "--omnicache",
+            "--reference",
+            dest="omnicache_path",
+            default=os.environ.get("OMNICACHE_PATH"),
+        )
+        parser.add_argument(
+            "-force",
+            "--force-git",
+            dest="git_force",
+            action="store_true",
+            help="Whether to force git repos to clone in the git cloning process",
+            default=False,
+        )
+        parser.add_argument(
+            "-update-git",
+            "--update-git",
+            dest="git_update",
+            action="store_true",
+            help="Whether to update git repos as needed in the git cloning process",
+            default=False,
+        )
         super().AddCommandLineOptions(parser)
 
     def RetrieveCommandLineOptions(self, args):
@@ -85,8 +112,12 @@ class Edk2CiBuildSetup(Edk2MultiPkgAwareInvocable):
         self.git_force = args.git_force
         self.git_update = args.git_update
         self.omnicache_path = args.omnicache_path
-        if (self.omnicache_path is not None) and (not os.path.exists(self.omnicache_path)):
-            logging.warning(f"Omnicache path set to invalid path: {args.omnicache_path}")
+        if (self.omnicache_path is not None) and (
+            not os.path.exists(self.omnicache_path)
+        ):
+            logging.warning(
+                f"Omnicache path set to invalid path: {args.omnicache_path}"
+            )
             self.omnicache_path = None
 
         super().RetrieveCommandLineOptions(args)
@@ -111,10 +142,14 @@ class Edk2CiBuildSetup(Edk2MultiPkgAwareInvocable):
         """Executes the core functionality of the Edk2CiSetup invocable."""
         setup_dependencies = self.PlatformSettings.GetDependencies()
         logging.debug(f"Dependencies list {setup_dependencies}")
-        repos = repo_resolver.resolve_all(self.GetWorkspaceRoot(),
-                                          setup_dependencies,
-                                          ignore=self.git_ignore, force=self.git_force,
-                                          update_ok=self.git_update, omnicache_dir=self.omnicache_path)
+        repos = repo_resolver.resolve_all(
+            self.GetWorkspaceRoot(),
+            setup_dependencies,
+            ignore=self.git_ignore,
+            force=self.git_force,
+            update_ok=self.git_update,
+            omnicache_dir=self.omnicache_path,
+        )
 
         logging.info(f"Repo resolver resolved {repos}")
 

--- a/edk2toolext/invocables/edk2_multipkg_aware_invocable.py
+++ b/edk2toolext/invocables/edk2_multipkg_aware_invocable.py
@@ -178,14 +178,33 @@ class Edk2MultiPkgAwareInvocable(Edk2Invocable):
     def AddCommandLineOptions(self, parserObj):
         """Adds command line options to the argparser."""
         # This will parse the packages that we are going to update
-        parserObj.add_argument('-p', '--pkg', '--pkg-dir', dest='packageList', type=str,
-                               help='Optional - A package or folder you want to update (workspace relative).'
-                               'Can list multiple by doing -p <pkg1>,<pkg2> or -p <pkg3> -p <pkg4>',
-                               action="append", default=[])
-        parserObj.add_argument('-a', '--arch', dest="requested_arch", type=str, default=None,
-                               help="Optional - CSV of architecutres requested to update. Example: -a X64,AARCH64")
-        parserObj.add_argument('-t', '--target', dest='requested_target', type=str, default=None,
-                               help="Optional - CSV of targets requested to update.  Example: -t DEBUG,NOOPT")
+        parserObj.add_argument(
+            "-p",
+            "--pkg",
+            "--pkg-dir",
+            dest="packageList",
+            type=str,
+            help="Optional - A package or folder you want to update (workspace relative)."
+            "Can list multiple by doing -p <pkg1>,<pkg2> or -p <pkg3> -p <pkg4>",
+            action="append",
+            default=[],
+        )
+        parserObj.add_argument(
+            "-a",
+            "--arch",
+            dest="requested_arch",
+            type=str,
+            default=None,
+            help="Optional - CSV of architecutres requested to update. Example: -a X64,AARCH64",
+        )
+        parserObj.add_argument(
+            "-t",
+            "--target",
+            dest="requested_target",
+            type=str,
+            default=None,
+            help="Optional - CSV of targets requested to update.  Example: -t DEBUG,NOOPT",
+        )
 
     def RetrieveCommandLineOptions(self, args):
         """Retrieve command line options from the argparser ."""
@@ -210,14 +229,20 @@ class Edk2MultiPkgAwareInvocable(Edk2Invocable):
 
     def InputParametersConfiguredCallback(self):
         """Initializes the environment once input parameters are collected."""
-        if (len(self.requested_package_list) == 0):
-            self.requested_package_list = list(self.PlatformSettings.GetPackagesSupported())
+        if len(self.requested_package_list) == 0:
+            self.requested_package_list = list(
+                self.PlatformSettings.GetPackagesSupported()
+            )
         self.PlatformSettings.SetPackages(self.requested_package_list)
 
-        if (len(self.requested_architecture_list) == 0):
-            self.requested_architecture_list = list(self.PlatformSettings.GetArchitecturesSupported())
+        if len(self.requested_architecture_list) == 0:
+            self.requested_architecture_list = list(
+                self.PlatformSettings.GetArchitecturesSupported()
+            )
         self.PlatformSettings.SetArchitectures(self.requested_architecture_list)
 
-        if (len(self.requested_target_list) == 0):
-            self.requested_target_list = list(self.PlatformSettings.GetTargetsSupported())
+        if len(self.requested_target_list) == 0:
+            self.requested_target_list = list(
+                self.PlatformSettings.GetTargetsSupported()
+            )
         self.PlatformSettings.SetTargets(self.requested_target_list)

--- a/edk2toolext/invocables/edk2_platform_build.py
+++ b/edk2toolext/invocables/edk2_platform_build.py
@@ -65,13 +65,25 @@ class Edk2PlatformBuild(Edk2Invocable):
         else:
             try:
                 # if it's not, we will try to find it in the module that was originally provided.
-                self.PlatformBuilder = locate_class_in_module(self.PlatformModule, UefiBuilder)()
-            except (TypeError):
-                raise RuntimeError(f"UefiBuild not found in module:\n{dir(self.PlatformModule)}")
+                self.PlatformBuilder = locate_class_in_module(
+                    self.PlatformModule, UefiBuilder
+                )()
+            except TypeError:
+                raise RuntimeError(
+                    f"UefiBuild not found in module:\n{dir(self.PlatformModule)}"
+                )
 
-        parserObj.add_argument('-nv', '-NV', '--noverify', '--NOVERIFY', '--NoVerify',
-                               dest="verify", default=True, action='store_false',
-                               help='Skip verifying external dependencies before build.')
+        parserObj.add_argument(
+            "-nv",
+            "-NV",
+            "--noverify",
+            "--NOVERIFY",
+            "--NoVerify",
+            dest="verify",
+            default=True,
+            action="store_false",
+            help="Skip verifying external dependencies before build.",
+        )
         self.PlatformBuilder.AddPlatformCommandLineOptions(parserObj)
 
     def RetrieveCommandLineOptions(self, args):
@@ -96,14 +108,19 @@ class Edk2PlatformBuild(Edk2Invocable):
             custom_epilog += "CLI Env Variables:"
             for v in variables:
                 # Setup wrap and print first portion of description
-                desc = wrap(v.description, max_desc_len,
-                            drop_whitespace=True, break_on_hyphens=True, break_long_words=True)
+                desc = wrap(
+                    v.description,
+                    max_desc_len,
+                    drop_whitespace=True,
+                    break_on_hyphens=True,
+                    break_long_words=True,
+                )
                 custom_epilog += f"\n  {v.name:<{max_name_len}} - {desc[0]:<{max_desc_len}}  [{v.default}]"
 
                 # If the line actually wrapped, we can print the rest of the lines here
                 for d in desc[1:]:
                     custom_epilog += f"\n  {'':<{max_name_len}}   {d:{max_desc_len}}"
-            custom_epilog += '\n\n'
+            custom_epilog += "\n\n"
 
         return custom_epilog + epilog
 
@@ -117,7 +134,9 @@ class Edk2PlatformBuild(Edk2Invocable):
             (bool): whether verify check is required or not
         """
         if not self.verify:
-            logging.warning("Skipping Environment Verification. Unexpected results may occur.")
+            logging.warning(
+                "Skipping Environment Verification. Unexpected results may occur."
+            )
         return self.verify
 
     def GetSettingsClass(self):
@@ -142,7 +161,10 @@ class Edk2PlatformBuild(Edk2Invocable):
         Edk2PlatformBuild.collect_python_pip_info()
 
         (build_env, shell_env) = self_describing_environment.BootstrapEnvironment(
-            self.GetWorkspaceRoot(), self.GetActiveScopes(), self.GetSkippedDirectories())
+            self.GetWorkspaceRoot(),
+            self.GetActiveScopes(),
+            self.GetSkippedDirectories(),
+        )
 
         # Bind our current execution environment into the shell vars.
         ph = os.path.dirname(sys.executable)
@@ -159,8 +181,7 @@ class Edk2PlatformBuild(Edk2Invocable):
         # Load plugins
         logging.log(edk2_logging.SECTION, "Loading Plugins")
         pm = plugin_manager.PluginManager()
-        failedPlugins = pm.SetListOfEnvironmentDescriptors(
-            build_env.plugins)
+        failedPlugins = pm.SetListOfEnvironmentDescriptors(build_env.plugins)
         if failedPlugins:
             logging.critical("One or more plugins failed to load. Halting build.")
             for a in failedPlugins:
@@ -168,7 +189,7 @@ class Edk2PlatformBuild(Edk2Invocable):
             raise Exception("One or more plugins failed to load.")
 
         helper = HelperFunctions()
-        if (helper.LoadFromPluginManager(pm) > 0):
+        if helper.LoadFromPluginManager(pm) > 0:
             raise Exception("One or more helper plugins failed to load.")
 
         # Make a pathobj so we can normalize and validate the workspace
@@ -179,10 +200,12 @@ class Edk2PlatformBuild(Edk2Invocable):
         # Now we can actually kick off a build.
         #
         logging.log(edk2_logging.SECTION, "Kicking off build")
-        ret = self.PlatformBuilder.Go(pathobj.WorkspacePath,
-                                      os.pathsep.join(pathobj.PackagePathList),
-                                      helper, pm)
-        logging.log(edk2_logging.SECTION, f"Log file is located at: {self.log_filename}")
+        ret = self.PlatformBuilder.Go(
+            pathobj.WorkspacePath, os.pathsep.join(pathobj.PackagePathList), helper, pm
+        )
+        logging.log(
+            edk2_logging.SECTION, f"Log file is located at: {self.log_filename}"
+        )
         return ret
 
 

--- a/edk2toolext/invocables/edk2_update.py
+++ b/edk2toolext/invocables/edk2_update.py
@@ -15,8 +15,12 @@ while allowing the invocable itself to remain platform agnostic.
 import logging
 from edk2toolext import edk2_logging
 from edk2toolext.environment import self_describing_environment
-from edk2toolext.invocables.edk2_multipkg_aware_invocable import Edk2MultiPkgAwareInvocable
-from edk2toolext.invocables.edk2_multipkg_aware_invocable import MultiPkgAwareSettingsInterface
+from edk2toolext.invocables.edk2_multipkg_aware_invocable import (
+    Edk2MultiPkgAwareInvocable,
+)
+from edk2toolext.invocables.edk2_multipkg_aware_invocable import (
+    MultiPkgAwareSettingsInterface,
+)
 
 
 class UpdateSettingsManager(MultiPkgAwareSettingsInterface):
@@ -28,14 +32,17 @@ class UpdateSettingsManager(MultiPkgAwareSettingsInterface):
     Update settings manager has no additional APIs not already defined in it's super class, however
     The class should still be overwritten by the platform.
     """
+
     pass
 
 
 def build_env_changed(build_env, build_env_2):
     """Return True if build_env has changed."""
-    return (build_env.paths != build_env_2.paths) or \
-           (build_env.extdeps != build_env_2.extdeps) or \
-           (build_env.plugins != build_env_2.plugins)
+    return (
+        (build_env.paths != build_env_2.paths)
+        or (build_env.extdeps != build_env_2.extdeps)
+        or (build_env.plugins != build_env_2.plugins)
+    )
 
 
 class Edk2Update(Edk2MultiPkgAwareInvocable):
@@ -48,10 +55,16 @@ class Edk2Update(Edk2MultiPkgAwareInvocable):
         ws_root = self.GetWorkspaceRoot()
         scopes = self.GetActiveScopes()
         skipped_dirs = self.GetSkippedDirectories()
-        (build_env, shell_env) = self_describing_environment.BootstrapEnvironment(ws_root, scopes, skipped_dirs)
-        (success, failure) = self_describing_environment.UpdateDependencies(ws_root, scopes, skipped_dirs)
+        (build_env, shell_env) = self_describing_environment.BootstrapEnvironment(
+            ws_root, scopes, skipped_dirs
+        )
+        (success, failure) = self_describing_environment.UpdateDependencies(
+            ws_root, scopes, skipped_dirs
+        )
         if success != 0:
-            logging.log(edk2_logging.SECTION, f"\tUpdated/Verified {success} dependencies")
+            logging.log(
+                edk2_logging.SECTION, f"\tUpdated/Verified {success} dependencies"
+            )
         return (build_env, shell_env, failure)
 
     def GetVerifyCheckRequired(self):
@@ -94,21 +107,31 @@ class Edk2Update(Edk2MultiPkgAwareInvocable):
         while RetryCount < Edk2Update.MAX_RETRY_COUNT:
             (build_env, shell_env, failure_count) = self.PerformUpdate()
 
-            if not build_env_changed(build_env, build_env_old):  # check if the environment changed on our last update
+            if not build_env_changed(
+                build_env, build_env_old
+            ):  # check if the environment changed on our last update
                 break
             # if the environment has changed, increment the retry count and notify user
             RetryCount += 1
-            logging.log(edk2_logging.SECTION,
-                        f"Something in the environment changed. Updating environment again. Pass {RetryCount}")
+            logging.log(
+                edk2_logging.SECTION,
+                f"Something in the environment changed. Updating environment again. Pass {RetryCount}",
+            )
 
             build_env_old = build_env
             self_describing_environment.DestroyEnvironment()
 
         if failure_count != 0:
-            logging.error(f"We were unable to successfully update {failure_count} dependencies in environment")
+            logging.error(
+                f"We were unable to successfully update {failure_count} dependencies in environment"
+            )
         if RetryCount >= Edk2Update.MAX_RETRY_COUNT:
-            logging.error(f"We did an update more than {Edk2Update.MAX_RETRY_COUNT} times.")
-            logging.error("Please check your dependencies and make sure you don't have any circular ones.")
+            logging.error(
+                f"We did an update more than {Edk2Update.MAX_RETRY_COUNT} times."
+            )
+            logging.error(
+                "Please check your dependencies and make sure you don't have any circular ones."
+            )
             return 1
         return failure_count
 

--- a/edk2toolext/nuget_publishing.py
+++ b/edk2toolext/nuget_publishing.py
@@ -33,9 +33,10 @@ LICENSE_IDENTIFIER_SUPPORTED = {
 
 class NugetSupport(object):
     """Support object for Nuget Publishing tool to configure NuPkg information, pack and send."""
+
     # NOTE: This *should* have a namespace (http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd)
     #       but ElementTree is incredibly stupid with namespaces.
-    NUSPEC_TEMPLATE_XML = r'''<?xml version="1.0" encoding="utf-8"?>
+    NUSPEC_TEMPLATE_XML = r"""<?xml version="1.0" encoding="utf-8"?>
 <package>
     <metadata>
         <!-- Required elements-->
@@ -56,7 +57,7 @@ class NugetSupport(object):
     <files>
         <file src="" target="" />
     </files>
-</package>'''
+</package>"""
 
     RELEASE_NOTE_SHORT_STRING_MAX_LENGTH = 500
 
@@ -71,12 +72,14 @@ class NugetSupport(object):
         self.NewVersion = None
         self.ConfigChanged = False
 
-        if (ConfigFile is not None):
+        if ConfigFile is not None:
             self.FromConfigfile(ConfigFile)
             self.Name = self.ConfigData["name"]
         else:
-            if (Name is None):
-                raise ValueError("Cannot construct object with both Name and ConfigFile as None")
+            if Name is None:
+                raise ValueError(
+                    "Cannot construct object with both Name and ConfigFile as None"
+                )
             self.ConfigData = {"name": Name}
             self.Config = None
 
@@ -88,18 +91,18 @@ class NugetSupport(object):
 
     def ToConfigFile(self, filepath=None):
         """Save config to a yaml file."""
-        if (not self.ConfigChanged):
+        if not self.ConfigChanged:
             logging.debug("No Config Changes.  Skip Writing config file")
             return 0
 
-        if (filepath is None and self.Config is None):
+        if filepath is None and self.Config is None:
             logging.error("No Config File to save to.")
             return -1
 
-        if (filepath is not None):
+        if filepath is not None:
             self.Config = filepath
 
-        if (filepath is None):
+        if filepath is None:
             logging.error("No filepath for Config File")
 
         with open(filepath, "w") as c:
@@ -114,9 +117,19 @@ class NugetSupport(object):
         with open(self.Config, "r") as c:
             self.ConfigData = yaml.safe_load(c)
 
-    def SetBasicData(self, authors, license, project, description, server, copyright,
-                     repositoryType=None, repositoryUrl=None, repositoryBranch=None,
-                     repositoryCommit=None):
+    def SetBasicData(
+        self,
+        authors,
+        license,
+        project,
+        description,
+        server,
+        copyright,
+        repositoryType=None,
+        repositoryUrl=None,
+        repositoryBranch=None,
+        repositoryCommit=None,
+    ):
         """Set basic data in the config data."""
         self.ConfigData["author_string"] = authors
         if license:
@@ -195,7 +208,7 @@ class NugetSupport(object):
         """Print info about the Nuget Object."""
         print("=======================================")
         print(" Name:        " + self.Name)
-        if (self.Config):
+        if self.Config:
             print(" ConfigFile:  " + self.Config)
         else:
             print(" ConfigFile:  NOT SET")
@@ -214,7 +227,7 @@ class NugetSupport(object):
         """Logs info about Nuget Object to the logger."""
         logging.debug("=======================================")
         logging.debug(" Name:        " + self.Name)
-        if (self.Config):
+        if self.Config:
             logging.debug(" ConfigFile:  " + self.Config)
         else:
             logging.debug(" ConfigFile:  NOT SET")
@@ -236,13 +249,17 @@ class NugetSupport(object):
 
     def _MakeNuspecXml(self, ContentDir, ReleaseNotesText=None):
         package = etree.fromstring(NugetSupport.NUSPEC_TEMPLATE_XML)
-        package.attrib["xmlns"] = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"
+        package.attrib[
+            "xmlns"
+        ] = "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"
         meta = package.find("./metadata")
         meta.find("id").text = self.Name
         meta.find("version").text = self.NewVersion
         meta.find("authors").text = self.ConfigData["author_string"]
         meta.find("projectUrl").text = self.ConfigData["project_url"]
-        repository_item_present = bool([k for k in self.ConfigData.keys() if "repository" in k.lower()])
+        repository_item_present = bool(
+            [k for k in self.ConfigData.keys() if "repository" in k.lower()]
+        )
         r = meta.find("repository")
         if repository_item_present:
             if "repository_type" in self.ConfigData:
@@ -270,29 +287,41 @@ class NugetSupport(object):
         if os.path.isfile(self.ConfigData["license"]):
             meta.find("license").text = os.path.basename(self.ConfigData["license"])
             meta.find("license").attrib["type"] = "file"
-            f = etree.Element("file", attrib={"src": self.ConfigData["license"], "target": ""})
+            f = etree.Element(
+                "file", attrib={"src": self.ConfigData["license"], "target": ""}
+            )
             files.append(f)
         else:
             meta.find("license").text = self.ConfigData["license"]
             meta.find("license").attrib["type"] = "expression"
 
-        if (ReleaseNotesText is not None):
+        if ReleaseNotesText is not None:
             logging.debug("Make Nuspec Xml - ReleaseNotesText is not none.")
             #
             # Make sure it doesn't exceed reasonable length of string
             #
-            if (len(ReleaseNotesText) > NugetSupport.RELEASE_NOTE_SHORT_STRING_MAX_LENGTH):
-                logging.info("Make Nuspec Xml - ReleaseNotesText too long.  Length is (%d)" % len(ReleaseNotesText))
+            if (
+                len(ReleaseNotesText)
+                > NugetSupport.RELEASE_NOTE_SHORT_STRING_MAX_LENGTH
+            ):
+                logging.info(
+                    "Make Nuspec Xml - ReleaseNotesText too long.  Length is (%d)"
+                    % len(ReleaseNotesText)
+                )
                 logging.debug("Original ReleaseNotesText is: %s" % ReleaseNotesText)
                 # cut it off at max length
-                ReleaseNotesText = ReleaseNotesText[:NugetSupport.RELEASE_NOTE_SHORT_STRING_MAX_LENGTH]
+                ReleaseNotesText = ReleaseNotesText[
+                    : NugetSupport.RELEASE_NOTE_SHORT_STRING_MAX_LENGTH
+                ]
                 # walk back to trim at last end of sentence
                 ReleaseNotesText = ReleaseNotesText.rpartition(".")[0].strip()
                 logging.debug("New ReleaseNotesText is: %s" % ReleaseNotesText)
 
             meta.find("releaseNotes").text = ReleaseNotesText
         else:
-            logging.debug("Make Nuspec Xml - ReleaseNotesText None. Removing element from nuspec.")
+            logging.debug(
+                "Make Nuspec Xml - ReleaseNotesText None. Removing element from nuspec."
+            )
             meta.remove(meta.find("releaseNotes"))
 
         return etree.tostring(package)
@@ -340,11 +369,13 @@ class NugetSupport(object):
         # cmd += ["-NonInteractive"]
         ret = RunCmd(cmd[0], " ".join(cmd[1:]))
 
-        if (ret != 0):
+        if ret != 0:
             logging.error("Failed on nuget command.  RC = 0x%x" % ret)
             return ret
 
-        self.NuPackageFile = os.path.join(OutputDirectory, self._GetNuPkgFileName(self.NewVersion))
+        self.NuPackageFile = os.path.join(
+            OutputDirectory, self._GetNuPkgFileName(self.NewVersion)
+        )
         self.TempFileToDelete.append(self.NuPackageFile)
         return ret
 
@@ -354,9 +385,11 @@ class NugetSupport(object):
         Raises:
             (Exception): file path is invalid
         """
-        if (not os.path.isfile(nuPackage)):
+        if not os.path.isfile(nuPackage):
             raise Exception("Invalid file path for NuPkg file")
-        logging.debug("Pushing %s file to server %s" % (nuPackage, self.ConfigData["server_url"]))
+        logging.debug(
+            "Pushing %s file to server %s" % (nuPackage, self.ConfigData["server_url"])
+        )
 
         cmd = NugetDependency.GetNugetCmd()
         cmd += ["push", nuPackage]
@@ -367,14 +400,16 @@ class NugetSupport(object):
         output_buffer = StringIO()
         ret = RunCmd(cmd[0], " ".join(cmd[1:]), outstream=output_buffer)
 
-        if (ret != 0):
+        if ret != 0:
             # Rewind the buffer and capture the contents.
             output_buffer.seek(0)
             output_contents = output_buffer.read()
 
             # Check for the API message.
             if "API key is invalid".lower() in output_contents.lower():
-                logging.critical("API key is invalid. Please use --ApiKey to provide a valid key.")
+                logging.critical(
+                    "API key is invalid. Please use --ApiKey to provide a valid key."
+                )
 
             # Generic error.
             logging.error("Failed on nuget command.  RC = 0x%x" % ret)
@@ -385,89 +420,219 @@ class NugetSupport(object):
 def GatherArguments():
     """Adds CLI arguments for controlling the nuget_publishing tool."""
     tempparser = argparse.ArgumentParser(
-        description='Nuget Helper Script for creating, packing, and pushing packages', add_help=False)
-    tempparser.add_argument('--Operation', dest="op", choices=["New", "Pack", "Push", "PackAndPush"], required=True)
+        description="Nuget Helper Script for creating, packing, and pushing packages",
+        add_help=False,
+    )
+    tempparser.add_argument(
+        "--Operation",
+        dest="op",
+        choices=["New", "Pack", "Push", "PackAndPush"],
+        required=True,
+    )
 
     # Get the operation the user wants to do
     (args, rest) = tempparser.parse_known_args()
 
     # now build up the real parser with required parameters
-    parser = argparse.ArgumentParser(description='Nuget Helper Script for creating, packing, and pushing packages')
-    parser.add_argument("--Dirty", dest="Dirty", action="store_true", help="Keep all temp files", default=False)
-    parser.add_argument('--Operation', dest="Operation", choices=["New", "Pack", "Push", "PackAndPush"], required=True)
-    parser.add_argument("--OutputLog", dest="OutputLog", help="Create an output log file")
+    parser = argparse.ArgumentParser(
+        description="Nuget Helper Script for creating, packing, and pushing packages"
+    )
+    parser.add_argument(
+        "--Dirty",
+        dest="Dirty",
+        action="store_true",
+        help="Keep all temp files",
+        default=False,
+    )
+    parser.add_argument(
+        "--Operation",
+        dest="Operation",
+        choices=["New", "Pack", "Push", "PackAndPush"],
+        required=True,
+    )
+    parser.add_argument(
+        "--OutputLog", dest="OutputLog", help="Create an output log file"
+    )
 
-    if (args.op.lower() == "new"):
-        parser.add_argument("--ConfigFileFolderPath", dest="ConfigFileFolderPath",
-                            help="<Required>Path to folder to save new config file to", required=True)
-        parser.add_argument('--Name',
-                            dest='Name',
-                            help='<Required> The unique id/name of the package.  This is a string naming the package',
-                            required=True)
-        parser.add_argument('--Author', dest="Author", help="<Required> Author string for publishing", required=True)
-        parser.add_argument("--ProjectUrl", dest="Project", help="<Required> Project Url", required=True)
-        repo_group = parser.add_argument_group(title="Repository Parameters",
-                                               description="Optional Repository Parameters")
-        repo_group.add_argument("--RepositoryType", dest="RepositoryType", help="<Optional> Repository Type",
-                                required=False)
-        repo_group.add_argument("--RepositoryUrl", dest="RepositoryUrl", help="<Optional> Repository Url",
-                                required=False)
-        repo_group.add_argument("--RepositoryBranch", dest="RepositoryBranch", help="<Optional> Repository Branch",
-                                required=False)
-        repo_group.add_argument("--RepositoryCommit", dest="RepositoryCommit", help="<Optional> Repository Commit",
-                                required=False)
-        parser.add_argument('--LicenseIdentifier', dest="LicenseIdentifier", default=None,
-                            choices=LICENSE_IDENTIFIER_SUPPORTED.keys(), help="Standard Licenses")
-        parser.add_argument('--Description', dest="Description",
-                            help="<Required> Description of package.", required=True)
-        parser.add_argument("--FeedUrl", dest="FeedUrl",
-                            help="<Required>Feed Url of the nuget server feed", required=True)
-        parser.add_argument('--Copyright', dest="Copyright", help="Copyright string", required=False)
+    if args.op.lower() == "new":
+        parser.add_argument(
+            "--ConfigFileFolderPath",
+            dest="ConfigFileFolderPath",
+            help="<Required>Path to folder to save new config file to",
+            required=True,
+        )
+        parser.add_argument(
+            "--Name",
+            dest="Name",
+            help="<Required> The unique id/name of the package.  This is a string naming the package",
+            required=True,
+        )
+        parser.add_argument(
+            "--Author",
+            dest="Author",
+            help="<Required> Author string for publishing",
+            required=True,
+        )
+        parser.add_argument(
+            "--ProjectUrl", dest="Project", help="<Required> Project Url", required=True
+        )
+        repo_group = parser.add_argument_group(
+            title="Repository Parameters", description="Optional Repository Parameters"
+        )
+        repo_group.add_argument(
+            "--RepositoryType",
+            dest="RepositoryType",
+            help="<Optional> Repository Type",
+            required=False,
+        )
+        repo_group.add_argument(
+            "--RepositoryUrl",
+            dest="RepositoryUrl",
+            help="<Optional> Repository Url",
+            required=False,
+        )
+        repo_group.add_argument(
+            "--RepositoryBranch",
+            dest="RepositoryBranch",
+            help="<Optional> Repository Branch",
+            required=False,
+        )
+        repo_group.add_argument(
+            "--RepositoryCommit",
+            dest="RepositoryCommit",
+            help="<Optional> Repository Commit",
+            required=False,
+        )
+        parser.add_argument(
+            "--LicenseIdentifier",
+            dest="LicenseIdentifier",
+            default=None,
+            choices=LICENSE_IDENTIFIER_SUPPORTED.keys(),
+            help="Standard Licenses",
+        )
+        parser.add_argument(
+            "--Description",
+            dest="Description",
+            help="<Required> Description of package.",
+            required=True,
+        )
+        parser.add_argument(
+            "--FeedUrl",
+            dest="FeedUrl",
+            help="<Required>Feed Url of the nuget server feed",
+            required=True,
+        )
+        parser.add_argument(
+            "--Copyright", dest="Copyright", help="Copyright string", required=False
+        )
 
-    elif (args.op.lower() == "pack" or args.op.lower() == "packandpush"):
-        parser.add_argument("--ConfigFilePath", dest="ConfigFilePath",
-                            help="<Required>Path to config file", required=True)
-        parser.add_argument('--Version', dest="Version", help="<Required> Version to publish", required=True)
-        parser.add_argument('--ReleaseNotesText', dest="ReleaseNotes",
-                            help="<Optional>Release Notes String", required=False)
-        parser.add_argument('--InputFolderPath', dest="InputFolderPath",
-                            help="<Required>Relative/Absolute Path to folder containing content to pack.",
-                            required=True)
-        parser.add_argument('--Copyright', dest="Copyright", help="<Optional>Change the Copyright string")
-        parser.add_argument('--t', "-tag", dest="Tags", type=str,
-                            help="<Optional>Add tags to the nuspec. Multiple are --t Tag1,Tag2 or --t Tag1 --t Tag2",
-                            action="append", default=[])
-        parser.add_argument('--ApiKey', dest="ApiKey",
-                            help="<Optional>Api key to use. Default is 'VSTS' which will invoke interactive login",
-                            default="VSTS")
-        parser.add_argument('--CustomLicensePath', dest="CustomLicensePath", default=None,
-                            help="<Optional> If CustomLicense set in `new` phase, provide absolute path of License \
-                            File to pack. Does not override existing valid license.")
-        repo_group = parser.add_argument_group(title="Repository Parameters",
-                                               description="Optional Repository Parameters")
-        repo_group.add_argument("--RepositoryType", dest="RepositoryType", help="<Optional> Repository Type",
-                                required=False)
-        repo_group.add_argument("--RepositoryUrl", dest="RepositoryUrl", help="<Optional> Change the repository Url",
-                                required=False)
-        repo_group.add_argument("--RepositoryBranch", dest="RepositoryBranch",
-                                help="<Optional> Change the repository branch", required=False)
-        repo_group.add_argument("--RepositoryCommit", dest="RepositoryCommit",
-                                help="<Optional> Change the repository commit", required=False)
+    elif args.op.lower() == "pack" or args.op.lower() == "packandpush":
+        parser.add_argument(
+            "--ConfigFilePath",
+            dest="ConfigFilePath",
+            help="<Required>Path to config file",
+            required=True,
+        )
+        parser.add_argument(
+            "--Version",
+            dest="Version",
+            help="<Required> Version to publish",
+            required=True,
+        )
+        parser.add_argument(
+            "--ReleaseNotesText",
+            dest="ReleaseNotes",
+            help="<Optional>Release Notes String",
+            required=False,
+        )
+        parser.add_argument(
+            "--InputFolderPath",
+            dest="InputFolderPath",
+            help="<Required>Relative/Absolute Path to folder containing content to pack.",
+            required=True,
+        )
+        parser.add_argument(
+            "--Copyright",
+            dest="Copyright",
+            help="<Optional>Change the Copyright string",
+        )
+        parser.add_argument(
+            "--t",
+            "-tag",
+            dest="Tags",
+            type=str,
+            help="<Optional>Add tags to the nuspec. Multiple are --t Tag1,Tag2 or --t Tag1 --t Tag2",
+            action="append",
+            default=[],
+        )
+        parser.add_argument(
+            "--ApiKey",
+            dest="ApiKey",
+            help="<Optional>Api key to use. Default is 'VSTS' which will invoke interactive login",
+            default="VSTS",
+        )
+        parser.add_argument(
+            "--CustomLicensePath",
+            dest="CustomLicensePath",
+            default=None,
+            help="<Optional> If CustomLicense set in `new` phase, provide absolute path of License \
+                            File to pack. Does not override existing valid license.",
+        )
+        repo_group = parser.add_argument_group(
+            title="Repository Parameters", description="Optional Repository Parameters"
+        )
+        repo_group.add_argument(
+            "--RepositoryType",
+            dest="RepositoryType",
+            help="<Optional> Repository Type",
+            required=False,
+        )
+        repo_group.add_argument(
+            "--RepositoryUrl",
+            dest="RepositoryUrl",
+            help="<Optional> Change the repository Url",
+            required=False,
+        )
+        repo_group.add_argument(
+            "--RepositoryBranch",
+            dest="RepositoryBranch",
+            help="<Optional> Change the repository branch",
+            required=False,
+        )
+        repo_group.add_argument(
+            "--RepositoryCommit",
+            dest="RepositoryCommit",
+            help="<Optional> Change the repository commit",
+            required=False,
+        )
 
-    elif (args.op.lower() == "push"):
-        parser.add_argument("--ConfigFilePath", dest="ConfigFilePath",
-                            help="<Required>Path to config file",
-                            required=True)
-        parser.add_argument('--PackageFile', dest="PackageFile", help="<Required>Path To Package File", required=True)
-        parser.add_argument('--ApiKey', dest="ApiKey",
-                            help="<Optional>Api key to use. Default is 'VSTS' which will invoke interactive login",
-                            default="VSTS")
+    elif args.op.lower() == "push":
+        parser.add_argument(
+            "--ConfigFilePath",
+            dest="ConfigFilePath",
+            help="<Required>Path to config file",
+            required=True,
+        )
+        parser.add_argument(
+            "--PackageFile",
+            dest="PackageFile",
+            help="<Required>Path To Package File",
+            required=True,
+        )
+        parser.add_argument(
+            "--ApiKey",
+            dest="ApiKey",
+            help="<Optional>Api key to use. Default is 'VSTS' which will invoke interactive login",
+            default="VSTS",
+        )
 
-    if (args.op.lower() == "pack"):
-        parser.add_argument('--OutputFolderPath',
-                            dest="OutputFolderPath",
-                            help="<Optional>Output folder where nupkg will be saved.  Default is cwd",
-                            default=os.getcwd())
+    if args.op.lower() == "pack":
+        parser.add_argument(
+            "--OutputFolderPath",
+            dest="OutputFolderPath",
+            help="<Optional>Output folder where nupkg will be saved.  Default is cwd",
+            default=os.getcwd(),
+        )
 
     return parser.parse_args()
 
@@ -478,32 +643,41 @@ def main():
     ret = 0
 
     # setup file based logging if outputReport specified
-    if (args.OutputLog):
-        if (len(args.OutputLog) < 2):
+    if args.OutputLog:
+        if len(args.OutputLog) < 2:
             logging.critical("the output log file parameter is invalid")
             return -2
 
         # setup file based logging
-        filelogger = logging.FileHandler(filename=args.OutputLog, mode='w')
+        filelogger = logging.FileHandler(filename=args.OutputLog, mode="w")
         filelogger.setLevel(logging.DEBUG)
-        logging.getLogger('').addHandler(filelogger)
+        logging.getLogger("").addHandler(filelogger)
 
-    logging.info("Log Started: " + datetime.datetime.strftime(datetime.datetime.now(), "%A, %B %d, %Y %I:%M%p"))
+    logging.info(
+        "Log Started: "
+        + datetime.datetime.strftime(datetime.datetime.now(), "%A, %B %d, %Y %I:%M%p")
+    )
 
     TempOutDir = None
     NuPkgFilePath = None
 
-    if (args.Operation.lower() == "new"):
+    if args.Operation.lower() == "new":
         logging.critical("Generating new nuget configuration...")
         logging.debug("Checking input parameters for new")
-        ConfigFilePath = os.path.join(args.ConfigFileFolderPath, args.Name.strip() + ".config.yaml")
+        ConfigFilePath = os.path.join(
+            args.ConfigFileFolderPath, args.Name.strip() + ".config.yaml"
+        )
 
-        if (not os.path.isdir(args.ConfigFileFolderPath)):
-            logging.critical("Config File Folder Path doesn't exist.  %s" % args.ConfigFileFolderPath)
+        if not os.path.isdir(args.ConfigFileFolderPath):
+            logging.critical(
+                "Config File Folder Path doesn't exist.  %s" % args.ConfigFileFolderPath
+            )
             raise Exception("Invalid Config File Folder.  Doesn't exist")
 
-        if (os.path.isfile(ConfigFilePath)):
-            logging.critical("Config File already exists at that path.  %s" % ConfigFilePath)
+        if os.path.isfile(ConfigFilePath):
+            logging.critical(
+                "Config File already exists at that path.  %s" % ConfigFilePath
+            )
             raise Exception("Can't Create New Config file when file already exists")
 
         nu = NugetSupport(Name=args.Name)
@@ -525,29 +699,38 @@ def main():
             args.RepositoryType,
             args.RepositoryUrl,
             args.RepositoryBranch,
-            args.RepositoryCommit)
+            args.RepositoryCommit,
+        )
         nu.LogObject()
         ret = nu.ToConfigFile(ConfigFilePath)
         return ret
 
-    elif (args.Operation.lower() == "pack" or args.Operation.lower() == "packandpush"):
+    elif args.Operation.lower() == "pack" or args.Operation.lower() == "packandpush":
         logging.critical("Creating nuget package")
         logging.debug("Checking input parameters for packing")
         # check args
-        if (not os.path.isfile(args.ConfigFilePath)):
-            logging.critical("Invalid Config File (%s).  File doesn't exist" % args.ConfigFilePath)
+        if not os.path.isfile(args.ConfigFilePath):
+            logging.critical(
+                "Invalid Config File (%s).  File doesn't exist" % args.ConfigFilePath
+            )
             raise Exception("Invalid Config File.  File doesn't exist")
-        if (not os.path.isdir(args.InputFolderPath)):
-            logging.critical("Invalid Input folder (%s).  Folder doesn't exist" % args.InputFolderPath)
+        if not os.path.isdir(args.InputFolderPath):
+            logging.critical(
+                "Invalid Input folder (%s).  Folder doesn't exist"
+                % args.InputFolderPath
+            )
             raise Exception("Invalid Input folder.  folder doesn't exist")
         contents = os.listdir(args.InputFolderPath)
         logging.debug("Input Folder contains %d files" % len(contents))
-        if (len(contents) == 0):
+        if len(contents) == 0:
             logging.critical("No binary contents to pack in %s" % args.InputFolderPath)
             raise Exception("No binary contents to package")
 
         # make a temp dir for the pack operation which actually creates files
-        TempOutDir = os.path.join(os.getcwd(), "_TEMP_" + str(datetime.datetime.now().time()).replace(":", "_"))
+        TempOutDir = os.path.join(
+            os.getcwd(),
+            "_TEMP_" + str(datetime.datetime.now().time()).replace(":", "_"),
+        )
         os.mkdir(TempOutDir)
 
         nu = NugetSupport(ConfigFile=args.ConfigFilePath)
@@ -555,24 +738,36 @@ def main():
         if not nu.IsValidLicense():
             # Invalid License and not setting it with a custom License
             if args.CustomLicensePath is None:
-                logging.critical("Standard License not found in config file and custom license not provided.")
-                logging.critical("Provide a custom license path with --CustomLicensePath.")
+                logging.critical(
+                    "Standard License not found in config file and custom license not provided."
+                )
+                logging.critical(
+                    "Provide a custom license path with --CustomLicensePath."
+                )
                 raise Exception("Invalid License.")
             nu.UpdateLicensePath(args.CustomLicensePath)
 
         if not nu.IsValidLicense():
             logging.critical("Invalid Custom License")
-            logging.critical("    Verify custom license file name is license.txt or license.md")
-            logging.critical("    Verify custom license file path is in absolute format and valid")
+            logging.critical(
+                "    Verify custom license file name is license.txt or license.md"
+            )
+            logging.critical(
+                "    Verify custom license file path is in absolute format and valid"
+            )
             raise Exception("Invalid License.")
 
-        if (args.Copyright is not None):
+        if args.Copyright is not None:
             nu.UpdateCopyright(args.Copyright)
 
-        nu.UpdateRepositoryInfo(args.RepositoryType, args.RepositoryUrl,
-                                args.RepositoryBranch, args.RepositoryCommit)
+        nu.UpdateRepositoryInfo(
+            args.RepositoryType,
+            args.RepositoryUrl,
+            args.RepositoryBranch,
+            args.RepositoryCommit,
+        )
 
-        if (len(args.Tags) > 0):
+        if len(args.Tags) > 0:
             tagListSet = set()
             for item in args.Tags:  # Parse out the individual packages
                 item_list = item.split(",")
@@ -582,53 +777,63 @@ def main():
                     tagListSet.add(individual_item.strip())
             tagList = list(tagListSet)
             nu.UpdateTags(tagList)
-        '''
+        """
         ret = nu.ToConfigFile()
         if (ret != 0):
             logging.error("Failed to save config file.  Return Code 0x%x" % ret)
             return ret
-        '''
+        """
 
         ret = nu.Pack(args.Version, TempOutDir, args.InputFolderPath, args.ReleaseNotes)
-        if (ret != 0):
+        if ret != 0:
             logging.error("Failed to pack.  Return Code 0x%x" % ret)
             return ret
 
         NuPkgFilePath = nu.NuPackageFile
 
-    if (args.Operation.lower() == "pack"):
-        if (not os.path.isdir(args.OutputFolderPath)):
-            logging.critical("Invalid Pack Output Folder (%s).  Folder doesn't exist" % args.OutputFolderPath)
+    if args.Operation.lower() == "pack":
+        if not os.path.isdir(args.OutputFolderPath):
+            logging.critical(
+                "Invalid Pack Output Folder (%s).  Folder doesn't exist"
+                % args.OutputFolderPath
+            )
             raise Exception("Invalid Output folder.  folder doesn't exist")
         # since it is pack only lets copy nupkg file to output
-        shutil.copyfile(NuPkgFilePath, os.path.join(args.OutputFolderPath, os.path.basename(NuPkgFilePath)))
-        NuPkgFilePath = os.path.join(args.OutputFolderPath, os.path.basename(NuPkgFilePath))
+        shutil.copyfile(
+            NuPkgFilePath,
+            os.path.join(args.OutputFolderPath, os.path.basename(NuPkgFilePath)),
+        )
+        NuPkgFilePath = os.path.join(
+            args.OutputFolderPath, os.path.basename(NuPkgFilePath)
+        )
 
-    if (args.Operation.lower() == "push"):
+    if args.Operation.lower() == "push":
         # set the parameters for push
         logging.debug("Checking input parameters for push")
         # check args
-        if (not os.path.isfile(args.ConfigFilePath)):
-            logging.critical("Invalid Config File (%s).  File doesn't exist" % args.ConfigFilePath)
+        if not os.path.isfile(args.ConfigFilePath):
+            logging.critical(
+                "Invalid Config File (%s).  File doesn't exist" % args.ConfigFilePath
+            )
             raise Exception("Invalid Config File.  File doesn't exist")
         NuPkgFilePath = args.PackageFile
         nu = NugetSupport(ConfigFile=args.ConfigFilePath)
 
-    if (args.Operation.lower() == "push" or args.Operation.lower() == "packandpush"):
+    if args.Operation.lower() == "push" or args.Operation.lower() == "packandpush":
         # do the pushing
         logging.critical("Pushing the package")
         logging.debug("NuPkgFilePath is %s" % NuPkgFilePath)
         # check args
-        if (not os.path.isfile(NuPkgFilePath)):
+        if not os.path.isfile(NuPkgFilePath):
             logging.critical("NuPkgFilePath is not valid file.  %s" % NuPkgFilePath)
             raise Exception("Invalid Pkg File.  File doesn't exist")
         ret = nu.Push(NuPkgFilePath, args.ApiKey)
 
     nu.LogObject()
     nu.ToConfigFile(args.ConfigFilePath)  # save any changes
-    if (not args.Dirty):
+    if not args.Dirty:
         nu.CleanUp()
-        if (TempOutDir is not None):
+        if TempOutDir is not None:
             os.removedirs(TempOutDir)
     return ret
 
@@ -636,7 +841,7 @@ def main():
 def go():
     """Main entry into the nuget publishing tool."""
     # setup main console as logger
-    logger = logging.getLogger('')
+    logger = logging.getLogger("")
     logger.setLevel(logging.DEBUG)
     formatter = logging.Formatter("%(levelname)s - %(message)s")
     console = logging.StreamHandler()
@@ -656,5 +861,5 @@ def go():
     sys.exit(retcode)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     go()

--- a/edk2toolext/omnicache.py
+++ b/edk2toolext/omnicache.py
@@ -37,8 +37,9 @@ OMNICACHE_VERSION = "0.12"
 PRE_0_11_OMNICACHE_FILENAME = "omnicache.yaml"
 
 
-class Omnicache():
+class Omnicache:
     """Class for managing an omnicache instance."""
+
     def __init__(self, cachepath, create=False, convert=True):
         """Initializes an omnicache.
 
@@ -52,13 +53,17 @@ class Omnicache():
         self._InvalidateUrlLookupCache()
 
         (valid, isConversionCandidate) = self._ValidateOmnicache()
-        if (not valid):
+        if not valid:
             if create and not isConversionCandidate:
                 self._InitOmnicache()
-            elif (convert and isConversionCandidate):
+            elif convert and isConversionCandidate:
                 self._ConvertOmnicache()
             else:
-                logging.critical("Omnicache at {0} not valid, and cannot create/convert.".format(cachepath))
+                logging.critical(
+                    "Omnicache at {0} not valid, and cannot create/convert.".format(
+                        cachepath
+                    )
+                )
                 raise RuntimeError("Invalid cache path: {0}".format(cachepath))
 
     def _ValidateOmnicache(self):
@@ -71,30 +76,61 @@ class Omnicache():
         NOTE: "convertible" is True if an older Omnicache that can be converted exists at self.path.
         """
         logging.info("Checking if {0} is valid omnicache.".format(self.path))
-        if (not os.path.isdir(self.path)):
-            logging.debug("{0} does not exist - not valid (not convertible).".format(self.path))
+        if not os.path.isdir(self.path):
+            logging.debug(
+                "{0} does not exist - not valid (not convertible).".format(self.path)
+            )
             return (False, False)
         out = StringIO()
-        ret = RunCmd("git", "rev-parse --is-bare-repository", workingdir=self.path, outstream=out)
-        if (ret != 0):
-            logging.debug("{0} error getting repo state - not valid (not convertible).".format(self.path))
+        ret = RunCmd(
+            "git", "rev-parse --is-bare-repository", workingdir=self.path, outstream=out
+        )
+        if ret != 0:
+            logging.debug(
+                "{0} error getting repo state - not valid (not convertible).".format(
+                    self.path
+                )
+            )
             return (False, False)
-        if (out.getvalue().strip().lower() == "true"):
-            if (os.path.exists(os.path.join(self.path, PRE_0_11_OMNICACHE_FILENAME))):
-                logging.debug("{0} - old config file present. not valid (is convertible).".format(self.path))
+        if out.getvalue().strip().lower() == "true":
+            if os.path.exists(os.path.join(self.path, PRE_0_11_OMNICACHE_FILENAME)):
+                logging.debug(
+                    "{0} - old config file present. not valid (is convertible).".format(
+                        self.path
+                    )
+                )
                 return (False, True)
             out = StringIO()
-            ret = RunCmd("git", "config --local omnicache.metadata.version", workingdir=self.path, outstream=out)
-            if (ret != 0):
-                logging.debug("{0} - error retrieving omnicache version. not valid (is convertible).".format(self.path))
+            ret = RunCmd(
+                "git",
+                "config --local omnicache.metadata.version",
+                workingdir=self.path,
+                outstream=out,
+            )
+            if ret != 0:
+                logging.debug(
+                    "{0} - error retrieving omnicache version. not valid (is convertible).".format(
+                        self.path
+                    )
+                )
                 return (False, True)
-            if (out.getvalue().strip() == OMNICACHE_VERSION):
-                logging.debug("{0} - matching omnicache version. valid (convertible don't care).".format(self.path))
+            if out.getvalue().strip() == OMNICACHE_VERSION:
+                logging.debug(
+                    "{0} - matching omnicache version. valid (convertible don't care).".format(
+                        self.path
+                    )
+                )
                 return (True, True)
             else:
-                logging.debug("{0} - non-matching omnicache version. not valid (is convertible).".format(self.path))
+                logging.debug(
+                    "{0} - non-matching omnicache version. not valid (is convertible).".format(
+                        self.path
+                    )
+                )
                 return (False, True)
-        logging.debug("{0} - not a bare repo. not valid (not convertible).".format(self.path))
+        logging.debug(
+            "{0} - not a bare repo. not valid (not convertible).".format(self.path)
+        )
         return (False, False)
 
     def _InitOmnicache(self):
@@ -102,50 +138,78 @@ class Omnicache():
         logging.critical("Initializing Omnicache in {0}".format(self.path))
         os.makedirs(self.path, exist_ok=True)
         ret = RunCmd("git", "init --bare", workingdir=self.path)
-        if (ret != 0):
+        if ret != 0:
             return ret
         # by default, git fetch is single-threaded. This configuration allows git to use a "reasonable" default
         # (presently equal to the number of cpus) to execute the fetch in parallel.
         ret = RunCmd("git", "config --local fetch.parallel 0", workingdir=self.path)
-        if (ret != 0):
+        if ret != 0:
             return ret
 
-        return RunCmd("git",
-                      "config --local omnicache.metadata.version {0}".format(OMNICACHE_VERSION),
-                      workingdir=self.path)
+        return RunCmd(
+            "git",
+            "config --local omnicache.metadata.version {0}".format(OMNICACHE_VERSION),
+            workingdir=self.path,
+        )
 
     def _ConvertOmnicache(self):
         """Converts an existing bare git repo from a previous omnicache version to the current omnicache version."""
         logging.info("Converting Omnicache in {0} to latest format.".format(self.path))
-        if (os.path.exists(os.path.join(self.path, PRE_0_11_OMNICACHE_FILENAME))):
+        if os.path.exists(os.path.join(self.path, PRE_0_11_OMNICACHE_FILENAME)):
             os.remove(os.path.join(self.path, PRE_0_11_OMNICACHE_FILENAME))
         remotes = Omnicache.GetRemotes(self.path)
         logging.info("Renaming non-UUID remotes with UUID.")
-        for (name, _) in remotes.items():
-            if (not Omnicache._IsValidUuid(name)):
+        for name, _ in remotes.items():
+            if not Omnicache._IsValidUuid(name):
                 logging.info("Converting remote {0} to UUID".format(name))
                 # Rename the remote with a valid UUID
                 newName = str(uuid.uuid4())
-                ret = RunCmd("git", "remote rename {0} {1}".format(name, newName), workingdir=self.path)
-                if (ret != 0):
+                ret = RunCmd(
+                    "git",
+                    "remote rename {0} {1}".format(name, newName),
+                    workingdir=self.path,
+                )
+                if ret != 0:
                     # rename failed; try removal.
-                    logging.warn("Failed to rename {0}. Attempting to remove it.".format(name))
-                    ret = RunCmd("git", "remote remove {0}".format(name), workingdir=self.path)
-                    if (ret != 0):
-                        logging.critical("Failed to rename or remove {0} - skipping.".format(name))
+                    logging.warn(
+                        "Failed to rename {0}. Attempting to remove it.".format(name)
+                    )
+                    ret = RunCmd(
+                        "git", "remote remove {0}".format(name), workingdir=self.path
+                    )
+                    if ret != 0:
+                        logging.critical(
+                            "Failed to rename or remove {0} - skipping.".format(name)
+                        )
                         continue
                 # Remove previous fetch config entries and regenerate them. Proceed to create new ones even if it fails.
-                RunCmd("git", "config --local --unset-all remote.{0}.fetch".format(newName), workingdir=self.path)
-                RunCmd("git",
-                       "config --local --add remote.{0}.fetch +refs/heads/*:refs/remotes/{0}/*".format(newName),
-                       workingdir=self.path)
-                RunCmd("git",
-                       "config --local --add remote.{0}.fetch refs/tags/*:refs/rtags/{0}/*".format(newName),
-                       workingdir=self.path)
+                RunCmd(
+                    "git",
+                    "config --local --unset-all remote.{0}.fetch".format(newName),
+                    workingdir=self.path,
+                )
+                RunCmd(
+                    "git",
+                    "config --local --add remote.{0}.fetch +refs/heads/*:refs/remotes/{0}/*".format(
+                        newName
+                    ),
+                    workingdir=self.path,
+                )
+                RunCmd(
+                    "git",
+                    "config --local --add remote.{0}.fetch refs/tags/*:refs/rtags/{0}/*".format(
+                        newName
+                    ),
+                    workingdir=self.path,
+                )
                 # Add the original name as a display name
-                RunCmd("git",
-                       "config --local omnicache.{0}.displayname {1}".format(newName, name),
-                       workingdir=self.path)
+                RunCmd(
+                    "git",
+                    "config --local omnicache.{0}.displayname {1}".format(
+                        newName, name
+                    ),
+                    workingdir=self.path,
+                )
                 logging.info("Remote {0} converted to {1}.".format(name, newName))
         # delete any tags in the global name space (older omnicaches fetched all tags into the global tag namespace)
         logging.info("Removing global tags")
@@ -157,36 +221,53 @@ class Omnicache():
         logging.info("Removing remotes with duplicate URLs")
         knownUrls = []
         remotes = Omnicache.GetRemotes(self.path)
-        for (name, url) in remotes.items():
-            if (url not in knownUrls):
-                logging.info("Retaining remote {0} with unique URL {1}".format(name, url))
+        for name, url in remotes.items():
+            if url not in knownUrls:
+                logging.info(
+                    "Retaining remote {0} with unique URL {1}".format(name, url)
+                )
                 knownUrls.append(url)
             else:
-                logging.info("Removing remote {0} with duplicate URL {1}".format(name, url))
+                logging.info(
+                    "Removing remote {0} with duplicate URL {1}".format(name, url)
+                )
                 RunCmd("git", "remote remove {0}".format(name), workingdir=self.path)
-                RunCmd("git", "config --local --unset omnicache.{0}.displayname".format(name), workingdir=self.path)
+                RunCmd(
+                    "git",
+                    "config --local --unset omnicache.{0}.displayname".format(name),
+                    workingdir=self.path,
+                )
         # by default, git fetch is single-threaded. This configuration allows git to use a "reasonable" default
         # (presently equal to the number of cpus) to execute the fetch in parallel.
         ret = RunCmd("git", "config --local fetch.parallel 0", workingdir=self.path)
-        if (ret != 0):
+        if ret != 0:
             return ret
         # write current omnicache version into cache
         logging.info("Writing Omnicache version")
-        return RunCmd("git",
-                      "config --local omnicache.metadata.version {0}".format(OMNICACHE_VERSION),
-                      workingdir=self.path)
+        return RunCmd(
+            "git",
+            "config --local omnicache.metadata.version {0}".format(OMNICACHE_VERSION),
+            workingdir=self.path,
+        )
 
     def _RefreshUrlLookupCache(self):
         """Refreshes the URL lookup cache."""
-        if (len(self.urlLookupCache) == 0):
+        if len(self.urlLookupCache) == 0:
             logging.info("Regenerating URL lookup cache.")
             out = StringIO()
-            ret = RunCmd("git", r"config --local --get-regexp remote\..*?\.url", workingdir=self.path, outstream=out)
-            if (ret != 0):
+            ret = RunCmd(
+                "git",
+                r"config --local --get-regexp remote\..*?\.url",
+                workingdir=self.path,
+                outstream=out,
+            )
+            if ret != 0:
                 return None
             # output is in the form: remote.<name>.url <url>
             for remote in out.getvalue().splitlines():
-                self.urlLookupCache[remote.split()[1]] = ".".join(remote.split()[0].split(".")[1:-1])
+                self.urlLookupCache[remote.split()[1]] = ".".join(
+                    remote.split()[0].split(".")[1:-1]
+                )
 
     def _InvalidateUrlLookupCache(self):
         """Invalidates the URL lookup cache."""
@@ -196,7 +277,7 @@ class Omnicache():
     def _LookupRemoteForUrl(self, url):
         """Returns the git remote name for the specified URL, or None if it doesn't exist."""
         self._RefreshUrlLookupCache()
-        if (url in self.urlLookupCache):
+        if url in self.urlLookupCache:
             return self.urlLookupCache[url]
         return None
 
@@ -208,32 +289,44 @@ class Omnicache():
             name(str, optional): provides a "display name" to be associated with this remote.
         """
         # if we already have this remote (i.e. a remote with this URL exists), then just update.
-        if (self._LookupRemoteForUrl(url) is not None):
+        if self._LookupRemoteForUrl(url) is not None:
             return self.UpdateRemote(url, newName=name)
         # otherwise create it.
         logging.info("Adding new remote for url {0}".format(url))
         newName = str(uuid.uuid4())
-        ret = RunCmd("git", "remote add {0} {1}".format(newName, url), workingdir=self.path)
-        if (ret != 0):
+        ret = RunCmd(
+            "git", "remote add {0} {1}".format(newName, url), workingdir=self.path
+        )
+        if ret != 0:
             return ret
         self._InvalidateUrlLookupCache()
         # add display name, if specified
-        if (name is not None):
-            ret = RunCmd("git",
-                         "config --local omnicache.{0}.displayname {1}".format(newName, name),
-                         workingdir=self.path)
-            if (ret != 0):
+        if name is not None:
+            ret = RunCmd(
+                "git",
+                "config --local omnicache.{0}.displayname {1}".format(newName, name),
+                workingdir=self.path,
+            )
+            if ret != 0:
                 return ret
         # add a special fetch refspec to fetch remote tags into a per-remote local namespace.
-        return RunCmd("git",
-                      "config --local --add remote.{0}.fetch refs/tags/*:refs/rtags/{0}/*".format(newName),
-                      workingdir=self.path)
+        return RunCmd(
+            "git",
+            "config --local --add remote.{0}.fetch refs/tags/*:refs/rtags/{0}/*".format(
+                newName
+            ),
+            workingdir=self.path,
+        )
 
     def RemoveRemote(self, url):
         """Removes the remote for the specified url from the cache."""
         name = self._LookupRemoteForUrl(url)
-        if (name is None):
-            logging.critical("Failed to remove node for url {0}: such a remote does not exist.".format(url))
+        if name is None:
+            logging.critical(
+                "Failed to remove node for url {0}: such a remote does not exist.".format(
+                    url
+                )
+            )
             return 1
         logging.info("Removing remote for url {0}".format(url))
         ret = RunCmd("git", "remote remove {0}".format(name), workingdir=self.path)
@@ -249,21 +342,33 @@ class Omnicache():
             newName (str, optional): updates the "displayname" for the remote.
         """
         remote = self._LookupRemoteForUrl(oldUrl)
-        if (remote is None):
-            logging.critical("Failed to update node for url {0}: such a remote does not exist.".format(oldUrl))
+        if remote is None:
+            logging.critical(
+                "Failed to update node for url {0}: such a remote does not exist.".format(
+                    oldUrl
+                )
+            )
             return 1
-        if (newName is not None):
-            logging.info("Updating display name for url {0} to {1}".format(oldUrl, newName))
-            ret = RunCmd("git",
-                         "config --local omnicache.{0}.displayname {1}".format(remote, newName),
-                         workingdir=self.path)
-            if (ret != 0):
+        if newName is not None:
+            logging.info(
+                "Updating display name for url {0} to {1}".format(oldUrl, newName)
+            )
+            ret = RunCmd(
+                "git",
+                "config --local omnicache.{0}.displayname {1}".format(remote, newName),
+                workingdir=self.path,
+            )
+            if ret != 0:
                 return ret
-        if (newUrl is not None):
+        if newUrl is not None:
             logging.info("Updating url {0} to {1}".format(oldUrl, newUrl))
-            ret = RunCmd("git", "remote set-url {0} {1}".format(remote, newUrl), workingdir=self.path)
+            ret = RunCmd(
+                "git",
+                "remote set-url {0} {1}".format(remote, newUrl),
+                workingdir=self.path,
+            )
             self._InvalidateUrlLookupCache()
-            if (ret != 0):
+            if ret != 0:
                 return ret
 
         return 0
@@ -274,8 +379,10 @@ class Omnicache():
         self._RefreshUrlLookupCache()
         # Tricky: we pass no-tags here, since we set up custom fetch refs for tags on a per-remote basis. This prevents
         # git from fetching the first set of tags into the global namespace.
-        if (jobs != 0):
-            return RunCmd("git", "fetch --all -j {0} --no-tags".format(jobs), workingdir=self.path)
+        if jobs != 0:
+            return RunCmd(
+                "git", "fetch --all -j {0} --no-tags".format(jobs), workingdir=self.path
+            )
         else:
             return RunCmd("git", "fetch --all --no-tags", workingdir=self.path)
 
@@ -294,16 +401,18 @@ class Omnicache():
             remoteData[self.urlLookupCache[url]] = {"url": url}
 
         out = StringIO()
-        ret = RunCmd("git",
-                     r"config --local --get-regexp omnicache\..*?\.displayname",
-                     workingdir=self.path,
-                     outstream=out)
-        if (ret != 0):
+        ret = RunCmd(
+            "git",
+            r"config --local --get-regexp omnicache\..*?\.displayname",
+            workingdir=self.path,
+            outstream=out,
+        )
+        if ret != 0:
             return remoteData
 
         for displayName in out.getvalue().splitlines():
             remoteName = displayName.split()[0].split(".")[1]
-            if (remoteName in remoteData.keys()):
+            if remoteName in remoteData.keys():
                 remoteData[remoteName].update({"displayname": displayName.split()[1]})
         return remoteData
 
@@ -311,9 +420,9 @@ class Omnicache():
         """Prints the current set of remotes."""
         print("List OMNICACHE content:\n")
         remoteData = self.GetRemoteData()
-        if (len(remoteData) == 0):
+        if len(remoteData) == 0:
             print("No remotes.")
-        for (name, data) in remoteData.items():
+        for name, data in remoteData.items():
             print("Id {0}: {1}".format(name, str(data)))
 
     @staticmethod
@@ -328,7 +437,7 @@ class Omnicache():
         out = StringIO()
 
         ret = RunCmd("git", "remote -v", workingdir=path, outstream=out)
-        if (ret != 0):
+        if ret != 0:
             return remotes
 
         # Note: this loop assumes fetch and push URLs will be identical. If not, the last URL output will be the result.
@@ -366,20 +475,25 @@ def ProcessInputConfig(omnicache, input_config):
 def ScanDirectory(omnicache, scanpath):
     """Recursively scans a directory for git repositories and adds remotes and submodule remotes to omnicache."""
     logging.info("Scanning {0} for remotes to add.".format(scanpath))
-    if (not os.path.isdir(scanpath)):
+    if not os.path.isdir(scanpath):
         logging.critical("specified scan path is invalid.")
         return -1
 
-    for (dirpath, dirnames, filenames) in os.walk(scanpath):
-        if (".git" in dirnames):
+    for dirpath, dirnames, filenames in os.walk(scanpath):
+        if ".git" in dirnames:
             newRemotes = Omnicache.GetRemotes(dirpath)
-            for (name, url) in newRemotes.items():
+            for name, url in newRemotes.items():
                 omnicache.AddRemote(url, name)
 
-        if (".gitmodules" in filenames):
+        if ".gitmodules" in filenames:
             out = StringIO()
-            ret = RunCmd("git", "config --file .gitmodules --get-regexp url", workingdir=dirpath, outstream=out)
-            if (ret == 0):
+            ret = RunCmd(
+                "git",
+                "config --file .gitmodules --get-regexp url",
+                workingdir=dirpath,
+                outstream=out,
+            )
+            if ret == 0:
                 for submodule in out.getvalue().splitlines():
                     url = submodule.split()[1]
                     name = submodule.split()[0].split(".")[1]
@@ -390,11 +504,13 @@ def ScanDirectory(omnicache, scanpath):
 
 def Export(omnicache, exportPath):
     """Exports omnicache configuration to YAML."""
-    logging.info("Exporting omnicache config for {0} to {1}".format(omnicache.path, exportPath))
+    logging.info(
+        "Exporting omnicache config for {0} to {1}".format(omnicache.path, exportPath)
+    )
     content = []
-    for (name, data) in omnicache.GetRemoteData().items():
+    for name, data in omnicache.GetRemoteData().items():
         remoteToWrite = {"url": data["url"]}
-        if ("displayname" in data):
+        if "displayname" in data:
             remoteToWrite["name"] = data["displayname"]
         else:
             remoteToWrite["name"] = name
@@ -408,35 +524,106 @@ def Export(omnicache, exportPath):
 
 def get_cli_options():
     """Add CLI arguments to argparse for controlling the omnicache."""
-    parser = argparse.ArgumentParser(description='Tool to provide easy method create and manage the OMNICACHE', )
-    parser.add_argument(dest="cache_dir", help="path to an existing or desired OMNICACHE directory")
-    parser.add_argument("--scan", dest="scan", default=None,
-                        help="Scans the path provided for top-level folders with repos to add to the OMNICACHE")
-    parser.add_argument("--new", dest="new", help="Initialize the OMNICACHE.  MUST NOT EXIST",
-                        action="store_true", default=False)
-    parser.add_argument("--init", dest="init", help="Initialize the OMNICACHE if it doesn't already exist",
-                        action="store_true", default=False)
-    parser.add_argument("-l", "--list", dest="list", default=False, action="store_true",
-                        help="List config of OMNICACHE")
-    parser.add_argument("-a", "--add", dest="add", nargs=2, action="append",
-                        help="Add config entry to OMNICACHE <name> <url>",
-                        default=[])
-    parser.add_argument("-c", "--configfile", dest="input_config_file", default=None,
-                        help="Add new entries from config file to OMNICACHE")
-    parser.add_argument("-e", "--exportConfig", dest="output_config_file", default=None,
-                        help="Export current omnicache config as a yaml file")
+    parser = argparse.ArgumentParser(
+        description="Tool to provide easy method create and manage the OMNICACHE",
+    )
+    parser.add_argument(
+        dest="cache_dir", help="path to an existing or desired OMNICACHE directory"
+    )
+    parser.add_argument(
+        "--scan",
+        dest="scan",
+        default=None,
+        help="Scans the path provided for top-level folders with repos to add to the OMNICACHE",
+    )
+    parser.add_argument(
+        "--new",
+        dest="new",
+        help="Initialize the OMNICACHE.  MUST NOT EXIST",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--init",
+        dest="init",
+        help="Initialize the OMNICACHE if it doesn't already exist",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "-l",
+        "--list",
+        dest="list",
+        default=False,
+        action="store_true",
+        help="List config of OMNICACHE",
+    )
+    parser.add_argument(
+        "-a",
+        "--add",
+        dest="add",
+        nargs=2,
+        action="append",
+        help="Add config entry to OMNICACHE <name> <url>",
+        default=[],
+    )
+    parser.add_argument(
+        "-c",
+        "--configfile",
+        dest="input_config_file",
+        default=None,
+        help="Add new entries from config file to OMNICACHE",
+    )
+    parser.add_argument(
+        "-e",
+        "--exportConfig",
+        dest="output_config_file",
+        default=None,
+        help="Export current omnicache config as a yaml file",
+    )
     group = parser.add_mutually_exclusive_group()
-    group.add_argument("-u", "--update", "--fetch", dest="fetch", action="store_true",
-                       help="Update the Omnicache.  All cache changes also cause a fetch", default=False)
-    group.add_argument("--no-fetch", dest="no_fetch", action="store_true",
-                       help="Prevent auto-fetch if implied by other arguments.", default=False)
-    group.add_argument("--fetch-jobs", dest="fetch_jobs", type=int,
-                       help="Specify the number of parallel threads (jobs) for fetch operation.", default=0)
-    parser.add_argument("-r", "--remove", dest="remove", nargs=1, action="append",
-                        help="remove config entry from OMNICACHE <name>", default=[])
-    parser.add_argument('--version', action='version', version='%(prog)s ' + OMNICACHE_VERSION)
-    parser.add_argument("--debug", dest="debug", help="Output all debug messages to console",
-                        action="store_true", default=False)
+    group.add_argument(
+        "-u",
+        "--update",
+        "--fetch",
+        dest="fetch",
+        action="store_true",
+        help="Update the Omnicache.  All cache changes also cause a fetch",
+        default=False,
+    )
+    group.add_argument(
+        "--no-fetch",
+        dest="no_fetch",
+        action="store_true",
+        help="Prevent auto-fetch if implied by other arguments.",
+        default=False,
+    )
+    group.add_argument(
+        "--fetch-jobs",
+        dest="fetch_jobs",
+        type=int,
+        help="Specify the number of parallel threads (jobs) for fetch operation.",
+        default=0,
+    )
+    parser.add_argument(
+        "-r",
+        "--remove",
+        dest="remove",
+        nargs=1,
+        action="append",
+        help="remove config entry from OMNICACHE <name>",
+        default=[],
+    )
+    parser.add_argument(
+        "--version", action="version", version="%(prog)s " + OMNICACHE_VERSION
+    )
+    parser.add_argument(
+        "--debug",
+        dest="debug",
+        help="Output all debug messages to console",
+        action="store_true",
+        default=False,
+    )
     args = parser.parse_args()
     return args
 
@@ -444,7 +631,7 @@ def get_cli_options():
 def main():
     """Main entry point to managing the omnicache."""
     # setup main console as logger
-    logger = logging.getLogger('')
+    logger = logging.getLogger("")
     logger.setLevel(logging.NOTSET)
     console = edk2_logging.setup_console_logging(False)
     logger.addHandler(console)
@@ -454,16 +641,24 @@ def main():
     if args.debug:
         console.setLevel(logging.DEBUG)
 
-    logging.info("Log Started: " + datetime.datetime.strftime(
-        datetime.datetime.now(), "%A, %B %d, %Y %I:%M%p"))
+    logging.info(
+        "Log Started: "
+        + datetime.datetime.strftime(datetime.datetime.now(), "%A, %B %d, %Y %I:%M%p")
+    )
 
     args.cache_dir = os.path.realpath(os.path.abspath(args.cache_dir))
     logging.debug("OMNICACHE dir: {0}".format(args.cache_dir))
 
     if args.input_config_file is not None:
-        args.input_config_file = os.path.realpath(os.path.abspath(args.input_config_file))
+        args.input_config_file = os.path.realpath(
+            os.path.abspath(args.input_config_file)
+        )
         if not os.path.isfile(args.input_config_file):
-            logging.critical("Invalid -c argument given.  File ({0}) isn't valid".format(args.input_config_file))
+            logging.critical(
+                "Invalid -c argument given.  File ({0}) isn't valid".format(
+                    args.input_config_file
+                )
+            )
             return -4
 
     logging.debug("Args: " + str(args))
@@ -488,54 +683,54 @@ def main():
         omnicache = Omnicache(args.cache_dir)
 
     # add: add new source(s) to omnicache from command line arg.
-    if (len(args.add) > 0):
-        for (name, url) in args.add:
+    if len(args.add) > 0:
+        for name, url in args.add:
             ret = omnicache.AddRemote(url, name)
-            if (ret != 0):
+            if ret != 0:
                 return -3
         auto_fetch = True
 
     # config: add or update sources(s) from config file.
-    if (args.input_config_file is not None):
+    if args.input_config_file is not None:
         ret = ProcessInputConfig(omnicache, args.input_config_file)
-        if (ret != 0):
+        if ret != 0:
             return -4
         auto_fetch = True
 
     # remove: remove source(s) from omnicache as specified by command line arg.
-    if (len(args.remove) > 0):
+    if len(args.remove) > 0:
         for url in args.remove:
             ret = omnicache.RemoveRemote(url)
-            if (ret != 0):
+            if ret != 0:
                 return -4
 
     # scan: recursively scan the given directory and add all repos and submodules
-    if (args.scan is not None):
+    if args.scan is not None:
         ret = ScanDirectory(omnicache, args.scan)
-        if (ret != 0):
+        if ret != 0:
             return -5
         auto_fetch = True
 
     # fetch: update the omnicache with objects from its remotes.
     # Note: errors are ignored here, since transient network failures may occur that prevent cache update. Those just
     # mean the omnicache may be a a little stale which should not be fatal to users of the cache.
-    if (args.fetch or (auto_fetch and not args.no_fetch)):
+    if args.fetch or (auto_fetch and not args.no_fetch):
         omnicache.Fetch(args.fetch_jobs)
 
     # list: print out the omnicache contents.
-    if (args.list):
+    if args.list:
         omnicache.List()
 
     # export:
-    if (args.output_config_file):
+    if args.output_config_file:
         ret = Export(omnicache, args.output_config_file)
-        if (ret != 0):
+        if ret != 0:
             return -6
 
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     retcode = main()
     logging.shutdown()
     sys.exit(retcode)

--- a/edk2toolext/tests/capsule/test_capsule_helper.py
+++ b/edk2toolext/tests/capsule/test_capsule_helper.py
@@ -14,27 +14,27 @@ import unittest
 import tempfile
 
 from edk2toollib.uefi.uefi_capsule_header import UefiCapsuleHeaderClass
-from edk2toollib.uefi.fmp_capsule_header import FmpCapsuleHeaderClass, FmpCapsuleImageHeaderClass
+from edk2toollib.uefi.fmp_capsule_header import (
+    FmpCapsuleHeaderClass,
+    FmpCapsuleImageHeaderClass,
+)
 from edk2toolext.capsule import capsule_helper
 
 DUMMY_OPTIONS = {
-    'capsule': {
-        'fw_version': '0xDEADBEEF',
-        'lsv_version': '0xFEEDF00D',
-        'esrt_guid': '00112233-4455-6677-8899-aabbccddeeff',
-        'fw_name': 'TEST_FW',
-        'fw_version_string': '1.2.3',  # deliberately use 3-part version to exercise version normalization.
-        'provider_name': 'TESTER',
-        'fw_description': 'TEST FW',
-        'fw_integrity_file': "IntegrityFile.bin"
+    "capsule": {
+        "fw_version": "0xDEADBEEF",
+        "lsv_version": "0xFEEDF00D",
+        "esrt_guid": "00112233-4455-6677-8899-aabbccddeeff",
+        "fw_name": "TEST_FW",
+        "fw_version_string": "1.2.3",  # deliberately use 3-part version to exercise version normalization.
+        "provider_name": "TESTER",
+        "fw_description": "TEST FW",
+        "fw_integrity_file": "IntegrityFile.bin",
     },
-    'signer': {
-        'option2': 'value2',
-        'option_not': 'orig_value'
-    }
+    "signer": {"option2": "value2", "option_not": "orig_value"},
 }
-DUMMY_OPTIONS_FILE_NAME = 'dummy_options_file'
-DUMMY_PAYLOAD_FILE_NAME = 'dummy_payload'
+DUMMY_OPTIONS_FILE_NAME = "dummy_options_file"
+DUMMY_PAYLOAD_FILE_NAME = "dummy_payload"
 
 
 class CapsuleSignerTest(unittest.TestCase):
@@ -45,26 +45,33 @@ class CapsuleSignerTest(unittest.TestCase):
         cls.temp_dir = tempfile.mkdtemp()
         cls.dummy_payload = os.path.join(cls.temp_dir, DUMMY_PAYLOAD_FILE_NAME + ".bin")
 
-        with open(cls.dummy_payload, 'wb') as dummy_file:
-            dummy_file.write(b'DEADBEEF')
+        with open(cls.dummy_payload, "wb") as dummy_file:
+            dummy_file.write(b"DEADBEEF")
 
     def test_should_pass_wrapped_blob_to_signing_module(self):
-        dummy_payload = b'This_Is_My_Sample_Payload,ThereAreManyLikeIt;This One Is Mine'
+        dummy_payload = b"This_Is_My_Sample_Payload,ThereAreManyLikeIt;This One Is Mine"
 
         class DummySigner(object):
             @classmethod
             def sign(cls, data, signature_options, signer_options):
                 self.assertTrue(dummy_payload in data)
 
-        capsule_helper.build_capsule(dummy_payload, DUMMY_OPTIONS['capsule'], DummySigner, DUMMY_OPTIONS['signer'])
+        capsule_helper.build_capsule(
+            dummy_payload,
+            DUMMY_OPTIONS["capsule"],
+            DummySigner,
+            DUMMY_OPTIONS["signer"],
+        )
 
     def test_should_pass_signer_options_to_signing_module(self):
         class DummySigner(object):
             @classmethod
             def sign(cls, data, signature_options, signer_options):
-                self.assertEqual(signer_options, DUMMY_OPTIONS['signer'])
+                self.assertEqual(signer_options, DUMMY_OPTIONS["signer"])
 
-        capsule_helper.build_capsule(b'030303', DUMMY_OPTIONS['capsule'], DummySigner, DUMMY_OPTIONS['signer'])
+        capsule_helper.build_capsule(
+            b"030303", DUMMY_OPTIONS["capsule"], DummySigner, DUMMY_OPTIONS["signer"]
+        )
 
     # def test_should_be_able_to_generate_a_production_equivalent_capsule(self):
     #     with open(BUILD_CAPSULE_BINARY_PATH, 'rb') as data_file:
@@ -129,12 +136,14 @@ class FileGenerationTest(unittest.TestCase):
         cls.temp_dir = tempfile.mkdtemp()
         cls.dummy_payload = os.path.join(cls.temp_dir, DUMMY_PAYLOAD_FILE_NAME + ".bin")
 
-        with open(cls.dummy_payload, 'wb') as dummy_file:
-            dummy_file.write(b'DEADBEEF')
+        with open(cls.dummy_payload, "wb") as dummy_file:
+            dummy_file.write(b"DEADBEEF")
 
     def test_should_be_able_to_save_a_capsule(self):
         fmp_capsule_image_header = FmpCapsuleImageHeaderClass()
-        fmp_capsule_image_header.UpdateImageTypeId = uuid.UUID(DUMMY_OPTIONS['capsule']['esrt_guid'])
+        fmp_capsule_image_header.UpdateImageTypeId = uuid.UUID(
+            DUMMY_OPTIONS["capsule"]["esrt_guid"]
+        )
         fmp_capsule_image_header.UpdateImageIndex = 1
 
         fmp_capsule_header = FmpCapsuleHeaderClass()
@@ -145,26 +154,33 @@ class FileGenerationTest(unittest.TestCase):
         uefi_capsule_header.PersistAcrossReset = True
         uefi_capsule_header.InitiateReset = True
 
-        capsule_file_path = capsule_helper.save_capsule(uefi_capsule_header, DUMMY_OPTIONS['capsule'], self.temp_dir)
+        capsule_file_path = capsule_helper.save_capsule(
+            uefi_capsule_header, DUMMY_OPTIONS["capsule"], self.temp_dir
+        )
 
         # Now read the data and check for the GUID.
-        with open(capsule_file_path, 'rb') as capsule_file:
+        with open(capsule_file_path, "rb") as capsule_file:
             capsule_bytes = capsule_file.read()
 
-        self.assertTrue(uuid.UUID(DUMMY_OPTIONS['capsule']['esrt_guid']).bytes_le in capsule_bytes)
+        self.assertTrue(
+            uuid.UUID(DUMMY_OPTIONS["capsule"]["esrt_guid"]).bytes_le in capsule_bytes
+        )
 
     def test_should_be_able_to_generate_windows_files(self):
-        inf_file_path = capsule_helper.create_inf_file(DUMMY_OPTIONS['capsule'], self.temp_dir)
+        inf_file_path = capsule_helper.create_inf_file(
+            DUMMY_OPTIONS["capsule"], self.temp_dir
+        )
         self.assertTrue(os.path.isfile(inf_file_path))
 
     @unittest.skip("test fails in unittest environment. need to debug")
     def test_should_be_able_to_generate_cat(self):
-        cat_file_path = capsule_helper.create_cat_file(DUMMY_OPTIONS['capsule'], self.temp_dir)
+        cat_file_path = capsule_helper.create_cat_file(
+            DUMMY_OPTIONS["capsule"], self.temp_dir
+        )
         self.assertTrue(os.path.isfile(cat_file_path))
 
 
 class MultiNodeFileGenerationTest(unittest.TestCase):
-
     @staticmethod
     def buildPayload(esrt):
         fmp_capsule_image_header = FmpCapsuleImageHeaderClass()
@@ -198,7 +214,7 @@ class MultiNodeFileGenerationTest(unittest.TestCase):
                 "test1.bin",
                 uuid.UUID("ea5c13fe-cac9-4fd7-ac30-37709bd668f2"),
                 0xDEADBEEF,
-                "TEST FW"
+                "TEST FW",
             )
         )
 
@@ -208,42 +224,48 @@ class MultiNodeFileGenerationTest(unittest.TestCase):
                 "test2.bin",
                 uuid.UUID("43e67b4e-b2f1-4891-9ff2-a6acd9c74cbd"),
                 0xDEADBEEF,
-                "TEST FW"
+                "TEST FW",
             )
         )
 
     def test_should_be_able_to_save_a_multi_node_capsule(self):
-
-        capsule_file_path = capsule_helper.save_multinode_capsule(self.capsule, self.temp_output_dir)
+        capsule_file_path = capsule_helper.save_multinode_capsule(
+            self.capsule, self.temp_output_dir
+        )
 
         # make sure all the files we expect got created
         for payload in self.capsule.payloads:
             payload_file = os.path.join(capsule_file_path, payload.payload_filename)
             self.assertTrue(os.path.isfile(payload_file))
-            with open(payload_file, 'rb') as fh:
+            with open(payload_file, "rb") as fh:
                 capsule_bytes = fh.read()
             self.assertIn(payload.esrt_guid.bytes_le, capsule_bytes)
 
     def test_should_be_able_to_save_a_multi_node_capsule_with_integrity(self):
-
-        self.capsule.payloads[0].integrity_data = uuid.UUID("ea5c13fe-cac9-4fd7-ac30-37709bd668f2").bytes
+        self.capsule.payloads[0].integrity_data = uuid.UUID(
+            "ea5c13fe-cac9-4fd7-ac30-37709bd668f2"
+        ).bytes
         self.capsule.payloads[0].integrity_filename = "integrity1.bin"
 
-        self.capsule.payloads[1].integrity_data = uuid.UUID("43e67b4e-b2f1-4891-9ff2-a6acd9c74cbd").bytes
+        self.capsule.payloads[1].integrity_data = uuid.UUID(
+            "43e67b4e-b2f1-4891-9ff2-a6acd9c74cbd"
+        ).bytes
         self.capsule.payloads[1].integrity_filename = "integrity2.bin"
 
-        capsule_file_path = capsule_helper.save_multinode_capsule(self.capsule, self.temp_output_dir)
+        capsule_file_path = capsule_helper.save_multinode_capsule(
+            self.capsule, self.temp_output_dir
+        )
 
         for payload in self.capsule.payloads:
             payload_file = os.path.join(capsule_file_path, payload.payload_filename)
             self.assertTrue(os.path.isfile(payload_file))
-            with open(payload_file, 'rb') as fh:
+            with open(payload_file, "rb") as fh:
                 capsule_bytes = fh.read()
             self.assertIn(payload.esrt_guid.bytes_le, capsule_bytes)
 
             integrityFile = os.path.join(capsule_file_path, payload.integrity_filename)
             self.assertTrue(os.path.isfile(integrityFile))
-            with open(integrityFile, 'rb') as fh:
+            with open(integrityFile, "rb") as fh:
                 integrity_bytes = fh.read()
             self.assertIn(payload.integrity_data, integrity_bytes)
 
@@ -254,10 +276,11 @@ class MultiNodeFileGenerationTest(unittest.TestCase):
         self.capsule.payloads[1].integrity_filename = None
 
     def test_should_be_able_to_generate_multi_node_inf_file(self):
-
-        inf_file_path = capsule_helper.create_multinode_inf_file(self.capsule, self.temp_output_dir)
+        inf_file_path = capsule_helper.create_multinode_inf_file(
+            self.capsule, self.temp_output_dir
+        )
         self.assertTrue(os.path.isfile(inf_file_path))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/capsule/test_capsule_tool.py
+++ b/edk2toolext/tests/capsule/test_capsule_tool.py
@@ -17,16 +17,11 @@ import yaml
 from edk2toolext.capsule import capsule_tool
 
 DUMMY_OPTIONS = {
-    'capsule': {
-        'option1': 'value1'
-    },
-    'signer': {
-        'option2': 'value2',
-        'option_not': 'orig_value'
-    }
+    "capsule": {"option1": "value1"},
+    "signer": {"option2": "value2", "option_not": "orig_value"},
 }
-DUMMY_OPTIONS_FILE_NAME = 'dummy_options_file'
-DUMMY_PAYLOAD_FILE_NAME = 'dummy_payload'
+DUMMY_OPTIONS_FILE_NAME = "dummy_options_file"
+DUMMY_PAYLOAD_FILE_NAME = "dummy_payload"
 
 
 class ParameterParsingTest(unittest.TestCase):
@@ -35,100 +30,108 @@ class ParameterParsingTest(unittest.TestCase):
         # We'll use the one-time setup to create
         # any temporary test files we'll need.
         cls.temp_dir = tempfile.mkdtemp()
-        cls.dummy_json_options = os.path.join(cls.temp_dir, DUMMY_OPTIONS_FILE_NAME + ".json")
-        cls.dummy_yaml_options = os.path.join(cls.temp_dir, DUMMY_OPTIONS_FILE_NAME + ".yaml")
+        cls.dummy_json_options = os.path.join(
+            cls.temp_dir, DUMMY_OPTIONS_FILE_NAME + ".json"
+        )
+        cls.dummy_yaml_options = os.path.join(
+            cls.temp_dir, DUMMY_OPTIONS_FILE_NAME + ".yaml"
+        )
         cls.dummy_payload = os.path.join(cls.temp_dir, DUMMY_PAYLOAD_FILE_NAME + ".bin")
 
-        with open(cls.dummy_json_options, 'w') as dummy_file:
+        with open(cls.dummy_json_options, "w") as dummy_file:
             json.dump(DUMMY_OPTIONS, dummy_file)
-        with open(cls.dummy_yaml_options, 'w') as dummy_file:
+        with open(cls.dummy_yaml_options, "w") as dummy_file:
             yaml.dump(DUMMY_OPTIONS, dummy_file)
-        with open(cls.dummy_payload, 'wb') as dummy_file:
-            dummy_file.write(b'DEADBEEF')
+        with open(cls.dummy_payload, "wb") as dummy_file:
+            dummy_file.write(b"DEADBEEF")
 
     @unittest.skip("test is incomplete")
     def test_should_require_a_signer_option(self):
         pass
 
     def test_capsule_options_should_be_passable(self):
-        cli_params = ['--builtin_signer', 'pyopenssl']
-        parsed_args = capsule_tool.get_cli_options(cli_params + [self.dummy_payload, self.temp_dir])
+        cli_params = ["--builtin_signer", "pyopenssl"]
+        parsed_args = capsule_tool.get_cli_options(
+            cli_params + [self.dummy_payload, self.temp_dir]
+        )
         self.assertEqual(len(parsed_args.capsule_options), 0)
 
-        cli_params += ['-dc', 'option1=value1']
-        cli_params += ['-dc', 'option2=value2']
+        cli_params += ["-dc", "option1=value1"]
+        cli_params += ["-dc", "option2=value2"]
         cli_params += [self.dummy_payload, self.temp_dir]
         parsed_args = capsule_tool.get_cli_options(cli_params)
         self.assertEqual(len(parsed_args.capsule_options), 2)
 
     def test_signer_options_should_be_passable(self):
-        cli_params = ['--builtin_signer', 'pyopenssl']
-        parsed_args = capsule_tool.get_cli_options(cli_params + [self.dummy_payload, self.temp_dir])
+        cli_params = ["--builtin_signer", "pyopenssl"]
+        parsed_args = capsule_tool.get_cli_options(
+            cli_params + [self.dummy_payload, self.temp_dir]
+        )
         self.assertEqual(len(parsed_args.signer_options), 0)
 
-        cli_params += ['-ds', 'option1=value1']
-        cli_params += ['-ds', 'option2=value2']
+        cli_params += ["-ds", "option1=value1"]
+        cli_params += ["-ds", "option2=value2"]
         cli_params += [self.dummy_payload, self.temp_dir]
         parsed_args = capsule_tool.get_cli_options(cli_params)
         self.assertEqual(len(parsed_args.signer_options), 2)
 
     def test_should_not_accept_an_invalid_path(self):
-        cli_params = ['--builtin_signer', 'pyopenssl']
-        cli_params += ['-o', 'not_a_path.bin']
+        cli_params = ["--builtin_signer", "pyopenssl"]
+        cli_params += ["-o", "not_a_path.bin"]
         cli_params += [self.dummy_payload]
         with self.assertRaises(SystemExit):
             capsule_tool.get_cli_options(cli_params)
 
     def test_should_not_load_an_invalid_path(self):
-        bad_path = 'not_a_path.bin'
+        bad_path = "not_a_path.bin"
         loaded_options = capsule_tool.load_options_file(bad_path)
         self.assertEqual(loaded_options, None)
 
     def test_options_file_should_load_json(self):
-        with open(self.dummy_json_options, 'r') as options_file:
+        with open(self.dummy_json_options, "r") as options_file:
             loaded_options = capsule_tool.load_options_file(options_file)
 
-        self.assertEqual(loaded_options['capsule']['option1'], 'value1')
-        self.assertEqual(loaded_options['signer']['option2'], 'value2')
+        self.assertEqual(loaded_options["capsule"]["option1"], "value1")
+        self.assertEqual(loaded_options["signer"]["option2"], "value2")
 
     def test_options_file_should_load_yaml(self):
-        with open(self.dummy_yaml_options, 'r') as options_file:
+        with open(self.dummy_yaml_options, "r") as options_file:
             loaded_options = capsule_tool.load_options_file(options_file)
 
-        self.assertEqual(loaded_options['capsule']['option1'], 'value1')
-        self.assertEqual(loaded_options['signer']['option2'], 'value2')
+        self.assertEqual(loaded_options["capsule"]["option1"], "value1")
+        self.assertEqual(loaded_options["signer"]["option2"], "value2")
 
     # @pytest.mark.skip(reason="test is incomplete")
     def test_cli_options_should_override_file_options(self):
-        capsule_cli_options = ['option1=value2', 'new_option=value3']
-        signer_cli_options = ['option2=value7', 'option2=value8']
+        capsule_cli_options = ["option1=value2", "new_option=value3"]
+        signer_cli_options = ["option2=value7", "option2=value8"]
 
-        final_options = capsule_tool.update_options(DUMMY_OPTIONS, capsule_cli_options, signer_cli_options)
+        final_options = capsule_tool.update_options(
+            DUMMY_OPTIONS, capsule_cli_options, signer_cli_options
+        )
 
-        self.assertEqual(final_options['capsule']['option1'], 'value2')
-        self.assertEqual(final_options['capsule']['new_option'], 'value3')
-        self.assertEqual(final_options['signer']['option2'], 'value8')
-        self.assertEqual(final_options['signer']['option_not'], 'orig_value')
+        self.assertEqual(final_options["capsule"]["option1"], "value2")
+        self.assertEqual(final_options["capsule"]["new_option"], "value3")
+        self.assertEqual(final_options["signer"]["option2"], "value8")
+        self.assertEqual(final_options["signer"]["option_not"], "orig_value")
 
     def test_full_options_path_should_work(self):
         # Parse the command parameters.
-        cli_params = ['--builtin_signer', 'pyopenssl']
-        cli_params += ['-o', self.dummy_json_options]
-        cli_params += ['-dc', 'option1=value2']
-        cli_params += ['-dc', 'new_option=value3']
-        cli_params += ['-ds', 'option2=value7']
-        cli_params += ['-ds', 'option2=value8']
+        cli_params = ["--builtin_signer", "pyopenssl"]
+        cli_params += ["-o", self.dummy_json_options]
+        cli_params += ["-dc", "option1=value2"]
+        cli_params += ["-dc", "new_option=value3"]
+        cli_params += ["-ds", "option2=value7"]
+        cli_params += ["-ds", "option2=value8"]
         cli_params += [self.dummy_payload, self.temp_dir]
         parsed_args = capsule_tool.get_cli_options(cli_params)
 
         loaded_options = capsule_tool.load_options_file(parsed_args.options_file)
         final_options = capsule_tool.update_options(
-            loaded_options,
-            parsed_args.capsule_options,
-            parsed_args.signer_options
+            loaded_options, parsed_args.capsule_options, parsed_args.signer_options
         )
 
-        self.assertEqual(final_options['capsule']['option1'], 'value2')
-        self.assertEqual(final_options['capsule']['new_option'], 'value3')
-        self.assertEqual(final_options['signer']['option2'], 'value8')
-        self.assertEqual(final_options['signer']['option_not'], 'orig_value')
+        self.assertEqual(final_options["capsule"]["option1"], "value2")
+        self.assertEqual(final_options["capsule"]["new_option"], "value3")
+        self.assertEqual(final_options["signer"]["option2"], "value8")
+        self.assertEqual(final_options["signer"]["option_not"], "orig_value")

--- a/edk2toolext/tests/capsule/test_signing_helper.py
+++ b/edk2toolext/tests/capsule/test_signing_helper.py
@@ -17,26 +17,30 @@ from edk2toolext.capsule import signing_helper
 class SignerLocationTests(unittest.TestCase):
     def test_should_be_able_to_fetch_a_builtin_signer_module(self):
         py_signer = signing_helper.get_signer(signing_helper.PYOPENSSL_SIGNER)
-        self.assertTrue(hasattr(py_signer, 'sign'))
+        self.assertTrue(hasattr(py_signer, "sign"))
 
         signtoolsigner = signing_helper.get_signer(signing_helper.SIGNTOOL_SIGNER)
-        self.assertTrue(hasattr(signtoolsigner, 'sign'))
+        self.assertTrue(hasattr(signtoolsigner, "sign"))
 
     def test_should_be_able_to_pass_a_signing_module(self):
         py_signer = signing_helper.get_signer(
-            signing_helper.PYPATH_MODULE_SIGNER,
-            'edk2toolext.capsule.pyopenssl_signer'
+            signing_helper.PYPATH_MODULE_SIGNER, "edk2toolext.capsule.pyopenssl_signer"
         )
-        self.assertTrue(hasattr(py_signer, 'sign'))
+        self.assertTrue(hasattr(py_signer, "sign"))
 
     def test_should_be_able_to_fetch_a_user_provided_signer_module(self):
         test_script_path = os.path.dirname(os.path.abspath(__file__))
         # TEST NOTE: This is a little hacky and will break if relative paths are changed.
         module_root_path = os.path.dirname(os.path.dirname(test_script_path))
-        py_signer_path = os.path.join(module_root_path, 'capsule', 'pyopenssl_signer.py')
+        py_signer_path = os.path.join(
+            module_root_path, "capsule", "pyopenssl_signer.py"
+        )
         self.assertTrue(os.path.isfile(py_signer_path))
-        py_signer = signing_helper.get_signer(signing_helper.LOCAL_MODULE_SIGNER, py_signer_path)
-        self.assertTrue(hasattr(py_signer, 'sign'))
+        py_signer = signing_helper.get_signer(
+            signing_helper.LOCAL_MODULE_SIGNER, py_signer_path
+        )
+        self.assertTrue(hasattr(py_signer, "sign"))
+
 
 # NOTE: These tests may not run on non-Windows or without the WDK installed.
 # class SigntoolSignerModuleTest(unittest.TestCase):

--- a/edk2toolext/tests/test_az_cli_universal_dependency.py
+++ b/edk2toolext/tests/test_az_cli_universal_dependency.py
@@ -18,13 +18,15 @@ import unittest
 import logging
 import tempfile
 from edk2toolext.environment import environment_descriptor_files as EDF
-from edk2toolext.environment.extdeptypes.az_cli_universal_dependency import AzureCliUniversalDependency
+from edk2toolext.environment.extdeptypes.az_cli_universal_dependency import (
+    AzureCliUniversalDependency,
+)
 from edk2toolext.environment import version_aggregator
 from edk2toollib.utility_functions import RemoveTree
 
 test_dir = None
 
-single_file_json_template = '''
+single_file_json_template = """
 {
   "scope": "global",
   "type": "az-universal",
@@ -35,9 +37,9 @@ single_file_json_template = '''
   "feed": "ext_dep_unit_test_feed",
   "pat_var": "PAT_FOR_UNIVERSAL_ORG_TIANOCORE"
 }
-'''
+"""
 
-folders_json_template = '''
+folders_json_template = """
 {
   "scope": "global",
   "type": "az-universal",
@@ -48,9 +50,9 @@ folders_json_template = '''
   "feed": "ext_dep_unit_test_feed",
   "pat_var": "PAT_FOR_UNIVERSAL_ORG_TIANOCORE"
 }
-'''
+"""
 
-file_filter_json_template = '''
+file_filter_json_template = """
 {
   "scope": "global",
   "type": "az-universal",
@@ -62,7 +64,7 @@ file_filter_json_template = '''
   "file-filter": "folder2/*.txt",
   "pat_var": "PAT_FOR_UNIVERSAL_ORG_TIANOCORE"
 }
-'''
+"""
 
 
 def prep_workspace():
@@ -92,7 +94,7 @@ class TestAzCliUniversalDependency(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        logger = logging.getLogger('')
+        logger = logging.getLogger("")
         logger.addHandler(logging.NullHandler())
         unittest.installHandler()
 
@@ -105,15 +107,19 @@ class TestAzCliUniversalDependency(unittest.TestCase):
         version_aggregator.GetVersionAggregator().Reset()
 
     # good case
-    @unittest.skipIf("PAT_FOR_UNIVERSAL_ORG_TIANOCORE" not in os.environ.keys(),
-                     "PAT not defined therefore universal packages tests will fail")
+    @unittest.skipIf(
+        "PAT_FOR_UNIVERSAL_ORG_TIANOCORE" not in os.environ.keys(),
+        "PAT not defined therefore universal packages tests will fail",
+    )
     def test_download_good_universal_dependency_single_file(self):
         version = "0.0.1"
         ext_dep_file_path = os.path.join(test_dir, "unit_test_ext_dep.json")
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(single_file_json_template % version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = AzureCliUniversalDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify())
@@ -122,15 +128,19 @@ class TestAzCliUniversalDependency(unittest.TestCase):
         ext_dep.clean()
 
     # good case
-    @unittest.skipIf("PAT_FOR_UNIVERSAL_ORG_TIANOCORE" not in os.environ.keys(),
-                     "PAT not defined therefore universal packages tests will fail")
+    @unittest.skipIf(
+        "PAT_FOR_UNIVERSAL_ORG_TIANOCORE" not in os.environ.keys(),
+        "PAT not defined therefore universal packages tests will fail",
+    )
     def test_download_good_universal_dependency_folders_pinned_old_version(self):
         version = "0.2.0"
         ext_dep_file_path = os.path.join(test_dir, "unit_test_ext_dep.json")
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(folders_json_template % version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = AzureCliUniversalDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify())
@@ -139,15 +149,19 @@ class TestAzCliUniversalDependency(unittest.TestCase):
         ext_dep.clean()
 
     # good case
-    @unittest.skipIf("PAT_FOR_UNIVERSAL_ORG_TIANOCORE" not in os.environ.keys(),
-                     "PAT not defined therefore universal packages tests will fail")
+    @unittest.skipIf(
+        "PAT_FOR_UNIVERSAL_ORG_TIANOCORE" not in os.environ.keys(),
+        "PAT not defined therefore universal packages tests will fail",
+    )
     def test_download_good_universal_dependency_folders_newer_version(self):
         version = "0.2.1"
         ext_dep_file_path = os.path.join(test_dir, "unit_test_ext_dep.json")
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(folders_json_template % version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = AzureCliUniversalDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify())
@@ -156,15 +170,19 @@ class TestAzCliUniversalDependency(unittest.TestCase):
         ext_dep.clean()
 
     # good case
-    @unittest.skipIf("PAT_FOR_UNIVERSAL_ORG_TIANOCORE" not in os.environ.keys(),
-                     "PAT not defined therefore universal packages tests will fail")
+    @unittest.skipIf(
+        "PAT_FOR_UNIVERSAL_ORG_TIANOCORE" not in os.environ.keys(),
+        "PAT not defined therefore universal packages tests will fail",
+    )
     def test_download_good_universal_dependency_folders_file_filter(self):
         version = "0.2.1"
         ext_dep_file_path = os.path.join(test_dir, "unit_test_ext_dep.json")
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(file_filter_json_template)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = AzureCliUniversalDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify())
@@ -175,7 +193,7 @@ class TestAzCliUniversalDependency(unittest.TestCase):
         files = 0
         folders = 0
 
-        for (dirpath, dirs, file_names) in os.walk(ext_dep.contents_dir):
+        for dirpath, dirs, file_names in os.walk(ext_dep.contents_dir):
             files += len(file_names)
             folders += len(dirs)
 
@@ -186,15 +204,19 @@ class TestAzCliUniversalDependency(unittest.TestCase):
         ext_dep.clean()
 
     # bad case
-    @unittest.skipIf("PAT_FOR_UNIVERSAL_ORG_TIANOCORE" not in os.environ.keys(),
-                     "PAT not defined therefore universal packages tests will fail")
+    @unittest.skipIf(
+        "PAT_FOR_UNIVERSAL_ORG_TIANOCORE" not in os.environ.keys(),
+        "PAT not defined therefore universal packages tests will fail",
+    )
     def test_download_bad_universal_dependency(self):
         non_existing_version = "0.1.0"
         ext_dep_file_path = os.path.join(test_dir, "unit_test_ext_dep.json")
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(single_file_json_template % non_existing_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = AzureCliUniversalDependency(ext_dep_descriptor)
         with self.assertRaises(Exception):
             ext_dep.fetch()
@@ -204,5 +226,5 @@ class TestAzCliUniversalDependency(unittest.TestCase):
         AzureCliUniversalDependency.VerifyToolDependencies()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/test_ci_build_plugin.py
+++ b/edk2toolext/tests/test_ci_build_plugin.py
@@ -14,7 +14,6 @@ from edk2toolext.environment.plugintypes.ci_build_plugin import ICiBuildPlugin
 
 
 class TestICiBuildPlugin(unittest.TestCase):
-
     def __init__(self, *args, **kwargs):
         self.test_dir = None
         super().__init__(*args, **kwargs)
@@ -58,8 +57,12 @@ class TestICiBuildPlugin(unittest.TestCase):
         self.assertTrue("directory is not an absolute path" in str(context.exception))
 
         with self.assertRaises(ValueError) as context:
-            plugin.WalkDirectoryForExtension(["test"], os.path.join(self.test_dir, "junkdir", "junk"), "")
-        self.assertTrue("directory is not a valid directory path" in str(context.exception))
+            plugin.WalkDirectoryForExtension(
+                ["test"], os.path.join(self.test_dir, "junkdir", "junk"), ""
+            )
+        self.assertTrue(
+            "directory is not a valid directory path" in str(context.exception)
+        )
 
         with self.assertRaises(TypeError) as context:
             plugin.WalkDirectoryForExtension([".py"], self.test_dir, "")
@@ -104,13 +107,19 @@ class TestICiBuildPlugin(unittest.TestCase):
         with open(os.path.join(nestedfolder, "file2.py"), "w") as the_file:
             the_file.write("hello 2")
 
-        result = plugin.WalkDirectoryForExtension([".txt", ".py"], self.test_dir, ["junk"])
+        result = plugin.WalkDirectoryForExtension(
+            [".txt", ".py"], self.test_dir, ["junk"]
+        )
         self.assertEqual(len(result), 1)
 
-        result = plugin.WalkDirectoryForExtension([".txt", ".py"], self.test_dir, ["file2"])
+        result = plugin.WalkDirectoryForExtension(
+            [".txt", ".py"], self.test_dir, ["file2"]
+        )
         self.assertEqual(len(result), 1)
 
-        result = plugin.WalkDirectoryForExtension([".txt", ".py"], self.test_dir, ["junk", "file2"])
+        result = plugin.WalkDirectoryForExtension(
+            [".txt", ".py"], self.test_dir, ["junk", "file2"]
+        )
         self.assertEqual(len(result), 0)
 
     def test_valid_parameters_ignore_caseinsensitive_WalkDirectoryForExtension(self):
@@ -126,13 +135,19 @@ class TestICiBuildPlugin(unittest.TestCase):
             the_file.write("hello 2")
 
         # case insensitive
-        result = plugin.WalkDirectoryForExtension([".txt", ".py"], self.test_dir, ["JUNK"])
+        result = plugin.WalkDirectoryForExtension(
+            [".txt", ".py"], self.test_dir, ["JUNK"]
+        )
         self.assertEqual(len(result), 1)
 
         # case insensitive + partial match
-        result = plugin.WalkDirectoryForExtension([".txt", ".py"], self.test_dir, ["FILE"])
+        result = plugin.WalkDirectoryForExtension(
+            [".txt", ".py"], self.test_dir, ["FILE"]
+        )
         self.assertEqual(len(result), 1)
 
         # case insensitive + all match including extension
-        result = plugin.WalkDirectoryForExtension([".txt", ".py"], self.test_dir, ["FILE2.py"])
+        result = plugin.WalkDirectoryForExtension(
+            [".txt", ".py"], self.test_dir, ["FILE2.py"]
+        )
         self.assertEqual(len(result), 1)

--- a/edk2toolext/tests/test_conf_mgmt.py
+++ b/edk2toolext/tests/test_conf_mgmt.py
@@ -13,7 +13,7 @@ import shutil
 import logging
 from edk2toolext.environment import conf_mgmt
 
-test_file_text = '''#
+test_file_text = """#
 #  Copyright (c) 2006 - 2018, Intel Corporation. All rights reserved.<BR>
 #  Portions copyright (c) 2008 - 2009, Apple Inc. All rights reserved.<BR>
 #  Portions copyright (c) 2011 - 2014, ARM Ltd. All rights reserved.<BR>
@@ -39,7 +39,7 @@ IDENTIFIER = Default TOOL_CHAIN_CONF
 
 # common path macros
 DEFINE VS2008_BIN      = ENV(VS2008_PREFIX)
-'''
+"""
 
 
 class TestConfMgmt(unittest.TestCase):
@@ -64,7 +64,9 @@ class TestConfMgmt(unittest.TestCase):
             f.write(f"#!VERSION={version}")
             logging.debug(f"Made file {filepath} with version {version}")
 
-    def make_edk2_files_dir(self, rootfolderpath, target_ver, tools_def_ver, build_rules_ver, is_template):
+    def make_edk2_files_dir(
+        self, rootfolderpath, target_ver, tools_def_ver, build_rules_ver, is_template
+    ):
         file_names = ["target", "tools_def", "build_rule"]
         versions = [target_ver, tools_def_ver, build_rules_ver]
         if is_template:
@@ -114,8 +116,7 @@ class TestConfMgmt(unittest.TestCase):
         self.assertEqual(c, "0.0")
 
     def test_invalid_version(self):
-        invalid_versions = ["1.2.3.4", "1.2.3", "Hello.1", "1.jk", "",
-                            "Wow", "Unknown"]
+        invalid_versions = ["1.2.3.4", "1.2.3", "Hello.1", "1.jk", "", "Wow", "Unknown"]
 
         p = os.path.join(self.test_dir, "test.txt")
         for a in invalid_versions:
@@ -262,5 +263,5 @@ class TestConfMgmt(unittest.TestCase):
             conf_mgmt.ConfMgmt().populate_conf_dir(conf, False, [temp])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/test_edk2_ci_build.py
+++ b/edk2toolext/tests/test_edk2_ci_build.py
@@ -19,7 +19,6 @@ from edk2toolext.environment import version_aggregator
 
 
 class TestEdk2CiBuild(unittest.TestCase):
-
     minimalTree = None
 
     def setUp(self):
@@ -49,11 +48,11 @@ class TestEdk2CiBuild(unittest.TestCase):
 
     @classmethod
     def restart_logging(cls):
-        '''
+        """
         We restart logging as logging is closed at the end of edk2 invocables.
         We also initialize it at the start.
         Reloading is the easiest way to get fresh state
-        '''
+        """
         logging.shutdown()
         reload(logging)
 
@@ -73,35 +72,42 @@ class TestEdk2CiBuild(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.minimalTree, "Build")))
 
     def test_merge_config(self):
-        descriptor = {'descriptor_file': 'C:\\MyRepo\\.pytool\\Plugin\\MyPlugin1\\MyPlugin1_plug_in.yaml',
-                      'module': 'MyPlugin1',
-                      'name': 'My Plugin 1',
-                      'scope': 'cibuild'}
+        descriptor = {
+            "descriptor_file": "C:\\MyRepo\\.pytool\\Plugin\\MyPlugin1\\MyPlugin1_plug_in.yaml",
+            "module": "MyPlugin1",
+            "name": "My Plugin 1",
+            "scope": "cibuild",
+        }
 
         global_config = {
             "MyPlugin1": {
-                "MySetting1": 'global value 1',
-                "MySetting2": 'global value 2',
+                "MySetting1": "global value 1",
+                "MySetting2": "global value 2",
             },
-            "MyPlugin2": {
-                "MySetting2": 'global value 2'
-            }
+            "MyPlugin2": {"MySetting2": "global value 2"},
         }
         package_config = {
             "MyPlugin1": {
-                "MySetting1": 'package value 1',
-                "MySetting3": 'package value 3'
+                "MySetting1": "package value 1",
+                "MySetting3": "package value 3",
             },
-            "MyPlugin3": {
-                "MySetting3": 'package value 3'
-            }
+            "MyPlugin3": {"MySetting3": "package value 3"},
         }
         merged_config = {
-            "MySetting1": 'package value 1',
-            "MySetting2": 'global value 2',
-            "MySetting3": 'package value 3'
+            "MySetting1": "package value 1",
+            "MySetting2": "global value 2",
+            "MySetting3": "package value 3",
         }
 
-        self.assertDictEqual(Edk2CiBuild.merge_config(global_config, {}, descriptor), global_config["MyPlugin1"])
-        self.assertDictEqual(Edk2CiBuild.merge_config({}, package_config, descriptor), package_config["MyPlugin1"])
-        self.assertDictEqual(Edk2CiBuild.merge_config(global_config, package_config, descriptor), merged_config)
+        self.assertDictEqual(
+            Edk2CiBuild.merge_config(global_config, {}, descriptor),
+            global_config["MyPlugin1"],
+        )
+        self.assertDictEqual(
+            Edk2CiBuild.merge_config({}, package_config, descriptor),
+            package_config["MyPlugin1"],
+        )
+        self.assertDictEqual(
+            Edk2CiBuild.merge_config(global_config, package_config, descriptor),
+            merged_config,
+        )

--- a/edk2toolext/tests/test_edk2_ci_setup.py
+++ b/edk2toolext/tests/test_edk2_ci_setup.py
@@ -19,7 +19,6 @@ from edk2toolext.environment import version_aggregator
 
 
 class TestEdk2CiSetup(unittest.TestCase):
-
     minimalTree = None
 
     def setUp(self):
@@ -40,11 +39,11 @@ class TestEdk2CiSetup(unittest.TestCase):
 
     @classmethod
     def restart_logging(cls):
-        '''
+        """
         We restart logging as logging is closed at the end of edk2 invocables.
         We also initialize it at the start.
         Reloading is the easiest way to get fresh state
-        '''
+        """
         logging.shutdown()
         reload(logging)
 
@@ -73,7 +72,14 @@ class TestEdk2CiSetup(unittest.TestCase):
     def test_ci_setup_bad_omnicache_path(self):
         builder = Edk2CiBuildSetup()
         settings_file = os.path.join(self.minimalTree, "settings.py")
-        sys.argv = ["stuart_ci_setup", "-c", settings_file, "-v", "--omnicache", "does_not_exist"]
+        sys.argv = [
+            "stuart_ci_setup",
+            "-c",
+            settings_file,
+            "-v",
+            "--omnicache",
+            "does_not_exist",
+        ]
         try:
             builder.Invoke()
         except SystemExit as e:

--- a/edk2toolext/tests/test_edk2_logging.py
+++ b/edk2toolext/tests/test_edk2_logging.py
@@ -14,7 +14,6 @@ from edk2toolext import edk2_logging
 
 
 class Test_edk2_logging(unittest.TestCase):
-
     def test_can_create_console_logger(self):
         console_logger = edk2_logging.setup_console_logging(False, False)
         self.assertIsNot(console_logger, None, "We created a console logger")
@@ -49,70 +48,105 @@ class Test_edk2_logging(unittest.TestCase):
 
     def test_scan_compiler_output_generic(self):
         # Input with compiler errors and warnings
-        output_stream = io.StringIO("<source_file>error A1: error 1 details\n"
-                                    "<source_file>warning B2: warning 2 details\n"
-                                    "<source_file>error C3: error 3 details\n"
-                                    "<source_file>warning D4: warning 4 details\n")
-        expected_output = [(logging.ERROR, "Compiler #1 from <source_file> error 1 details"),
-                           (logging.WARNING, "Compiler #2 from <source_file> warning 2 details"),
-                           (logging.ERROR, "Compiler #3 from <source_file> error 3 details"),
-                           (logging.WARNING, "Compiler #4 from <source_file> warning 4 details")]
-        self.assertEqual(edk2_logging.scan_compiler_output(output_stream), expected_output)
+        output_stream = io.StringIO(
+            "<source_file>error A1: error 1 details\n"
+            "<source_file>warning B2: warning 2 details\n"
+            "<source_file>error C3: error 3 details\n"
+            "<source_file>warning D4: warning 4 details\n"
+        )
+        expected_output = [
+            (logging.ERROR, "Compiler #1 from <source_file> error 1 details"),
+            (logging.WARNING, "Compiler #2 from <source_file> warning 2 details"),
+            (logging.ERROR, "Compiler #3 from <source_file> error 3 details"),
+            (logging.WARNING, "Compiler #4 from <source_file> warning 4 details"),
+        ]
+        self.assertEqual(
+            edk2_logging.scan_compiler_output(output_stream), expected_output
+        )
 
         # Input with no issue (empty string)
         output_stream = io.StringIO("")
         expected_output = []
-        self.assertEqual(edk2_logging.scan_compiler_output(output_stream), expected_output)
+        self.assertEqual(
+            edk2_logging.scan_compiler_output(output_stream), expected_output
+        )
 
         # Input with no issue (string has content but not expected to match)
         output_stream = io.StringIO("Some debug message string.")
         expected_output = []
-        self.assertEqual(edk2_logging.scan_compiler_output(output_stream), expected_output)
+        self.assertEqual(
+            edk2_logging.scan_compiler_output(output_stream), expected_output
+        )
 
         # Input with no issue (string that mentions an error but does not match)
         output_stream = io.StringIO("An error and warning occurred in x.")
         expected_output = []
-        self.assertEqual(edk2_logging.scan_compiler_output(output_stream), expected_output)
+        self.assertEqual(
+            edk2_logging.scan_compiler_output(output_stream), expected_output
+        )
 
         # Input with only compiler warnings
-        output_stream = io.StringIO("<source_file.c>warning C8: warning details...\n"
-                                    "<source_file.h>warning D10: info about the issue\n")
-        expected_output = [(logging.WARNING, "Compiler #8 from <source_file.c> warning details..."),
-                           (logging.WARNING, "Compiler #10 from <source_file.h> info about the issue")]
-        self.assertEqual(edk2_logging.scan_compiler_output(output_stream), expected_output)
+        output_stream = io.StringIO(
+            "<source_file.c>warning C8: warning details...\n"
+            "<source_file.h>warning D10: info about the issue\n"
+        )
+        expected_output = [
+            (logging.WARNING, "Compiler #8 from <source_file.c> warning details..."),
+            (logging.WARNING, "Compiler #10 from <source_file.h> info about the issue"),
+        ]
+        self.assertEqual(
+            edk2_logging.scan_compiler_output(output_stream), expected_output
+        )
 
         # Input with only compiler errors
-        output_stream = io.StringIO("dir/file.c error T4: uninitialized variable c...\n"
-                                    "dir1/dir2/file1.c error B2: duplicate symbol xyz.\n"
-                                    "dir1/file_2.h error 5: header file problem")
-        expected_output = [(logging.ERROR, "Compiler #4 from dir/file.c uninitialized variable c..."),
-                           (logging.ERROR, "Compiler #2 from dir1/dir2/file1.c duplicate symbol xyz."),
-                           (logging.ERROR, "Compiler #5 from dir1/file_2.h header file problem")]
-        self.assertEqual(edk2_logging.scan_compiler_output(output_stream), expected_output)
+        output_stream = io.StringIO(
+            "dir/file.c error T4: uninitialized variable c...\n"
+            "dir1/dir2/file1.c error B2: duplicate symbol xyz.\n"
+            "dir1/file_2.h error 5: header file problem"
+        )
+        expected_output = [
+            (logging.ERROR, "Compiler #4 from dir/file.c uninitialized variable c..."),
+            (logging.ERROR, "Compiler #2 from dir1/dir2/file1.c duplicate symbol xyz."),
+            (logging.ERROR, "Compiler #5 from dir1/file_2.h header file problem"),
+        ]
+        self.assertEqual(
+            edk2_logging.scan_compiler_output(output_stream), expected_output
+        )
 
         # Input with near matches that should not match
-        output_stream = io.StringIO("source.c error A1 error 1 details.\n"
-                                    "source warning D6 warning 6 details\n"
-                                    "source.obj LNK4: linker 4 details\n"
-                                    "script.py 5E: build 5 details\n")
+        output_stream = io.StringIO(
+            "source.c error A1 error 1 details.\n"
+            "source warning D6 warning 6 details\n"
+            "source.obj LNK4: linker 4 details\n"
+            "script.py 5E: build 5 details\n"
+        )
         expected_output = []
-        self.assertEqual(edk2_logging.scan_compiler_output(output_stream), expected_output)
+        self.assertEqual(
+            edk2_logging.scan_compiler_output(output_stream), expected_output
+        )
 
         # Test input with different error types
-        output_stream = io.StringIO("source.c error A1: error 1 details\n"
-                                    "source.c warning B2: warning 2 details\n"
-                                    "source.dsc error F3: error 3 details\n"
-                                    "source.obj error LNK4: linker 4 details\n"
-                                    "script.py error 5E: build 5 details\n")
-        expected_output = [(logging.ERROR, "Compiler #1 from source.c error 1 details"),
-                           (logging.WARNING, "Compiler #2 from source.c warning 2 details"),
-                           (logging.ERROR, "EDK2 #3 from source.dsc error 3 details"),
-                           (logging.ERROR, "Linker #4 from source.obj linker 4 details"),
-                           (logging.ERROR, "Build.py #5 from script.py build 5 details")]
-        self.assertEqual(edk2_logging.scan_compiler_output(output_stream), expected_output)
+        output_stream = io.StringIO(
+            "source.c error A1: error 1 details\n"
+            "source.c warning B2: warning 2 details\n"
+            "source.dsc error F3: error 3 details\n"
+            "source.obj error LNK4: linker 4 details\n"
+            "script.py error 5E: build 5 details\n"
+        )
+        expected_output = [
+            (logging.ERROR, "Compiler #1 from source.c error 1 details"),
+            (logging.WARNING, "Compiler #2 from source.c warning 2 details"),
+            (logging.ERROR, "EDK2 #3 from source.dsc error 3 details"),
+            (logging.ERROR, "Linker #4 from source.obj linker 4 details"),
+            (logging.ERROR, "Build.py #5 from script.py build 5 details"),
+        ]
+        self.assertEqual(
+            edk2_logging.scan_compiler_output(output_stream), expected_output
+        )
 
     def test_scan_compiler_output_vs_actual(self):
-        output_stream = io.StringIO("""
+        output_stream = io.StringIO(
+            """
             "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.34.31933\\bin\\Hostx86\\x64\\cl.exe" /Fod:\\a\\1\\s\\Build\\SetupDataPkg\\DEBUG_VS2022\\X64\\SetupDataPkg\\ConfApp\\ConfApp\\OUTPUT\\SvdUsb\\ /showIncludes /nologo /c /WX /GS /W4 /Gs32768 /D UNICODE /O1b2s /GL /Gy /FIAutoGen.h /EHs-c- /GR- /GF /Z7 /Gw -D DISABLE_NEW_DEPRECATED_INTERFACES /Id:\\a\\1\\s\\SetupDataPkg\\ConfApp\\SvdUsb  /Id:\\a\\1\\s\\SetupDataPkg\\ConfApp  /Id:\\a\\1\\s\\Build\\SetupDataPkg\\DEBUG_VS2022\\X64\\SetupDataPkg\\ConfApp\\ConfApp\\DEBUG  /Id:\\a\\1\\s\\MU_BASECORE\\MdePkg  /Id:\\a\\1\\s\\MU_BASECORE\\MdePkg\\Include  /Id:\\a\\1\\s\\MU_BASECORE\\MdePkg\\Test\\UnitTest\\Include  /Id:\\a\\1\\s\\MU_BASECORE\\MdePkg\\Include\\X64  /Id:\\a\\1\\s\\MU_BASECORE\\MdeModulePkg  /Id:\\a\\1\\s\\MU_BASECORE\\MdeModulePkg\\Include  /Id:\\a\\1\\s\\SetupDataPkg  /Id:\\a\\1\\s\\SetupDataPkg\\Include  /Id:\\a\\1\\s\\SetupDataPkg\\Test\\Include  /Id:\\a\\1\\s\\Common\\MU_PLUS\\PcBdsPkg  /Id:\\a\\1\\s\\Common\\MU_PLUS\\PcBdsPkg\\Include  /Id:\\a\\1\\s\\Common\\MU_PLUS\\MsCorePkg  /Id:\\a\\1\\s\\Common\\MU_PLUS\\MsCorePkg\\Include  /Id:\\a\\1\\s\\Common\\MU_PLUS\\XmlSupportPkg  /Id:\\a\\1\\s\\Common\\MU_PLUS\\XmlSupportPkg\\Include  /Id:\\a\\1\\s\\Common\\MU_TIANO_PLUS\\SecurityPkg  /Id:\\a\\1\\s\\Common\\MU_TIANO_PLUS\\SecurityPkg\\Include  /Id:\\a\\1\\s\\MU_BASECORE\\PolicyServicePkg  /Id:\\a\\1\\s\\MU_BASECORE\\PolicyServicePkg\\Include d:\\a\\1\\s\\SetupDataPkg\\ConfApp\\SvdUsb\\SvdUsb.c
             SvdUsb.c
             "C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.34.31933\\bin\\Hostx86\\x64\\lib.exe" /NOLOGO /LTCG /OUT:d:\\a\\1\\s\\Build\\SetupDataPkg\\DEBUG_VS2022\\X64\\SetupDataPkg\\ConfApp\\ConfApp\\OUTPUT\\ConfApp.lib @d:\\a\\1\\s\\Build\\SetupDataPkg\\DEBUG_VS2022\\X64\\SetupDataPkg\\ConfApp\\ConfApp\\OUTPUT\\object_files.lst
@@ -132,18 +166,39 @@ class Test_edk2_logging(unittest.TestCase):
             build.py...
             : error F002: Failed to build module
                 d:\\a\\1\\s\\SetupDataPkg\\ConfApp\\ConfApp.inf [X64, VS2022, DEBUG]
-            """)    # noqa: E501
+            """
+        )  # noqa: E501
 
-        expected_output = [(logging.ERROR, "Linker #2001 from UefiApplicationEntryPoint.lib(ApplicationEntryPoint.obj) : unresolved external symbol __security_check_cookie"),  # noqa: E501
-                           (logging.ERROR, "Linker #2001 from ConfApp.lib(SetupConf.obj) : unresolved external symbol __report_rangecheckfailure"),  # noqa: E501
-                           (logging.ERROR, "Linker #1120 from d:\\a\\1\\s\\Build\\SetupDataPkg\\DEBUG_VS2022\\X64\\SetupDataPkg\\ConfApp\\ConfApp\\DEBUG\\ConfApp.dll : fatal 2 unresolved externals"),  # noqa: E501
-                           (logging.ERROR, "Compiler #1077 from NMAKE : fatal \'\"C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.34.31933\\bin\\Hostx86\\x64\\link.exe\"\' : return code \'0x460\'"),  # noqa: E501
-                           (logging.ERROR, "Compiler #7000 from : Failed to execute command"),  # noqa: E501
-                           (logging.ERROR, "EDK2 #002 from : Failed to build module")]
-        self.assertEqual(edk2_logging.scan_compiler_output(output_stream), expected_output)
+        expected_output = [
+            (
+                logging.ERROR,
+                "Linker #2001 from UefiApplicationEntryPoint.lib(ApplicationEntryPoint.obj) : unresolved external symbol __security_check_cookie",
+            ),  # noqa: E501
+            (
+                logging.ERROR,
+                "Linker #2001 from ConfApp.lib(SetupConf.obj) : unresolved external symbol __report_rangecheckfailure",
+            ),  # noqa: E501
+            (
+                logging.ERROR,
+                "Linker #1120 from d:\\a\\1\\s\\Build\\SetupDataPkg\\DEBUG_VS2022\\X64\\SetupDataPkg\\ConfApp\\ConfApp\\DEBUG\\ConfApp.dll : fatal 2 unresolved externals",
+            ),  # noqa: E501
+            (
+                logging.ERROR,
+                "Compiler #1077 from NMAKE : fatal '\"C:\\Program Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.34.31933\\bin\\Hostx86\\x64\\link.exe\"' : return code '0x460'",
+            ),  # noqa: E501
+            (
+                logging.ERROR,
+                "Compiler #7000 from : Failed to execute command",
+            ),  # noqa: E501
+            (logging.ERROR, "EDK2 #002 from : Failed to build module"),
+        ]
+        self.assertEqual(
+            edk2_logging.scan_compiler_output(output_stream), expected_output
+        )
 
     def test_scan_compiler_output_vs_linker_actual(self):
-        output_stream = io.StringIO("""
+        output_stream = io.StringIO(
+            """
                 copy /y d:/a/1/s/Build/MdeModule/RELEASE_VS2022/IA32/MdeModulePkg/Universal/LegacyRegion2Dxe/LegacyRegion2Dxe/DEBUG/*.map d:/a/1/s/Build/MdeModule/RELEASE_VS2022/IA32/MdeModulePkg/Universal/LegacyRegion2Dxe/LegacyRegion2Dxe/OUTPUT
             SdMmcPciHcPei.lib(SdMmcPciHcPei.obj) : error LNK2001: unresolved external symbol _SafeUint8Add
             d:/a/1/s/Build/MdeModule/RELEASE_VS2022/IA32/MdeModulePkg/Bus/Pci/SdMmcPciHcPei/SdMmcPciHcPei/DEBUG/SdMmcPciHcPei.dll : fatal error LNK1120: 1 unresolved externals
@@ -151,16 +206,31 @@ class Test_edk2_logging(unittest.TestCase):
                     1 file(s) copied.
                 copy /y d:/a/1/s/Build/MdeModule/RELEASE_VS2022/IA32/MdeModulePkg/Universal/LegacyRegion2Dxe/LegacyRegion2Dxe/DEBUG/*.pdb d:/a/1/s/Build/MdeModule/RELEASE_VS2022/IA32/MdeModulePkg/Universal/LegacyRegion2Dxe/LegacyRegion2Dxe/OUTPUT
             NMAKE : fatal error U1077: '"C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.34.31933/bin/Hostx86/x86/link.exe"' : return code '0x460'
-            """)    # noqa: E501
+            """
+        )  # noqa: E501
 
-        expected_output = [(logging.ERROR, "Linker #2001 from SdMmcPciHcPei.lib(SdMmcPciHcPei.obj) : unresolved external symbol _SafeUint8Add"),  # noqa: E501
-                           (logging.ERROR, "Linker #1120 from d:/a/1/s/Build/MdeModule/RELEASE_VS2022/IA32/MdeModulePkg/Bus/Pci/SdMmcPciHcPei/SdMmcPciHcPei/DEBUG/SdMmcPciHcPei.dll : fatal 1 unresolved externals"),  # noqa: E501
-                           (logging.ERROR, "Compiler #1077 from NMAKE : fatal \'\"C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.34.31933/bin/Hostx86/x86/link.exe\"\' : return code \'0x460\'")]  # noqa: E501
-        self.assertEqual(edk2_logging.scan_compiler_output(output_stream), expected_output)
+        expected_output = [
+            (
+                logging.ERROR,
+                "Linker #2001 from SdMmcPciHcPei.lib(SdMmcPciHcPei.obj) : unresolved external symbol _SafeUint8Add",
+            ),  # noqa: E501
+            (
+                logging.ERROR,
+                "Linker #1120 from d:/a/1/s/Build/MdeModule/RELEASE_VS2022/IA32/MdeModulePkg/Bus/Pci/SdMmcPciHcPei/SdMmcPciHcPei/DEBUG/SdMmcPciHcPei.dll : fatal 1 unresolved externals",
+            ),  # noqa: E501
+            (
+                logging.ERROR,
+                "Compiler #1077 from NMAKE : fatal '\"C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.34.31933/bin/Hostx86/x86/link.exe\"' : return code '0x460'",
+            ),
+        ]  # noqa: E501
+        self.assertEqual(
+            edk2_logging.scan_compiler_output(output_stream), expected_output
+        )
 
     def test_scan_compiler_output_gcc_mixed_actual(self):
         # Test input with all types of issues (errors and warnings)
-        output_stream = io.StringIO("""
+        output_stream = io.StringIO(
+            """
             "/usr/bin/aarch64-linux-gnu-gcc"   -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common -ffunction-sections -fdata-sections -DSTRING_ARRAY_NAME=BaseLibStrings -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common -mlittle-endian -fno-short-enums -fverbose-asm -funsigned-char -ffunction-sections -fdata-sections -Wno-address -fno-asynchronous-unwind-tables -fno-unwind-tables -fno-pic -fno-pie -ffixed-x18 -mcmodel=small -flto -Wno-unused-but-set-variable -Wno-unused-const-variable -D DISABLE_NEW_DEPRECATED_INTERFACES -mstrict-align -mgeneral-regs-only -c -o /__w/1/s/Build/SetupDataPkg/DEBUG_GCC5/AARCH64/MdePkg/Library/BaseLib/BaseLib/OUTPUT/./FilePaths.obj -I/__w/1/s/MU_BASECORE/MdePkg/Library/BaseLib/AArch64 -I/__w/1/s/MU_BASECORE/MdePkg/Library/BaseLib/Arm -I/__w/1/s/MU_BASECORE/MdePkg/Library/BaseLib -I/__w/1/s/Build/SetupDataPkg/DEBUG_GCC5/AARCH64/MdePkg/Library/BaseLib/BaseLib/DEBUG -I/__w/1/s/MU_BASECORE/MdePkg -I/__w/1/s/MU_BASECORE/MdePkg/Include -I/__w/1/s/MU_BASECORE/MdePkg/Test/UnitTest/Include -I/__w/1/s/MU_BASECORE/MdePkg/Include/AArch64 /__w/1/s/MU_BASECORE/MdePkg/Library/BaseLib/FilePaths.c
             "/usr/bin/aarch64-linux-gnu-gcc"   -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common -ffunction-sections -fdata-sections -DSTRING_ARRAY_NAME=BaseLibStrings -g -Os -fshort-wchar -fno-builtin -fno-strict-aliasing -Wall -Werror -Wno-array-bounds -include AutoGen.h -fno-common -mlittle-endian -fno-short-enums -fverbose-asm -funsigned-char -ffunction-sections -fdata-sections -Wno-address -fno-asynchronous-unwind-tables -fno-unwind-tables -fno-pic -fno-pie -ffixed-x18 -mcmodel=small -flto -Wno-unused-but-set-variable -Wno-unused-const-variable -D DISABLE_NEW_DEPRECATED_INTERFACES -mstrict-align -mgeneral-regs-only -c -o /__w/1/s/Build/SetupDataPkg/DEBUG_GCC5/AARCH64/MdePkg/Library/BaseLib/BaseLib/OUTPUT/./GetPowerOfTwo32.obj -I/__w/1/s/MU_BASECORE/MdePkg/Library/BaseLib/AArch64 -I/__w/1/s/MU_BASECORE/MdePkg/Library/BaseLib/Arm -I/__w/1/s/MU_BASECORE/MdePkg/Library/BaseLib -I/__w/1/s/Build/SetupDataPkg/DEBUG_GCC5/AARCH64/MdePkg/Library/BaseLib/BaseLib/DEBUG -I/__w/1/s/MU_BASECORE/MdePkg -I/__w/1/s/MU_BASECORE/MdePkg/Include -I/__w/1/s/MU_BASECORE/MdePkg/Test/UnitTest/Include -I/__w/1/s/MU_BASECORE/MdePkg/Include/AArch64 /__w/1/s/MU_BASECORE/MdePkg/Library/BaseLib/GetPowerOfTwo32.c
             /__w/1/s/SetupDataPkg/Library/ConfigVariableListLib/ConfigVariableListLib.c:20:1: error: conflicting types for `ConvertVariableListToVariableEntry`; have `EFI_STATUS(const void *, UINTN *, CONFIG_VAR_LIST_ENTRY *)` {aka `long long unsigned int(const void *, long long unsigned int *, CONFIG_VAR_LIST_ENTRY *)`}
@@ -182,12 +252,20 @@ class Test_edk2_logging(unittest.TestCase):
             build.py...
             : error F002: Failed to build module
                 /__w/1/s/SetupDataPkg/Library/ConfigVariableListLib/ConfigVariableListLib.inf [AARCH64, GCC5, DEBUG]
-        """)    # noqa: E501
+        """
+        )  # noqa: E501
 
-        expected_output = [(logging.ERROR, "Compiler #error from /__w/1/s/SetupDataPkg/Library/ConfigVariableListLib/ConfigVariableListLib.c conflicting types for `ConvertVariableListToVariableEntry`; have `EFI_STATUS(const void *, UINTN *, CONFIG_VAR_LIST_ENTRY *)` {aka `long long unsigned int(const void *, long long unsigned int *, CONFIG_VAR_LIST_ENTRY *)`}"),  # noqa: E501
-                           (logging.ERROR, "Compiler #7000 from : Failed to execute command"),
-                           (logging.ERROR, "EDK2 #002 from : Failed to build module")]
-        self.assertEqual(edk2_logging.scan_compiler_output(output_stream), expected_output)
+        expected_output = [
+            (
+                logging.ERROR,
+                "Compiler #error from /__w/1/s/SetupDataPkg/Library/ConfigVariableListLib/ConfigVariableListLib.c conflicting types for `ConvertVariableListToVariableEntry`; have `EFI_STATUS(const void *, UINTN *, CONFIG_VAR_LIST_ENTRY *)` {aka `long long unsigned int(const void *, long long unsigned int *, CONFIG_VAR_LIST_ENTRY *)`}",
+            ),  # noqa: E501
+            (logging.ERROR, "Compiler #7000 from : Failed to execute command"),
+            (logging.ERROR, "EDK2 #002 from : Failed to build module"),
+        ]
+        self.assertEqual(
+            edk2_logging.scan_compiler_output(output_stream), expected_output
+        )
 
 
 # caplog is a pytest fixture that captures log messages
@@ -203,7 +281,7 @@ def test_catch_secrets_filter(caplog):
     for start, end in zip(start_list, end_list):
         logging.debug(f"This is a secret{start}{fake_secret}{end}to be caught")
 
-    for (record, start, end) in zip(caplog.records, start_list, end_list):
+    for record, start, end in zip(caplog.records, start_list, end_list):
         assert record.msg == f"This is a secret{start}*******{end}to be caught"
     caplog.clear()
 
@@ -212,7 +290,7 @@ def test_catch_secrets_filter(caplog):
     for start, end in zip(start_list, end_list):
         logging.debug(f"This is a secret{start}{fake_secret}{end}to be caught")
 
-    for (record, start, end) in zip(caplog.records, start_list, end_list):
+    for record, start, end in zip(caplog.records, start_list, end_list):
         assert record.msg == f"This is a secret{start}*******{end}to be caught"
     caplog.clear()
 
@@ -221,7 +299,7 @@ def test_catch_secrets_filter(caplog):
     for start, end in zip(start_list, end_list):
         logging.debug(f"This is a secret{start}{fake_secret}{end}to be caught")
 
-    for (record, start, end) in zip(caplog.records, start_list, end_list):
+    for record, start, end in zip(caplog.records, start_list, end_list):
         assert record.msg == f"This is a secret{start}{fake_secret}{end}to be caught"
     caplog.clear()
 
@@ -230,7 +308,7 @@ def test_catch_secrets_filter(caplog):
     for start, end in zip(start_list, end_list):
         logging.debug(f"This is a secret{start}{fake_secret}{end}to be caught")
 
-    for (record, start, end) in zip(caplog.records, start_list, end_list):
+    for record, start, end in zip(caplog.records, start_list, end_list):
         assert record.msg == f"This is a secret{start}*******{end}to be caught"
     caplog.clear()
 
@@ -239,6 +317,6 @@ def test_catch_secrets_filter(caplog):
     for start, end in zip(start_list, end_list):
         logging.debug(f"This is a secret{start}{fake_secret}{end}to be caught")
 
-    for (record, start, end) in zip(caplog.records, start_list, end_list):
+    for record, start, end in zip(caplog.records, start_list, end_list):
         assert record.msg == f"This is a secret{start}{fake_secret}{end}to be caught"
     caplog.clear()

--- a/edk2toolext/tests/test_edk2_plat_build.py
+++ b/edk2toolext/tests/test_edk2_plat_build.py
@@ -19,7 +19,6 @@ from edk2toolext.environment import version_aggregator
 
 
 class TestEdk2PlatBuild(unittest.TestCase):
-
     minimalTree = None
 
     def setUp(self):
@@ -40,11 +39,11 @@ class TestEdk2PlatBuild(unittest.TestCase):
 
     @classmethod
     def restart_logging(cls):
-        '''
+        """
         We restart logging as logging is closed at the end of edk2 invocables.
         We also initialize it at the start.
         Reloading is the easiest way to get fresh state
-        '''
+        """
         logging.shutdown()
         reload(logging)
 

--- a/edk2toolext/tests/test_edk2_setup.py
+++ b/edk2toolext/tests/test_edk2_setup.py
@@ -121,7 +121,7 @@ def tree(tmpdir):
 def write_build_file(tree, file):
     """Writes the requested build file to the base of the tree."""
     build_file = tree / "BuildFile.py"
-    with open(build_file, 'x') as f:
+    with open(build_file, "x") as f:
         f.write(file)
     return build_file
 
@@ -161,7 +161,7 @@ def test_setup_simple_repo(tree: pathlib.Path):
     # Dirty a submodule file and verify we skip without --FORCE #
     #############################################################
     min_build_file = write_build_file(tree, MIN_BUILD_FILE)
-    with open(mu_submodule / "License.txt", 'a') as f:
+    with open(mu_submodule / "License.txt", "a") as f:
         f.write("TEST")
 
     with git.Repo(mu_submodule) as repo:
@@ -196,7 +196,14 @@ def test_setup_bad_omnicache(caplog, tree: pathlib.Path):
     """Tests that edk2_setup catches a bad omnicache path."""
     caplog.at_level(logging.WARNING)  # Capture only warnings
     empty_build_file = write_build_file(tree, EMPTY_BUILD_FILE)
-    sys.argv = ["stuart_setup", "-c", str(empty_build_file), "-v", "--omnicache", "does_not_exist"]
+    sys.argv = [
+        "stuart_setup",
+        "-c",
+        str(empty_build_file),
+        "-v",
+        "--omnicache",
+        "does_not_exist",
+    ]
 
     try:
         edk2_setup.main()
@@ -242,13 +249,15 @@ def test_parse_command_line_options(tree: pathlib.Path):
     # Test valid command line options
     empty_build_file = write_build_file(tree, EMPTY_BUILD_FILE)
     sys.argv = [
-        "stuart_setup", "-c", str(empty_build_file),
+        "stuart_setup",
+        "-c",
+        str(empty_build_file),
         "BLD_*_VAR",
         "VAR",
         "BLD_DEBUG_VAR2",
         "BLD_RELEASE_VAR2",
         "TEST_VAR=TEST",
-        "BLD_*_TEST_VAR2=TEST"
+        "BLD_*_TEST_VAR2=TEST",
     ]
     try:
         edk2_setup.main()
@@ -264,12 +273,13 @@ def test_parse_command_line_options(tree: pathlib.Path):
     assert env.GetValue("BLD_*_TEST_VAR2") == "TEST"
 
     # Test invalid command line options
-    for arg in ["BLD_*_VAR=5=10", "BLD_DEBUG_VAR2=5=5", "BLD_RELEASE_VAR3=5=5", "VAR=10=10"]:
-        sys.argv = [
-            "stuart_setup",
-            "-c", str(empty_build_file),
-            arg
-        ]
+    for arg in [
+        "BLD_*_VAR=5=10",
+        "BLD_DEBUG_VAR2=5=5",
+        "BLD_RELEASE_VAR3=5=5",
+        "VAR=10=10",
+    ]:
+        sys.argv = ["stuart_setup", "-c", str(empty_build_file), arg]
         try:
             edk2_setup.main()
         except RuntimeError as e:
@@ -279,16 +289,18 @@ def test_parse_command_line_options(tree: pathlib.Path):
 def test_conf_file(tree: pathlib.Path):
     """Tests that the config file parser works correctly."""
     empty_build_file = write_build_file(tree, EMPTY_BUILD_FILE)
-    build_conf = tree / 'BuildConfig.conf'
-    with open(build_conf, 'x') as f:
-        f.writelines([
-            "BLD_*_VAR",
-            "\nVAR",
-            "\nBLD_DEBUG_VAR2",
-            "\nBLD_RELEASE_VAR2",
-            "\nTEST_VAR=TEST",
-            "\nBLD_*_TEST_VAR2=TEST"
-        ])
+    build_conf = tree / "BuildConfig.conf"
+    with open(build_conf, "x") as f:
+        f.writelines(
+            [
+                "BLD_*_VAR",
+                "\nVAR",
+                "\nBLD_DEBUG_VAR2",
+                "\nBLD_RELEASE_VAR2",
+                "\nTEST_VAR=TEST",
+                "\nBLD_*_TEST_VAR2=TEST",
+            ]
+        )
     sys.argv = ["stuart_setup", "-c", str(empty_build_file)]
 
     try:
@@ -305,16 +317,17 @@ def test_conf_file(tree: pathlib.Path):
     assert env.GetValue("BLD_*_TEST_VAR2") == "TEST"
 
     # Test invalid build config
-    for arg in ["BLD_*_VAR=5=10", "BLD_DEBUG_VAR2=5=5", "BLD_RELEASE_VAR3=5=5", "VAR=10=10"]:
+    for arg in [
+        "BLD_*_VAR=5=10",
+        "BLD_DEBUG_VAR2=5=5",
+        "BLD_RELEASE_VAR3=5=5",
+        "VAR=10=10",
+    ]:
         build_conf.unlink()
-        with open(build_conf, 'x') as f:
+        with open(build_conf, "x") as f:
             f.writelines([arg])
 
-        sys.argv = [
-            "stuart_setup",
-            "-c", str(empty_build_file),
-            arg
-        ]
+        sys.argv = ["stuart_setup", "-c", str(empty_build_file), arg]
         try:
             edk2_setup.main()
         except RuntimeError as e:

--- a/edk2toolext/tests/test_external_dependency.py
+++ b/edk2toolext/tests/test_external_dependency.py
@@ -61,7 +61,7 @@ class TestExternalDependency(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        logger = logging.getLogger('')
+        logger = logging.getLogger("")
         logger.addHandler(logging.NullHandler())
         unittest.installHandler()
 
@@ -71,11 +71,11 @@ class TestExternalDependency(unittest.TestCase):
 
     def test_determine_cache_path(self):
         nuget_desc = copy.copy(NUGET_TEMPLATE)
-        nuget_desc['version'] = GOOD_VERSION
-        nuget_desc['descriptor_file'] = os.path.join(TEST_DIR, 'non_file.yaml')
+        nuget_desc["version"] = GOOD_VERSION
+        nuget_desc["descriptor_file"] = os.path.join(TEST_DIR, "non_file.yaml")
         ext_dep = ExtDep(nuget_desc)
 
-        cache_path = os.path.join(TEST_DIR, 'stuart_cache')
+        cache_path = os.path.join(TEST_DIR, "stuart_cache")
 
         self.assertIsNone(ext_dep.determine_cache_path())
 
@@ -83,69 +83,77 @@ class TestExternalDependency(unittest.TestCase):
         self.assertIsNone(ext_dep.determine_cache_path())
 
         os.makedirs(cache_path)
-        self.assertTrue(ext_dep.determine_cache_path().startswith(os.path.join(cache_path, 'nuget')))
+        self.assertTrue(
+            ext_dep.determine_cache_path().startswith(os.path.join(cache_path, "nuget"))
+        )
 
         web_desc = copy.copy(WEB_TEMPLATE)
-        web_desc['version'] = GOOD_VERSION
-        web_desc['descriptor_file'] = os.path.join(TEST_DIR, 'non_file.yaml')
+        web_desc["version"] = GOOD_VERSION
+        web_desc["descriptor_file"] = os.path.join(TEST_DIR, "non_file.yaml")
         ext_dep = ExtDep(web_desc)
         ext_dep.set_global_cache_path(cache_path)
-        self.assertTrue(ext_dep.determine_cache_path().startswith(os.path.join(cache_path, 'web')))
+        self.assertTrue(
+            ext_dep.determine_cache_path().startswith(os.path.join(cache_path, "web"))
+        )
 
     def test_different_versions_have_different_caches(self):
-        cache_path = os.path.join(TEST_DIR, 'stuart_cache')
+        cache_path = os.path.join(TEST_DIR, "stuart_cache")
         os.makedirs(cache_path)
 
         nuget_desc1 = copy.copy(NUGET_TEMPLATE)
-        nuget_desc1['version'] = GOOD_VERSION
-        nuget_desc1['descriptor_file'] = os.path.join(TEST_DIR, 'non_file.yaml')
+        nuget_desc1["version"] = GOOD_VERSION
+        nuget_desc1["descriptor_file"] = os.path.join(TEST_DIR, "non_file.yaml")
         ext_dep1 = ExtDep(nuget_desc1)
 
         nuget_desc2 = copy.copy(NUGET_TEMPLATE)
-        nuget_desc2['version'] = "7.0.0"
-        nuget_desc2['descriptor_file'] = os.path.join(TEST_DIR, 'non_file.yaml')
+        nuget_desc2["version"] = "7.0.0"
+        nuget_desc2["descriptor_file"] = os.path.join(TEST_DIR, "non_file.yaml")
         ext_dep2 = ExtDep(nuget_desc2)
 
         ext_dep1.set_global_cache_path(cache_path)
         ext_dep2.set_global_cache_path(cache_path)
 
-        self.assertNotEqual(ext_dep1.determine_cache_path(), ext_dep2.determine_cache_path())
+        self.assertNotEqual(
+            ext_dep1.determine_cache_path(), ext_dep2.determine_cache_path()
+        )
 
     def test_different_sources_have_different_caches(self):
-        cache_path = os.path.join(TEST_DIR, 'stuart_cache')
+        cache_path = os.path.join(TEST_DIR, "stuart_cache")
         os.makedirs(cache_path)
 
         nuget_desc1 = copy.copy(NUGET_TEMPLATE)
-        nuget_desc1['version'] = GOOD_VERSION
-        nuget_desc1['descriptor_file'] = os.path.join(TEST_DIR, 'non_file.yaml')
+        nuget_desc1["version"] = GOOD_VERSION
+        nuget_desc1["descriptor_file"] = os.path.join(TEST_DIR, "non_file.yaml")
         ext_dep1 = ExtDep(nuget_desc1)
 
         nuget_desc2 = copy.copy(NUGET_TEMPLATE)
-        nuget_desc2['version'] = GOOD_VERSION
-        nuget_desc2['descriptor_file'] = os.path.join(TEST_DIR, 'non_file.yaml')
-        nuget_desc2['source'] = "https://api.nuget.org/v3/different_index.json"
+        nuget_desc2["version"] = GOOD_VERSION
+        nuget_desc2["descriptor_file"] = os.path.join(TEST_DIR, "non_file.yaml")
+        nuget_desc2["source"] = "https://api.nuget.org/v3/different_index.json"
         ext_dep2 = ExtDep(nuget_desc2)
 
         ext_dep1.set_global_cache_path(cache_path)
         ext_dep2.set_global_cache_path(cache_path)
 
-        self.assertNotEqual(ext_dep1.determine_cache_path(), ext_dep2.determine_cache_path())
+        self.assertNotEqual(
+            ext_dep1.determine_cache_path(), ext_dep2.determine_cache_path()
+        )
 
     def test_can_copy_to_cache(self):
-        cache_path = os.path.join(TEST_DIR, 'stuart_cache')
+        cache_path = os.path.join(TEST_DIR, "stuart_cache")
         os.makedirs(cache_path)
 
         nuget_desc = copy.copy(NUGET_TEMPLATE)
-        nuget_desc['version'] = GOOD_VERSION
-        nuget_desc['descriptor_file'] = os.path.join(TEST_DIR, 'non_file.yaml')
+        nuget_desc["version"] = GOOD_VERSION
+        nuget_desc["descriptor_file"] = os.path.join(TEST_DIR, "non_file.yaml")
         ext_dep = ExtDep(nuget_desc)
         ext_dep.set_global_cache_path(cache_path)
 
         self.assertFalse(os.path.exists(ext_dep.determine_cache_path()))
 
         # Create a new directory with a dummy file.
-        test_path = os.path.join(TEST_DIR, 'test_path')
-        test_file = os.path.join(test_path, 'test_file.txt')
+        test_path = os.path.join(TEST_DIR, "test_path")
+        test_file = os.path.join(test_path, "test_file.txt")
         os.makedirs(test_path)
         with open(test_file, "w") as fp:
             fp.write("DEADBEEF\n")
@@ -154,7 +162,7 @@ class TestExternalDependency(unittest.TestCase):
         ext_dep.copy_to_global_cache(test_path)
 
         self.assertTrue(os.path.exists(ext_dep.determine_cache_path()))
-        copied_file = os.path.join(ext_dep.determine_cache_path(), 'test_file.txt')
+        copied_file = os.path.join(ext_dep.determine_cache_path(), "test_file.txt")
         self.assertTrue(os.path.exists(copied_file))
         file_contents = None
         with open(copied_file, "r") as fp:
@@ -162,31 +170,31 @@ class TestExternalDependency(unittest.TestCase):
         self.assertTrue("DEADBEEF" in file_contents)
 
     def test_can_copy_from_cache(self):
-        cache_path = os.path.join(TEST_DIR, 'stuart_cache')
+        cache_path = os.path.join(TEST_DIR, "stuart_cache")
         os.makedirs(cache_path)
 
         nuget_desc = copy.copy(NUGET_TEMPLATE)
-        nuget_desc['version'] = GOOD_VERSION
-        nuget_desc['descriptor_file'] = os.path.join(TEST_DIR, 'non_file.yaml')
+        nuget_desc["version"] = GOOD_VERSION
+        nuget_desc["descriptor_file"] = os.path.join(TEST_DIR, "non_file.yaml")
         ext_dep = ExtDep(nuget_desc)
         ext_dep.set_global_cache_path(cache_path)
 
         self.assertFalse(os.path.exists(ext_dep.determine_cache_path()))
 
-        test_path = os.path.join(TEST_DIR, 'test_path')
-        test_file = os.path.join(test_path, 'test_file.txt')
+        test_path = os.path.join(TEST_DIR, "test_path")
+        test_file = os.path.join(test_path, "test_file.txt")
         os.makedirs(test_path)
         with open(test_file, "w") as fp:
             fp.write("DEADBEEF\n")
         ext_dep.copy_to_global_cache(test_path)
 
-        test_path2 = os.path.join(TEST_DIR, 'test_path2')
+        test_path2 = os.path.join(TEST_DIR, "test_path2")
         self.assertFalse(os.path.exists(test_path2))
 
         ext_dep.copy_from_global_cache(test_path2)
 
         self.assertTrue(os.path.exists(test_path2))
-        copied_file = os.path.join(test_path2, 'test_file.txt')
+        copied_file = os.path.join(test_path2, "test_file.txt")
         self.assertTrue(os.path.exists(copied_file))
         file_contents = None
         with open(copied_file, "r") as fp:
@@ -194,5 +202,5 @@ class TestExternalDependency(unittest.TestCase):
         self.assertTrue("DEADBEEF" in file_contents)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/test_git_dependency.py
+++ b/edk2toolext/tests/test_git_dependency.py
@@ -23,7 +23,7 @@ invalid_version = "762941318ee16e59d123456789049eec22f0d303"
 short_version = "7fd1a60"
 short_upper_version = "7FD1A60"
 
-hw_json_template = '''
+hw_json_template = """
 {
   "scope": "global",
   "type": "git",
@@ -32,7 +32,7 @@ hw_json_template = '''
   "version": "%s",
   "flags": []
 }
-'''
+"""
 
 
 def prep_workspace():
@@ -62,7 +62,7 @@ class TestGitDependency(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        logger = logging.getLogger('')
+        logger = logging.getLogger("")
         logger.addHandler(logging.NullHandler())
         unittest.installHandler()
 
@@ -76,7 +76,9 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % uptodate_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify())
@@ -86,7 +88,9 @@ class TestGitDependency(unittest.TestCase):
         ext_dep_file_path = os.path.join(test_dir, "hw_ext_dep.json")
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % short_version)
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify())
@@ -96,7 +100,9 @@ class TestGitDependency(unittest.TestCase):
         ext_dep_file_path = os.path.join(test_dir, "hw_ext_dep.json")
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % short_upper_version)
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify())
@@ -107,7 +113,9 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % behind_one_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify())
@@ -118,7 +126,9 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % invalid_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertEqual(ext_dep.version, invalid_version)
@@ -129,7 +139,9 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % invalid_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         self.assertFalse(ext_dep.verify())
 
@@ -138,7 +150,9 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % invalid_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         os.makedirs(ext_dep._local_repo_root_path, exist_ok=True)
         self.assertFalse(ext_dep.verify())
@@ -148,10 +162,14 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % invalid_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         os.makedirs(ext_dep._local_repo_root_path, exist_ok=True)
-        with open(os.path.join(ext_dep._local_repo_root_path, "testfile.txt"), 'a') as my_file:
+        with open(
+            os.path.join(ext_dep._local_repo_root_path, "testfile.txt"), "a"
+        ) as my_file:
             my_file.write("Test code\n")
         self.assertFalse(ext_dep.verify())
 
@@ -160,11 +178,15 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % uptodate_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         ext_dep.fetch()
         # now write a new file
-        with open(os.path.join(ext_dep._local_repo_root_path, "testfile.txt"), 'a') as my_file:
+        with open(
+            os.path.join(ext_dep._local_repo_root_path, "testfile.txt"), "a"
+        ) as my_file:
             my_file.write("Test code to make repo dirty\n")
         self.assertFalse(ext_dep.verify())
 
@@ -173,7 +195,9 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % uptodate_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify())
@@ -183,7 +207,9 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % behind_one_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify(), "Confirm valid ext_dep at one commit behind")
@@ -191,7 +217,9 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % uptodate_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         self.assertFalse(ext_dep.verify(), "Confirm downlevel repo fails to verify")
         ext_dep.fetch()
@@ -204,9 +232,14 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % uptodate_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
-        self.assertFalse(os.path.isdir(ext_dep.contents_dir), "Confirm not ext dep directory before cleaning")
+        self.assertFalse(
+            os.path.isdir(ext_dep.contents_dir),
+            "Confirm not ext dep directory before cleaning",
+        )
         ext_dep.clean()
         self.assertFalse(os.path.isdir(ext_dep.contents_dir))
 
@@ -215,10 +248,14 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % invalid_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         os.makedirs(ext_dep._local_repo_root_path, exist_ok=True)
-        with open(os.path.join(ext_dep._local_repo_root_path, "testfile.txt"), 'a') as my_file:
+        with open(
+            os.path.join(ext_dep._local_repo_root_path, "testfile.txt"), "a"
+        ) as my_file:
             my_file.write("Test code\n")
         ext_dep.clean()
         self.assertFalse(os.path.isdir(ext_dep.contents_dir))
@@ -228,12 +265,16 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % uptodate_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify(), "Confirm repo is valid")
         # now write a new file
-        with open(os.path.join(ext_dep._local_repo_root_path, "testfile.txt"), 'a') as my_file:
+        with open(
+            os.path.join(ext_dep._local_repo_root_path, "testfile.txt"), "a"
+        ) as my_file:
             my_file.write("Test code to make repo dirty\n")
         self.assertFalse(ext_dep.verify(), "Confirm repo is dirty")
         ext_dep.clean()
@@ -244,7 +285,9 @@ class TestGitDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % uptodate_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = GitDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify(), "Confirm repo is valid and clean")
@@ -260,7 +303,7 @@ class TestGitDependencyUrlPatching(unittest.TestCase):
         "name": "HelloWorld",
         "source": "https://github.com/octocat/Hello-World.git",
         "version": "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
-        "flags": []
+        "flags": [],
     }
 
     def tearDown(self):
@@ -278,42 +321,44 @@ class TestGitDependencyUrlPatching(unittest.TestCase):
     def test_url_should_not_be_modified_without_env(self):
         my_test_descriptor = copy.copy(TestGitDependencyUrlPatching.TEST_DESCRIPTOR)
         # Add the indicator for patching.
-        my_test_descriptor['url_creds_var'] = 'test_creds_var'
+        my_test_descriptor["url_creds_var"] = "test_creds_var"
 
         # Initialize the GitDependency object.
         git_dep = GitDependency(my_test_descriptor)
 
         # Assert that the URL is identical.
-        self.assertEqual(git_dep.source, my_test_descriptor['source'])
+        self.assertEqual(git_dep.source, my_test_descriptor["source"])
 
     def test_url_should_not_be_modified_without_descriptor_field(self):
         my_test_descriptor = copy.copy(TestGitDependencyUrlPatching.TEST_DESCRIPTOR)
 
         env = shell_environment.GetEnvironment()
         # Add the var to the environment.
-        env.set_shell_var('test_creds_var', 'my_stuff')
+        env.set_shell_var("test_creds_var", "my_stuff")
 
         # Initialize the GitDependency object.
         git_dep = GitDependency(my_test_descriptor)
 
         # Assert that the URL is identical.
-        self.assertEqual(git_dep.source, my_test_descriptor['source'])
+        self.assertEqual(git_dep.source, my_test_descriptor["source"])
 
     def test_url_should_be_modified_if_creds_are_indicated_and_supplied(self):
         my_test_descriptor = copy.copy(TestGitDependencyUrlPatching.TEST_DESCRIPTOR)
         # Add the indicator for patching.
-        my_test_descriptor['url_creds_var'] = 'test_creds_var'
+        my_test_descriptor["url_creds_var"] = "test_creds_var"
 
         env = shell_environment.GetEnvironment()
         # Add the var to the environment.
-        env.set_shell_var('test_creds_var', 'my_stuff')
+        env.set_shell_var("test_creds_var", "my_stuff")
 
         # Initialize the GitDependency object.
         git_dep = GitDependency(my_test_descriptor)
 
         # Assert that the URL is identical.
-        self.assertEqual(git_dep.source, "https://my_stuff@github.com/octocat/Hello-World.git")
+        self.assertEqual(
+            git_dep.source, "https://my_stuff@github.com/octocat/Hello-World.git"
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/test_image_validation.py
+++ b/edk2toolext/tests/test_image_validation.py
@@ -26,6 +26,7 @@ class FileHeader:
     def __init__(self):
         self.Machine = 0x8664
 
+
 # A Dummy class to represent a PE.
 
 
@@ -40,9 +41,7 @@ class PE:
 
 
 class TestImageValidationInterface(unittest.TestCase):
-
     def test_add_test(self):
-
         test_manager = IV.TestManager()
         self.assertEqual(len(test_manager.tests), 0)
         test_manager.add_test(IV.TestSectionAlignment())
@@ -56,14 +55,8 @@ class TestImageValidationInterface(unittest.TestCase):
 
     def test_test_manager(self):
         config_data = {
-            "TARGET_ARCH": {
-                "X64": "IMAGE_FILE_MACHINE_AMD64"
-            },
-            "IMAGE_FILE_MACHINE_AMD64": {
-                "DEFAULT": {
-                    "DATA_CODE_SEPARATION": False
-                }
-            }
+            "TARGET_ARCH": {"X64": "IMAGE_FILE_MACHINE_AMD64"},
+            "IMAGE_FILE_MACHINE_AMD64": {"DEFAULT": {"DATA_CODE_SEPARATION": False}},
         }
         test_manager = IV.TestManager(config_data=config_data)
         self.assertEqual(test_manager.config_data, config_data)
@@ -82,55 +75,71 @@ class TestImageValidationInterface(unittest.TestCase):
         1. If test requirement is not specified, or equal to false, return Result.SKIP
         3. Return Result.PASS / Result.FAIL returned based on Characteristic value
         """
-        test_pe0 = PE(sections=[
-            Section("S1.1".encode("utf-8"), characteristics=0x80000000),
-            Section("S1.2".encode("utf-8"), characteristics=0x20000000),
-            Section("S1.3".encode("utf-8"), characteristics=0x00000000)])
+        test_pe0 = PE(
+            sections=[
+                Section("S1.1".encode("utf-8"), characteristics=0x80000000),
+                Section("S1.2".encode("utf-8"), characteristics=0x20000000),
+                Section("S1.3".encode("utf-8"), characteristics=0x00000000),
+            ]
+        )
 
-        test_pe1 = PE(sections=[
-            Section("S2.1".encode("utf-8"), characteristics=0xA0000000),
-            Section("S2.2".encode("utf-8"), characteristics=0x20000000),
-            Section("S2.3".encode("utf-8"), characteristics=0x00000000)])
+        test_pe1 = PE(
+            sections=[
+                Section("S2.1".encode("utf-8"), characteristics=0xA0000000),
+                Section("S2.2".encode("utf-8"), characteristics=0x20000000),
+                Section("S2.3".encode("utf-8"), characteristics=0x00000000),
+            ]
+        )
 
-        test_pe2 = PE(sections=[
-            Section("S3.1".encode("utf-8"), characteristics=0x20000000),
-            Section("S3.2".encode("utf-8"), characteristics=0x80000000),
-            Section("S3.3".encode("utf-8"), characteristics=0xC0000000)])
+        test_pe2 = PE(
+            sections=[
+                Section("S3.1".encode("utf-8"), characteristics=0x20000000),
+                Section("S3.2".encode("utf-8"), characteristics=0x80000000),
+                Section("S3.3".encode("utf-8"), characteristics=0xC0000000),
+            ]
+        )
 
-        test_pe3 = PE(sections=[
-            Section("S4.1".encode("utf-8"), characteristics=0xE0000000)])
+        test_pe3 = PE(
+            sections=[Section("S4.1".encode("utf-8"), characteristics=0xE0000000)]
+        )
 
-        config_data1 = {
-            "TARGET_REQUIREMENTS": {"DATA_CODE_SEPARATION": False}
-        }
+        config_data1 = {"TARGET_REQUIREMENTS": {"DATA_CODE_SEPARATION": False}}
 
         config_data2 = {"TARGET_REQUIREMENTS": {}}
 
         test_write_execute_flags = IV.TestWriteExecuteFlags()
-        tests = [(test_pe0, IV.Result.PASS), (test_pe1, IV.Result.FAIL),
-                 (test_pe2, IV.Result.PASS), (test_pe3, IV.Result.FAIL)]
+        tests = [
+            (test_pe0, IV.Result.PASS),
+            (test_pe1, IV.Result.FAIL),
+            (test_pe2, IV.Result.PASS),
+            (test_pe3, IV.Result.FAIL),
+        ]
 
-        config_data0 = {
-            "TARGET_REQUIREMENTS": {"DATA_CODE_SEPARATION": True}
-        }
+        config_data0 = {"TARGET_REQUIREMENTS": {"DATA_CODE_SEPARATION": True}}
 
         # Test set 1
         for i in range(len(tests)):
             with self.subTest("test_write_execute1", i=i):
                 pe, result = tests[i]
-                self.assertEqual(test_write_execute_flags.execute(pe, config_data0), result)
+                self.assertEqual(
+                    test_write_execute_flags.execute(pe, config_data0), result
+                )
 
         # Test set 2
         for i in range(len(tests)):
             with self.subTest("test_write_execute2", i=i):
                 pe, _ = tests[i]
-                self.assertEqual(test_write_execute_flags.execute(pe, config_data1), IV.Result.SKIP)
+                self.assertEqual(
+                    test_write_execute_flags.execute(pe, config_data1), IV.Result.SKIP
+                )
 
         # Test set 3
         for i in range(len(tests)):
             with self.subTest("test_write_execute3", i=i):
                 pe, _ = tests[i]
-                self.assertEqual(test_write_execute_flags.execute(pe, config_data2), IV.Result.SKIP)
+                self.assertEqual(
+                    test_write_execute_flags.execute(pe, config_data2), IV.Result.SKIP
+                )
 
     def test_section_alignment_test(self):
         """
@@ -142,38 +151,44 @@ class TestImageValidationInterface(unittest.TestCase):
 
         config_data0 = {
             "TARGET_REQUIREMENTS": {},
-            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}},
         }
         config_data1 = {
             "TARGET_REQUIREMENTS": {"ALIGNMENT": []},
-            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}},
         }
         config_data2 = {
             "TARGET_REQUIREMENTS": {"ALIGNMENT": [{"COMPARISON": ">=", "VALUE": 0}]},
-            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}},
         }
 
         config_data3 = {
             "TARGET_REQUIREMENTS": {"ALIGNMENT": [{"COMPARISON": "==", "VALUE": 1}]},
-            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}},
         }
 
         config_data4 = {
-            "TARGET_REQUIREMENTS": {"ALIGNMENT": [
-                {"COMPARISON": ">=", "VALUE": 0},
-                {"COMPARISON": ">=", "VALUE": 64},
-                {"COMPARISON": "<=", "VALUE": 8192}],
-                "ALIGNMENT_LOGIC_SEP": "AND"},
-            "TARGET_INFO": {}
+            "TARGET_REQUIREMENTS": {
+                "ALIGNMENT": [
+                    {"COMPARISON": ">=", "VALUE": 0},
+                    {"COMPARISON": ">=", "VALUE": 64},
+                    {"COMPARISON": "<=", "VALUE": 8192},
+                ],
+                "ALIGNMENT_LOGIC_SEP": "AND",
+            },
+            "TARGET_INFO": {},
         }
 
         config_data5 = {
-            "TARGET_REQUIREMENTS": {"ALIGNMENT": [
-                {"COMPARISON": ">=", "VALUE": 0},
-                {"COMPARISON": ">=", "VALUE": 64},
-                {"COMPARISON": "!=", "VALUE": 4096}],
-                "ALIGNMENT_LOGIC_SEP": "AND"},
-            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+            "TARGET_REQUIREMENTS": {
+                "ALIGNMENT": [
+                    {"COMPARISON": ">=", "VALUE": 0},
+                    {"COMPARISON": ">=", "VALUE": 64},
+                    {"COMPARISON": "!=", "VALUE": 4096},
+                ],
+                "ALIGNMENT_LOGIC_SEP": "AND",
+            },
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}},
         }
 
         test_pe0 = PE(optional_header=OptionalHeader(SectionAlignment=4096))
@@ -181,96 +196,131 @@ class TestImageValidationInterface(unittest.TestCase):
         test_pe2 = PE(optional_header=None)
 
         test_section_alignment_test = IV.TestSectionAlignment()
-        tests0 = [(config_data0, IV.Result.SKIP), (config_data1, IV.Result.SKIP),
-                  (config_data2, IV.Result.PASS), (config_data3, IV.Result.FAIL),
-                  (config_data4, IV.Result.PASS), (config_data5, IV.Result.FAIL)]
+        tests0 = [
+            (config_data0, IV.Result.SKIP),
+            (config_data1, IV.Result.SKIP),
+            (config_data2, IV.Result.PASS),
+            (config_data3, IV.Result.FAIL),
+            (config_data4, IV.Result.PASS),
+            (config_data5, IV.Result.FAIL),
+        ]
 
         # Test set 1
         for i in range(len(tests0)):
             with self.subTest("test_section_alignment_test0", i=i):
                 config, result = tests0[i]
-                self.assertEqual(test_section_alignment_test.execute(test_pe0, config), result)
+                self.assertEqual(
+                    test_section_alignment_test.execute(test_pe0, config), result
+                )
 
-        tests1 = [(config_data0, IV.Result.SKIP), (config_data1, IV.Result.SKIP),
-                  (config_data2, IV.Result.WARN), (config_data3, IV.Result.WARN),
-                  (config_data4, IV.Result.WARN), (config_data5, IV.Result.WARN)]
+        tests1 = [
+            (config_data0, IV.Result.SKIP),
+            (config_data1, IV.Result.SKIP),
+            (config_data2, IV.Result.WARN),
+            (config_data3, IV.Result.WARN),
+            (config_data4, IV.Result.WARN),
+            (config_data5, IV.Result.WARN),
+        ]
 
         # Test set 2
         for i in range(len(tests1)):
             with self.subTest("test_section_alignment_test1", i=i):
                 config, result = tests1[i]
-                self.assertEqual(test_section_alignment_test.execute(test_pe1, config), result)
+                self.assertEqual(
+                    test_section_alignment_test.execute(test_pe1, config), result
+                )
 
         # Test set 3
         for i in range(len(tests1)):
             with self.subTest("test_section_alignment_test2", i=i):
                 config, result = tests1[i]
-                self.assertEqual(test_section_alignment_test.execute(test_pe2, config), result)
+                self.assertEqual(
+                    test_section_alignment_test.execute(test_pe2, config), result
+                )
 
     def test_section_alignment_test2(self):
-
         target_config0 = {
             "TARGET_REQUIREMENTS": {
                 "ALIGNMENT": [
                     {"COMPARISON": ">=", "VALUE": 0},
-                    {"COMPARISON": "<=", "VALUE": 8192}],
-                "ALIGNMENT_LOGIC_SEP": "AND"},
-            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+                    {"COMPARISON": "<=", "VALUE": 8192},
+                ],
+                "ALIGNMENT_LOGIC_SEP": "AND",
+            },
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}},
         }
 
         target_config1 = {
             "TARGET_REQUIREMENTS": {
                 "ALIGNMENT": [
                     {"COMPARISON": "==", "VALUE": 0},
-                    {"COMPARISON": "<=", "VALUE": 8192}],
-                "ALIGNMENT_LOGIC_SEP": "AND"},
-            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+                    {"COMPARISON": "<=", "VALUE": 8192},
+                ],
+                "ALIGNMENT_LOGIC_SEP": "AND",
+            },
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}},
         }
 
         target_config2 = {
             "TARGET_REQUIREMENTS": {
                 "ALIGNMENT": [
                     {"COMPARISON": "==", "VALUE": 32},
-                    {"COMPARISON": "==", "VALUE": 4096}],
-                "ALIGNMENT_LOGIC_SEP": "OR"},
-            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+                    {"COMPARISON": "==", "VALUE": 4096},
+                ],
+                "ALIGNMENT_LOGIC_SEP": "OR",
+            },
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}},
         }
 
         target_config3 = {
             "TARGET_REQUIREMENTS": {
                 "ALIGNMENT": [
                     {"COMPARISON": "==", "VALUE": 31},
-                    {"COMPARISON": "==", "VALUE": 61}],
-                "ALIGNMENT_LOGIC_SEP": "OR"},
-            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+                    {"COMPARISON": "==", "VALUE": 61},
+                ],
+                "ALIGNMENT_LOGIC_SEP": "OR",
+            },
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}},
         }
 
         target_config4 = {
             "TARGET_REQUIREMENTS": {
                 "ALIGNMENT": [
                     {"COMPARISON": "==", "VALUE": 32},
-                    {"COMPARISON": "==", "VALUE": 64}]},
-            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+                    {"COMPARISON": "==", "VALUE": 64},
+                ]
+            },
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}},
         }
 
         target_config5 = {
             "TARGET_REQUIREMENTS": {
                 "ALIGNMENT": [
                     {"COMPARISON": "==", "VALUE": 32},
-                    {"COMPARISON": "==", "VALUE": 64}],
-                "ALIGNMENT_LOGIC_SEP": "AR"},
-            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}}
+                    {"COMPARISON": "==", "VALUE": 64},
+                ],
+                "ALIGNMENT_LOGIC_SEP": "AR",
+            },
+            "TARGET_INFO": {"MACHINE_TYPE": "", "PROFILE": {}},
         }
 
         test_section_alignment_test = IV.TestSectionAlignment()
         pe = PE(optional_header=OptionalHeader(SectionAlignment=4096))
-        tests = [(target_config0, IV.Result.PASS), (target_config1, IV.Result.FAIL), (target_config2, IV.Result.PASS),
-                 (target_config3, IV.Result.FAIL), (target_config4, IV.Result.FAIL), (target_config5, IV.Result.FAIL)]
+        tests = [
+            (target_config0, IV.Result.PASS),
+            (target_config1, IV.Result.FAIL),
+            (target_config2, IV.Result.PASS),
+            (target_config3, IV.Result.FAIL),
+            (target_config4, IV.Result.FAIL),
+            (target_config5, IV.Result.FAIL),
+        ]
 
         for i in range(len(tests)):
             with self.subTest("test_section_alignment_and_or_logic", i=i):
                 config, result = tests[i]
-                self.assertEqual(test_section_alignment_test.execute(pe, config), result)
+                self.assertEqual(
+                    test_section_alignment_test.execute(pe, config), result
+                )
 
     def test_subsystem_value_test(self):
         """
@@ -280,52 +330,70 @@ class TestImageValidationInterface(unittest.TestCase):
         3. If subsystem type is invalid, return Result.FAIL
         3. return Result.PASS / Result.FAIL returned based on subsystem value
         """
-        config_data0 = {
-            "TARGET_REQUIREMENTS": {}
-        }
-        config_data1 = {
-            "TARGET_REQUIREMENTS": {"ALLOWED_SUBSYSTEMS": []}
-        }
+        config_data0 = {"TARGET_REQUIREMENTS": {}}
+        config_data1 = {"TARGET_REQUIREMENTS": {"ALLOWED_SUBSYSTEMS": []}}
         config_data2 = {
-            "TARGET_REQUIREMENTS": {"ALLOWED_SUBSYSTEMS": ["IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER"]}
+            "TARGET_REQUIREMENTS": {
+                "ALLOWED_SUBSYSTEMS": ["IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER"]
+            }
         }
         config_data3 = {
-            "TARGET_REQUIREMENTS": {"ALLOWED_SUBSYSTEMS":
-                                    ["IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
-                                     "IMAGE_SUBSYSTEM_EFI_APPLICATION"]}
+            "TARGET_REQUIREMENTS": {
+                "ALLOWED_SUBSYSTEMS": [
+                    "IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER",
+                    "IMAGE_SUBSYSTEM_EFI_APPLICATION",
+                ]
+            }
         }
 
         test_subsystem_value_test = IV.TestSubsystemValue()
 
         TEST_PE0 = PE(optional_header=OptionalHeader(Subsystem=10))
-        tests0 = [(config_data0, IV.Result.SKIP), (config_data1, IV.Result.SKIP),
-                  (config_data2, IV.Result.FAIL), (config_data3, IV.Result.PASS)]
+        tests0 = [
+            (config_data0, IV.Result.SKIP),
+            (config_data1, IV.Result.SKIP),
+            (config_data2, IV.Result.FAIL),
+            (config_data3, IV.Result.PASS),
+        ]
 
         for i in range(len(tests0)):
             with self.subTest("test_subsystem_value0", i=i):
                 config, result = tests0[i]
-                self.assertEqual(test_subsystem_value_test.execute(TEST_PE0, config), result)
+                self.assertEqual(
+                    test_subsystem_value_test.execute(TEST_PE0, config), result
+                )
 
         TEST_PE1 = PE(optional_header=OptionalHeader(Subsystem="UEFI_"))
-        tests1 = [(config_data0, IV.Result.SKIP), (config_data1, IV.Result.SKIP),
-                  (config_data2, IV.Result.FAIL), (config_data3, IV.Result.FAIL)]
+        tests1 = [
+            (config_data0, IV.Result.SKIP),
+            (config_data1, IV.Result.SKIP),
+            (config_data2, IV.Result.FAIL),
+            (config_data3, IV.Result.FAIL),
+        ]
 
         for i in range(len(tests1)):
             with self.subTest("test_subsystem_value1", i=i):
                 config, result = tests1[i]
-                self.assertEqual(test_subsystem_value_test.execute(TEST_PE1, config), result)
+                self.assertEqual(
+                    test_subsystem_value_test.execute(TEST_PE1, config), result
+                )
 
         TEST_PE2 = PE(optional_header=OptionalHeader(Subsystem=None))
-        tests2 = [(config_data0, IV.Result.SKIP), (config_data1, IV.Result.SKIP),
-                  (config_data2, IV.Result.WARN), (config_data3, IV.Result.WARN)]
+        tests2 = [
+            (config_data0, IV.Result.SKIP),
+            (config_data1, IV.Result.SKIP),
+            (config_data2, IV.Result.WARN),
+            (config_data3, IV.Result.WARN),
+        ]
 
         for i in range(len(tests2)):
             with self.subTest("test_subsystem_value2", i=i):
                 config, result = tests2[i]
-                self.assertEqual(test_subsystem_value_test.execute(TEST_PE2, config), result)
+                self.assertEqual(
+                    test_subsystem_value_test.execute(TEST_PE2, config), result
+                )
 
     def test_helper_functions(self):
-
         data = 0b00000000
         results = [1, 2, 4, 8, 16, 32, 64]
 
@@ -366,16 +434,12 @@ class TestImageValidationInterface(unittest.TestCase):
             "T2": "T",
             "T3": "T",
         }
-        target_config = {
-            "T2": "F"
-        }
-        final_config = {
-            "T1": "T",
-            "T2": "F",
-            "T3": "T"
-        }
+        target_config = {"T2": "F"}
+        final_config = {"T1": "T", "T2": "F", "T3": "T"}
 
-        self.assertEqual(IV.fill_missing_requirements(default_config, target_config), final_config)
+        self.assertEqual(
+            IV.fill_missing_requirements(default_config, target_config), final_config
+        )
 
     def test_test_interface(self):
         c = IV.TestInterface()
@@ -386,7 +450,6 @@ class TestImageValidationInterface(unittest.TestCase):
             c.execute(1, 2)
 
     def test_get_cli_args(self):
-
         test1 = ["-i", "file.efi"]
         test2 = ["-i", "file.efi", "-d"]
         test3 = ["-i", "file.efi", "-p", "APP"]

--- a/edk2toolext/tests/test_nuget.py
+++ b/edk2toolext/tests/test_nuget.py
@@ -12,7 +12,6 @@ from edk2toolext.bin import nuget
 
 
 class Test_nuget(unittest.TestCase):
-
     def test_can_download_nuget(self):
         test_dir = tempfile.mkdtemp()
         nuget_path = os.path.join(test_dir, "NuGet.exe")

--- a/edk2toolext/tests/test_nuget_dependency.py
+++ b/edk2toolext/tests/test_nuget_dependency.py
@@ -24,7 +24,7 @@ bad_version = "5.2.13.1.2"
 missing_version = "5.200.13"
 
 hw_package_name = "NuGet.CommandLine"
-hw_json_template = '''
+hw_json_template = """
 {
   "scope": "global",
   "type": "nuget",
@@ -32,7 +32,7 @@ hw_json_template = '''
   "source": "https://api.nuget.org/v3/index.json",
   "version": "%s"
 }
-'''
+"""
 
 
 def prep_workspace():
@@ -63,7 +63,7 @@ class TestNugetDependency(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        logger = logging.getLogger('')
+        logger = logging.getLogger("")
         logger.addHandler(logging.NullHandler())
         unittest.installHandler()
 
@@ -89,16 +89,17 @@ class TestNugetDependency(unittest.TestCase):
     def test_can_get_nuget_path(self):
         nuget_cmd = NugetDependency.GetNugetCmd()
         nuget_cmd += ["locals", "global-packages", "-list"]
-        ret = RunCmd(nuget_cmd[0], ' '.join(nuget_cmd[1:]), outstream=sys.stdout)
+        ret = RunCmd(nuget_cmd[0], " ".join(nuget_cmd[1:]), outstream=sys.stdout)
         self.assertEqual(ret, 0)  # make sure we have a zero return code
 
     def test_missing_nuget(self):
-
         if NugetDependency.NUGET_ENV_VAR_NAME in os.environ:
             del os.environ[NugetDependency.NUGET_ENV_VAR_NAME]
 
         # delete the package file
-        original = NugetDependency.GetNugetCmd()[-1]  # get last item which will be exe path
+        original = NugetDependency.GetNugetCmd()[
+            -1
+        ]  # get last item which will be exe path
         os.remove(original)
         path = NugetDependency.GetNugetCmd()
         self.assertIsNone(path)  # Should not be found
@@ -142,7 +143,9 @@ class TestNugetDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % good_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = NugetDependency(ext_dep_descriptor)
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify())
@@ -156,9 +159,13 @@ class TestNugetDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % bad_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = NugetDependency(ext_dep_descriptor)
-        with self.assertRaises((RuntimeError, ValueError)):  # we can throw a value error if we hit the cache
+        with self.assertRaises(
+            (RuntimeError, ValueError)
+        ):  # we can throw a value error if we hit the cache
             # we should throw an exception because we don't know how to parse the version
             ext_dep.fetch()
         self.assertFalse(ext_dep.verify())
@@ -223,7 +230,9 @@ class TestNugetDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % missing_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = NugetDependency(ext_dep_descriptor)
         with self.assertRaises(RuntimeError):
             ext_dep.fetch()
@@ -235,7 +244,9 @@ class TestNugetDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % good_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = NugetDependency(ext_dep_descriptor)
 
         ext_dep.nuget_cache_path = "not_a_real_path"
@@ -246,18 +257,22 @@ class TestNugetDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % good_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = NugetDependency(ext_dep_descriptor)
 
         #
         # Create a cache with a bad cached package.
         #
         # First, create the cache.
-        cache_dir = os.path.join(test_dir, 'nuget_test_bad_cache')
+        cache_dir = os.path.join(test_dir, "nuget_test_bad_cache")
         os.mkdir(cache_dir)
         ext_dep.nuget_cache_path = cache_dir
         # Then create the directories inside the cache that should hold the contents.
-        package_cache_dir = os.path.join(cache_dir, hw_package_name.lower(), good_version)
+        package_cache_dir = os.path.join(
+            cache_dir, hw_package_name.lower(), good_version
+        )
         os.makedirs(package_cache_dir)
         # There are no package directories inside the cache.
         self.assertFalse(ext_dep._fetch_from_nuget_cache(hw_package_name))
@@ -272,22 +287,28 @@ class TestNugetDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(hw_json_template % good_version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = NugetDependency(ext_dep_descriptor)
 
         #
         # Create a cache with a good cached package.
         #
         # First, create the cache.
-        cache_dir = os.path.join(test_dir, 'nuget_test_good_cache')
+        cache_dir = os.path.join(test_dir, "nuget_test_good_cache")
         os.mkdir(cache_dir)
         ext_dep.nuget_cache_path = cache_dir
         # Then create the directories inside the cache that should hold the contents.
-        package_cache_dir = os.path.join(cache_dir, hw_package_name.lower(), good_version)
+        package_cache_dir = os.path.join(
+            cache_dir, hw_package_name.lower(), good_version
+        )
         os.makedirs(package_cache_dir)
 
         # Create a directory that does match the heuristic.
-        test_cache_contents = os.path.join(package_cache_dir, hw_package_name, "working_blah")
+        test_cache_contents = os.path.join(
+            package_cache_dir, hw_package_name, "working_blah"
+        )
         os.makedirs(test_cache_contents)
         self.assertTrue(ext_dep._fetch_from_nuget_cache(hw_package_name))
         ext_dep.update_state_file()
@@ -298,5 +319,5 @@ class TestNugetDependency(unittest.TestCase):
         self.assertTrue(ext_dep.verify())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/test_nuget_publish.py
+++ b/edk2toolext/tests/test_nuget_publish.py
@@ -75,7 +75,14 @@ class test_nuget_publish(unittest.TestCase):
     def test_empty_pack(self):
         nuget = nuget_publishing.NugetSupport("test")
         version = "1.1"
-        nuget.SetBasicData("EDK2", "https://BSD2", "https://project_url", "descr", "server", "copyright")
+        nuget.SetBasicData(
+            "EDK2",
+            "https://BSD2",
+            "https://project_url",
+            "descr",
+            "server",
+            "copyright",
+        )
         tempfolder_in = tempfile.mkdtemp()
         tempfolder_out = tempfile.mkdtemp()
         # this should fail because we don't have anything to pack
@@ -102,26 +109,53 @@ class test_nuget_publish(unittest.TestCase):
 
     def test_push(self):
         nuget = nuget_publishing.NugetSupport("test")
-        nuget.SetBasicData("EDK2", "BSD-2-Clause", "https://project_url", "descr", "https://server", "copyright")
+        nuget.SetBasicData(
+            "EDK2",
+            "BSD-2-Clause",
+            "https://project_url",
+            "descr",
+            "https://server",
+            "copyright",
+        )
         tempfolder_out = tempfile.mkdtemp()
         spec = os.path.join(tempfolder_out, "test.nuspec")
-        test_nuget_publish.write_to_file(spec, ["This is a legit nuget file lol", ])
+        test_nuget_publish.write_to_file(
+            spec,
+            [
+                "This is a legit nuget file lol",
+            ],
+        )
         ret = nuget.Push(spec, "")
         self.assertEqual(ret, 1)
 
     def test_pack_license_espression_invalid(self):
         nuget = nuget_publishing.NugetSupport("test")
         version = "1.1.1"
-        nuget.SetBasicData("EDK2", "BSD-2-Clause", "https://project_url", "description", "server", "copyright")
+        nuget.SetBasicData(
+            "EDK2",
+            "BSD-2-Clause",
+            "https://project_url",
+            "description",
+            "server",
+            "copyright",
+        )
         tempfolder_in = tempfile.mkdtemp()
         tempfolder_out = tempfile.mkdtemp()
         outfile = os.path.join(tempfolder_in, "readme.txt")
         # Create a very long release notes
         release_notes = ""
-        while len(release_notes) <= nuget_publishing.NugetSupport.RELEASE_NOTE_SHORT_STRING_MAX_LENGTH:
+        while (
+            len(release_notes)
+            <= nuget_publishing.NugetSupport.RELEASE_NOTE_SHORT_STRING_MAX_LENGTH
+        ):
             release_notes += f"This is now {len(release_notes)} characters long. "
         # write a file that can be packaged by nuget
-        test_nuget_publish.write_to_file(outfile, [release_notes, ])
+        test_nuget_publish.write_to_file(
+            outfile,
+            [
+                release_notes,
+            ],
+        )
         ret = nuget.Pack(version, tempfolder_out, tempfolder_in, release_notes)
         self.assertEqual(ret, 0)
         spec = os.path.join(tempfolder_out, "test.nuspec")
@@ -133,36 +167,40 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_and_pack_LicenseIdentifier(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--LicenseIdentifier",
-                    "BSD2"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+            "--LicenseIdentifier",
+            "BSD2",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
 
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
@@ -171,38 +209,42 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_and_pack_CustomLicense_valid(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        open(os.path.join(tempfolder, 'license.txt'), 'w')
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder]
+        open(os.path.join(tempfolder, "license.txt"), "w")
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+        ]
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
 
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--Copyright",
-                    "2023",
-                    "--InputFolderPath",
-                    tempfolder,
-                    "--CustomLicensePath",
-                    os.path.join(tempfolder, 'license.txt')]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--Copyright",
+            "2023",
+            "--InputFolderPath",
+            tempfolder,
+            "--CustomLicensePath",
+            os.path.join(tempfolder, "license.txt"),
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
@@ -211,32 +253,36 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_and_pack_no_CustomLicense(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder]
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+        ]
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+        ]
 
         self.assertRaises(Exception, nuget_publishing.main)
         sys.argv = args
@@ -244,34 +290,38 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_and_pack_CustomLicense_invalid_path(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder]
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+        ]
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder,
-                    "--CustomLicensePath",
-                    "/bad/path/license.txt"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+            "--CustomLicensePath",
+            "/bad/path/license.txt",
+        ]
 
         self.assertRaises(Exception, nuget_publishing.main)
         sys.argv = args
@@ -279,35 +329,39 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_and_pack_CustomLicense_invalid_license_name(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        open(os.path.join(tempfolder, 'license2.txt'), 'w')
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder]
+        open(os.path.join(tempfolder, "license2.txt"), "w")
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+        ]
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder,
-                    "--CustomLicensePath",
-                    os.path.join(tempfolder, 'license2.txt')]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+            "--CustomLicensePath",
+            os.path.join(tempfolder, "license2.txt"),
+        ]
 
         self.assertRaises(Exception, nuget_publishing.main)
         sys.argv = args
@@ -315,38 +369,42 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_RepositoryType_and_pack(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--LicenseIdentifier",
-                    "BSD2",
-                    "--RepositoryType",
-                    "git"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+            "--LicenseIdentifier",
+            "BSD2",
+            "--RepositoryType",
+            "git",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
 
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
@@ -355,38 +413,42 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_RepositoryUrl_and_pack(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--LicenseIdentifier",
-                    "BSD2",
-                    "--RepositoryUrl",
-                    "https://github.com/microsoft/mu_basecore"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+            "--LicenseIdentifier",
+            "BSD2",
+            "--RepositoryUrl",
+            "https://github.com/microsoft/mu_basecore",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
 
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
@@ -395,38 +457,42 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_RepositoryBranch_and_pack(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--LicenseIdentifier",
-                    "BSD2",
-                    "--RepositoryBranch",
-                    "main"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+            "--LicenseIdentifier",
+            "BSD2",
+            "--RepositoryBranch",
+            "main",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
 
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
@@ -435,38 +501,42 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_RepositoryCommit_and_pack(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--LicenseIdentifier",
-                    "BSD2",
-                    "--RepositoryCommit",
-                    "cd845afd5c3c838a9f7af7dad238452ae9a17146"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+            "--LicenseIdentifier",
+            "BSD2",
+            "--RepositoryCommit",
+            "cd845afd5c3c838a9f7af7dad238452ae9a17146",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
 
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
@@ -475,44 +545,48 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_RepositoryAll_and_pack(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--LicenseIdentifier",
-                    "BSD2",
-                    "--RepositoryType",
-                    "git",
-                    "--RepositoryUrl",
-                    "https://github.com/microsoft/mu_plus",
-                    "--RepositoryBranch",
-                    "master",
-                    "--RepositoryCommit",
-                    "06df12360d561b2007e03503491510c36426d860"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+            "--LicenseIdentifier",
+            "BSD2",
+            "--RepositoryType",
+            "git",
+            "--RepositoryUrl",
+            "https://github.com/microsoft/mu_plus",
+            "--RepositoryBranch",
+            "master",
+            "--RepositoryCommit",
+            "06df12360d561b2007e03503491510c36426d860",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
 
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
@@ -521,38 +595,42 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_and_pack_RepositoryType(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--LicenseIdentifier",
-                    "BSD2"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+            "--LicenseIdentifier",
+            "BSD2",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
 
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder,
-                    "--RepositoryType",
-                    "git"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+            "--RepositoryType",
+            "git",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
@@ -561,38 +639,42 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_and_pack_RepositoryUrl(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--LicenseIdentifier",
-                    "BSD2"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+            "--LicenseIdentifier",
+            "BSD2",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
 
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder,
-                    "--RepositoryUrl",
-                    "https://github.com/microsoft/mu_basecore"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+            "--RepositoryUrl",
+            "https://github.com/microsoft/mu_basecore",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
@@ -601,38 +683,42 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_and_pack_RepositoryBranch(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--LicenseIdentifier",
-                    "BSD2"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+            "--LicenseIdentifier",
+            "BSD2",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
 
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder,
-                    "--RepositoryBranch",
-                    "main"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+            "--RepositoryBranch",
+            "main",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
@@ -641,38 +727,42 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_and_pack_RepositoryCommit(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--LicenseIdentifier",
-                    "BSD2"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+            "--LicenseIdentifier",
+            "BSD2",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
 
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder,
-                    "--RepositoryCommit",
-                    "cd845afd5c3c838a9f7af7dad238452ae9a17146"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+            "--RepositoryCommit",
+            "cd845afd5c3c838a9f7af7dad238452ae9a17146",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
@@ -681,44 +771,48 @@ class test_nuget_publish(unittest.TestCase):
     def test_main_new_and_pack_RepositoryAll(self):
         args = sys.argv
         tempfolder = tempfile.mkdtemp()
-        sys.argv = ["",
-                    "--Operation",
-                    "New",
-                    "--Name",
-                    "Test",
-                    "--Author",
-                    "test",
-                    "--ProjectUrl",
-                    "https://github.com",
-                    "--Description",
-                    "test",
-                    "--FeedUrl",
-                    " https://github.com",
-                    "--ConfigFileFolderPath",
-                    tempfolder,
-                    "--LicenseIdentifier",
-                    "BSD2"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "New",
+            "--Name",
+            "Test",
+            "--Author",
+            "test",
+            "--ProjectUrl",
+            "https://github.com",
+            "--Description",
+            "test",
+            "--FeedUrl",
+            " https://github.com",
+            "--ConfigFileFolderPath",
+            tempfolder,
+            "--LicenseIdentifier",
+            "BSD2",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
 
-        sys.argv = ["",
-                    "--Operation",
-                    "Pack",
-                    "--ConfigFilePath",
-                    os.path.join(tempfolder, "Test.config.yaml"),
-                    "--Version",
-                    "1.0.0",
-                    "--InputFolderPath",
-                    tempfolder,
-                    "--RepositoryType",
-                    "git",
-                    "--RepositoryUrl",
-                    "https://github.com/microsoft/mu_plus",
-                    "--RepositoryBranch",
-                    "master",
-                    "--RepositoryCommit",
-                    "06df12360d561b2007e03503491510c36426d860"]
+        sys.argv = [
+            "",
+            "--Operation",
+            "Pack",
+            "--ConfigFilePath",
+            os.path.join(tempfolder, "Test.config.yaml"),
+            "--Version",
+            "1.0.0",
+            "--InputFolderPath",
+            tempfolder,
+            "--RepositoryType",
+            "git",
+            "--RepositoryUrl",
+            "https://github.com/microsoft/mu_plus",
+            "--RepositoryBranch",
+            "master",
+            "--RepositoryCommit",
+            "06df12360d561b2007e03503491510c36426d860",
+        ]
 
         ret = nuget_publishing.main()
         self.assertEqual(ret, 0)
@@ -727,5 +821,5 @@ class test_nuget_publish(unittest.TestCase):
     # TODO: finish unit test
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/test_omnicache.py
+++ b/edk2toolext/tests/test_omnicache.py
@@ -63,7 +63,7 @@ class TestOmniCache(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        logger = logging.getLogger('')
+        logger = logging.getLogger("")
         logger.addHandler(logging.NullHandler())
         unittest.installHandler()
 
@@ -79,33 +79,39 @@ class TestOmniCache(unittest.TestCase):
 
         # check that the new cache was created as a bare repo
         out = StringIO()
-        gitret = utility_functions.RunCmd("git", "rev-parse --is-bare-repository", workingdir=testcache, outstream=out)
-        assert (gitret == 0)
-        assert (out.getvalue().strip().lower() == "true")
+        gitret = utility_functions.RunCmd(
+            "git", "rev-parse --is-bare-repository", workingdir=testcache, outstream=out
+        )
+        assert gitret == 0
+        assert out.getvalue().strip().lower() == "true"
 
         # check that it has the right metadata
         out = StringIO()
-        gitret = utility_functions.RunCmd("git",
-                                          "config --local omnicache.metadata.version",
-                                          workingdir=testcache,
-                                          outstream=out)
-        assert (gitret == 0)
-        assert (out.getvalue().strip().lower() == omnicache.OMNICACHE_VERSION)
+        gitret = utility_functions.RunCmd(
+            "git",
+            "config --local omnicache.metadata.version",
+            workingdir=testcache,
+            outstream=out,
+        )
+        assert gitret == 0
+        assert out.getvalue().strip().lower() == omnicache.OMNICACHE_VERSION
 
         # check that omnicache thinks it's valid
         (valid, _) = oc._ValidateOmnicache()
-        assert (valid)
+        assert valid
 
         # remove the metadata to simulate an older omnicache that is candidate for conversion
-        gitret = utility_functions.RunCmd("git",
-                                          "config --local --unset omnicache.metadata.version",
-                                          workingdir=testcache)
-        assert (gitret == 0)
+        gitret = utility_functions.RunCmd(
+            "git",
+            "config --local --unset omnicache.metadata.version",
+            workingdir=testcache,
+        )
+        assert gitret == 0
 
         # check that omnicache thinks it's not valid but convertible.
         (valid, convertible) = oc._ValidateOmnicache()
-        assert (not valid)
-        assert (convertible)
+        assert not valid
+        assert convertible
 
         # attempt to create a new cache - test repo is valid git repo, but doesn't have the meta.
         with self.assertRaises(RuntimeError):
@@ -114,27 +120,32 @@ class TestOmniCache(unittest.TestCase):
         # set the metadata version to an unexpected value
         gitret = utility_functions.RunCmd(
             "git",
-            "config --local omnicache.metadata.version {0}".format(omnicache.OMNICACHE_VERSION + "x"),
-            workingdir=testcache)
-        assert (gitret == 0)
+            "config --local omnicache.metadata.version {0}".format(
+                omnicache.OMNICACHE_VERSION + "x"
+            ),
+            workingdir=testcache,
+        )
+        assert gitret == 0
 
         # check that omnicache thinks it's not valid but convertible.
         (valid, convertible) = oc._ValidateOmnicache()
-        assert (not valid)
-        assert (convertible)
+        assert not valid
+        assert convertible
 
         # attempt to create a new cache - test repo is valid git repo, but doesn't have the expected meta.
         with self.assertRaises(RuntimeError):
             oc = omnicache.Omnicache(testcache, create=False, convert=False)
 
         # now make it a non-bare (but technically valid) git repo
-        gitret = utility_functions.RunCmd("git", "config --local core.bare false", workingdir=testcache)
-        assert (gitret == 0)
+        gitret = utility_functions.RunCmd(
+            "git", "config --local core.bare false", workingdir=testcache
+        )
+        assert gitret == 0
 
         # check that omnicache thinks it's not valid and not convertible.
         (valid, convertible) = oc._ValidateOmnicache()
-        assert (not valid)
-        assert (not convertible)
+        assert not valid
+        assert not convertible
 
         # attempt to create a new cache - test repo is valid non-bare git repo
         with self.assertRaises(RuntimeError):
@@ -145,8 +156,8 @@ class TestOmniCache(unittest.TestCase):
 
         # check that omnicache thinks it's not valid and not convertible.
         (valid, convertible) = oc._ValidateOmnicache()
-        assert (not valid)
-        assert (not convertible)
+        assert not valid
+        assert not convertible
 
         # attempt to create a new cache - test repo is not valid git repo
         with self.assertRaises(RuntimeError):
@@ -159,96 +170,121 @@ class TestOmniCache(unittest.TestCase):
         oc = omnicache.Omnicache(testcache, create=True, convert=False)
 
         (valid, _) = oc._ValidateOmnicache()
-        assert (valid)
+        assert valid
 
         # remove the metadata to simulate an older omnicache that is candidate for conversion
-        gitret = utility_functions.RunCmd("git",
-                                          "config --local --unset omnicache.metadata.version",
-                                          workingdir=testcache)
-        assert (gitret == 0)
+        gitret = utility_functions.RunCmd(
+            "git",
+            "config --local --unset omnicache.metadata.version",
+            workingdir=testcache,
+        )
+        assert gitret == 0
 
         # add an empty file to simulate the old config yaml
-        with open(os.path.join(testcache, omnicache.PRE_0_11_OMNICACHE_FILENAME), "w") as yf:
+        with open(
+            os.path.join(testcache, omnicache.PRE_0_11_OMNICACHE_FILENAME), "w"
+        ) as yf:
             yf.write("Not A Real YAML File")
 
         # confirm that _ValidateOmnicache correctly identifies cache state
         (valid, convertible) = oc._ValidateOmnicache()
-        assert (not valid)
-        assert (convertible)
+        assert not valid
+        assert convertible
 
         # add a traditionally-named remote to the cache to simulate an older omnicache
         gitret = utility_functions.RunCmd(
             "git",
             "remote add pytools-ext https://github.com/tianocore/edk2-pytool-extensions.git",
-            workingdir=testcache)
-        assert (gitret == 0)
+            workingdir=testcache,
+        )
+        assert gitret == 0
 
         # add a second copy of the remote remote with a different name to the cache to simulate a duplicate
         gitret = utility_functions.RunCmd(
             "git",
             "remote add pytools-ext2 https://github.com/tianocore/edk2-pytool-extensions.git",
-            workingdir=testcache)
-        assert (gitret == 0)
+            workingdir=testcache,
+        )
+        assert gitret == 0
 
         # fetch the remote and its tags to populate the cache for conversion.
-        gitret = utility_functions.RunCmd("git", "fetch pytools-ext --tags", workingdir=testcache)
-        assert (gitret == 0)
+        gitret = utility_functions.RunCmd(
+            "git", "fetch pytools-ext --tags", workingdir=testcache
+        )
+        assert gitret == 0
 
         # confirm that _ValidateOmnicache still correctly identifies cache state
         (valid, convertible) = oc._ValidateOmnicache()
-        assert (not valid)
-        assert (convertible)
+        assert not valid
+        assert convertible
 
         # re-create the omnicache object to trigger conversion
         oc = omnicache.Omnicache(testcache, create=False, convert=True)
 
         # validate converted cache
         (valid, _) = oc._ValidateOmnicache()
-        assert (valid)
+        assert valid
 
         # verify that old config file was deleted.
-        assert (not os.path.exists(os.path.join(testcache, omnicache.PRE_0_11_OMNICACHE_FILENAME)))
+        assert not os.path.exists(
+            os.path.join(testcache, omnicache.PRE_0_11_OMNICACHE_FILENAME)
+        )
 
         # verify that the traditionally-named remote is no longer in the cache (it should have been renamed with a UUID)
         remotes = omnicache.Omnicache.GetRemotes(testcache)
-        assert ("pytools-ext" not in remotes.keys())
+        assert "pytools-ext" not in remotes.keys()
 
         # verify that the URL still is in the cache
-        assert ("https://github.com/tianocore/edk2-pytool-extensions.git" in remotes.values())
+        assert (
+            "https://github.com/tianocore/edk2-pytool-extensions.git"
+            in remotes.values()
+        )
 
         # verify that there is exactly one entry in the cache for this URL (duplicates should be removed)
-        assert (sum(url == "https://github.com/tianocore/edk2-pytool-extensions.git" for url in remotes.values()) == 1)
+        assert (
+            sum(
+                url == "https://github.com/tianocore/edk2-pytool-extensions.git"
+                for url in remotes.values()
+            )
+            == 1
+        )
 
         # verify that the former remote name is now the "omnicache display name"
-        for (name, url) in remotes.items():
-            if (url == "https://github.com/tianocore/edk2-pytool-extensions.git"):
+        for name, url in remotes.items():
+            if url == "https://github.com/tianocore/edk2-pytool-extensions.git":
                 out = StringIO()
-                gitret = utility_functions.RunCmd("git",
-                                                  f"config --local omnicache.{name}.displayname",
-                                                  workingdir=testcache,
-                                                  outstream=out)
-                assert (gitret == 0)
+                gitret = utility_functions.RunCmd(
+                    "git",
+                    f"config --local omnicache.{name}.displayname",
+                    workingdir=testcache,
+                    outstream=out,
+                )
+                assert gitret == 0
                 displayname = out.getvalue().strip()
                 # if there are duplicates, which displayname is chosen is arbitrary, so allow either.
-                assert (displayname == "pytools-ext" or displayname == "pytools-ext2")
+                assert displayname == "pytools-ext" or displayname == "pytools-ext2"
 
         # verify that there are no global tags in the root.
         out = StringIO()
-        gitret = utility_functions.RunCmd("git", "tag -l", workingdir=testcache, outstream=out)
-        assert (gitret == 0)
-        assert (out.getvalue().strip() == "")
+        gitret = utility_functions.RunCmd(
+            "git", "tag -l", workingdir=testcache, outstream=out
+        )
+        assert gitret == 0
+        assert out.getvalue().strip() == ""
 
         # add an empty file to simulate the old config yaml, but leave metadata in place.
         # this simulates the case where an old version of omnicache ran and updated the remotes
         # with some non-UUID versions, but the metadata version still exists. In this case, conversion
         # should be run to cleanup the remotes.
-        with open(os.path.join(testcache, omnicache.PRE_0_11_OMNICACHE_FILENAME), "w") as yf:
+        with open(
+            os.path.join(testcache, omnicache.PRE_0_11_OMNICACHE_FILENAME), "w"
+        ) as yf:
             yf.write("Not A Real YAML File")
 
         # confirm that _ValidateOmnicache correctly identifies cache state
         (valid, convertible) = oc._ValidateOmnicache()
-        assert (not valid)
-        assert (convertible)
+        assert not valid
+        assert convertible
 
     def test_omnicache_add_remove(self):
         testcache = os.path.join(os.path.abspath(os.getcwd()), test_dir, "testcache")
@@ -257,72 +293,101 @@ class TestOmniCache(unittest.TestCase):
         oc = omnicache.Omnicache(testcache, create=True, convert=False)
 
         (valid, _) = oc._ValidateOmnicache()
-        assert (valid)
+        assert valid
 
         # add a remote with display name
-        ret = oc.AddRemote("https://github.com/tianocore/edk2-pytool-extensions.git", name="pytools-ext")
-        assert (ret == 0)
+        ret = oc.AddRemote(
+            "https://github.com/tianocore/edk2-pytool-extensions.git",
+            name="pytools-ext",
+        )
+        assert ret == 0
 
-        assert (len(omnicache.Omnicache.GetRemotes(testcache).keys()) == 1)
-        assert ("https://github.com/tianocore/edk2-pytool-extensions.git"
-               in omnicache.Omnicache.GetRemotes(testcache).values())
+        assert len(omnicache.Omnicache.GetRemotes(testcache).keys()) == 1
+        assert (
+            "https://github.com/tianocore/edk2-pytool-extensions.git"
+            in omnicache.Omnicache.GetRemotes(testcache).values()
+        )
 
         # get the remote UUID
-        remoteName = oc._LookupRemoteForUrl("https://github.com/tianocore/edk2-pytool-extensions.git")
-        assert (remoteName is not None)
+        remoteName = oc._LookupRemoteForUrl(
+            "https://github.com/tianocore/edk2-pytool-extensions.git"
+        )
+        assert remoteName is not None
 
         # confirm that remote data is as expected
         remoteData = oc.GetRemoteData()
-        assert (len(remoteData.keys()) == 1)
-        assert (remoteData[remoteName]["url"] == "https://github.com/tianocore/edk2-pytool-extensions.git")
-        assert (remoteData[remoteName]["displayname"] == "pytools-ext")
+        assert len(remoteData.keys()) == 1
+        assert (
+            remoteData[remoteName]["url"]
+            == "https://github.com/tianocore/edk2-pytool-extensions.git"
+        )
+        assert remoteData[remoteName]["displayname"] == "pytools-ext"
 
         # remove the remote and make sure it is gone
         ret = oc.RemoveRemote("https://github.com/tianocore/edk2-pytool-extensions.git")
-        assert (ret == 0)
-        assert (len(omnicache.Omnicache.GetRemotes(testcache).keys()) == 0)
-        assert ("https://github.com/tianocore/edk2-pytool-extensions.git"
-               not in omnicache.Omnicache.GetRemotes(testcache).values())
+        assert ret == 0
+        assert len(omnicache.Omnicache.GetRemotes(testcache).keys()) == 0
+        assert (
+            "https://github.com/tianocore/edk2-pytool-extensions.git"
+            not in omnicache.Omnicache.GetRemotes(testcache).values()
+        )
 
         # add a remote without display name
         ret = oc.AddRemote("https://github.com/tianocore/edk2-pytool-extensions.git")
-        assert (ret == 0)
+        assert ret == 0
 
-        assert (len(omnicache.Omnicache.GetRemotes(testcache).keys()) == 1)
-        assert ("https://github.com/tianocore/edk2-pytool-extensions.git"
-               in omnicache.Omnicache.GetRemotes(testcache).values())
+        assert len(omnicache.Omnicache.GetRemotes(testcache).keys()) == 1
+        assert (
+            "https://github.com/tianocore/edk2-pytool-extensions.git"
+            in omnicache.Omnicache.GetRemotes(testcache).values()
+        )
 
         # get the remote UUID
-        remoteName = oc._LookupRemoteForUrl("https://github.com/tianocore/edk2-pytool-extensions.git")
-        assert (remoteName is not None)
+        remoteName = oc._LookupRemoteForUrl(
+            "https://github.com/tianocore/edk2-pytool-extensions.git"
+        )
+        assert remoteName is not None
 
         # confirm that remote data is as expected
         remoteData = oc.GetRemoteData()
-        assert (len(remoteData.keys()) == 1)
-        assert (remoteData[remoteName]["url"] == "https://github.com/tianocore/edk2-pytool-extensions.git")
-        assert ("displayname" not in remoteData[remoteName])
+        assert len(remoteData.keys()) == 1
+        assert (
+            remoteData[remoteName]["url"]
+            == "https://github.com/tianocore/edk2-pytool-extensions.git"
+        )
+        assert "displayname" not in remoteData[remoteName]
 
         # add a remote that already exists (with new display name) and make sure it is treated as an update.
-        ret = oc.AddRemote("https://github.com/tianocore/edk2-pytool-extensions.git", name="pytools-ext2")
-        assert (ret == 0)
+        ret = oc.AddRemote(
+            "https://github.com/tianocore/edk2-pytool-extensions.git",
+            name="pytools-ext2",
+        )
+        assert ret == 0
 
-        assert (len(omnicache.Omnicache.GetRemotes(testcache).keys()) == 1)
-        assert ("https://github.com/tianocore/edk2-pytool-extensions.git"
-               in omnicache.Omnicache.GetRemotes(testcache).values())
+        assert len(omnicache.Omnicache.GetRemotes(testcache).keys()) == 1
+        assert (
+            "https://github.com/tianocore/edk2-pytool-extensions.git"
+            in omnicache.Omnicache.GetRemotes(testcache).values()
+        )
 
         # get the remote UUID
-        remoteName = oc._LookupRemoteForUrl("https://github.com/tianocore/edk2-pytool-extensions.git")
-        assert (remoteName is not None)
+        remoteName = oc._LookupRemoteForUrl(
+            "https://github.com/tianocore/edk2-pytool-extensions.git"
+        )
+        assert remoteName is not None
 
         # confirm that remote data is as expected
         remoteData = oc.GetRemoteData()
-        assert (len(remoteData.keys()) == 1)
-        assert (remoteData[remoteName]["url"] == "https://github.com/tianocore/edk2-pytool-extensions.git")
-        assert (remoteData[remoteName]["displayname"] == "pytools-ext2")
+        assert len(remoteData.keys()) == 1
+        assert (
+            remoteData[remoteName]["url"]
+            == "https://github.com/tianocore/edk2-pytool-extensions.git"
+        )
+        assert remoteData[remoteName]["displayname"] == "pytools-ext2"
 
         # attempt to remove a non-existent remote
         ret = oc.RemoveRemote("http://thisisnot.com/good.git")
-        assert (ret != 0)
+        assert ret != 0
 
     def test_omnicache_update(self):
         testcache = os.path.join(os.path.abspath(os.getcwd()), test_dir, "testcache")
@@ -331,43 +396,58 @@ class TestOmniCache(unittest.TestCase):
         oc = omnicache.Omnicache(testcache, create=True, convert=False)
 
         (valid, _) = oc._ValidateOmnicache()
-        assert (valid)
+        assert valid
 
         # add a remote with display name
-        ret = oc.AddRemote("https://github.com/tianocore/edk2-pytool-extensions.git", name="pytools-ext")
-        assert (ret == 0)
+        ret = oc.AddRemote(
+            "https://github.com/tianocore/edk2-pytool-extensions.git",
+            name="pytools-ext",
+        )
+        assert ret == 0
 
-        assert (len(omnicache.Omnicache.GetRemotes(testcache).keys()) == 1)
-        assert ("https://github.com/tianocore/edk2-pytool-extensions.git"
-               in omnicache.Omnicache.GetRemotes(testcache).values())
+        assert len(omnicache.Omnicache.GetRemotes(testcache).keys()) == 1
+        assert (
+            "https://github.com/tianocore/edk2-pytool-extensions.git"
+            in omnicache.Omnicache.GetRemotes(testcache).values()
+        )
 
         # get the remote UUID
-        remoteName = oc._LookupRemoteForUrl("https://github.com/tianocore/edk2-pytool-extensions.git")
-        assert (remoteName is not None)
+        remoteName = oc._LookupRemoteForUrl(
+            "https://github.com/tianocore/edk2-pytool-extensions.git"
+        )
+        assert remoteName is not None
 
         # update the URL and displayname of the remote
         ret = oc.UpdateRemote(
             "https://github.com/tianocore/edk2-pytool-extensions.git",
             newUrl="https://github.com/tianocore/edk2-pytool-extensions2.git",
-            newName="pytools-ext2")
-        assert (ret == 0)
+            newName="pytools-ext2",
+        )
+        assert ret == 0
 
-        assert (len(omnicache.Omnicache.GetRemotes(testcache).keys()) == 1)
-        assert ("https://github.com/tianocore/edk2-pytool-extensions2.git"
-               in omnicache.Omnicache.GetRemotes(testcache).values())
+        assert len(omnicache.Omnicache.GetRemotes(testcache).keys()) == 1
+        assert (
+            "https://github.com/tianocore/edk2-pytool-extensions2.git"
+            in omnicache.Omnicache.GetRemotes(testcache).values()
+        )
 
         # make sure UUID didn't change
-        assert (remoteName == oc._LookupRemoteForUrl("https://github.com/tianocore/edk2-pytool-extensions2.git"))
+        assert remoteName == oc._LookupRemoteForUrl(
+            "https://github.com/tianocore/edk2-pytool-extensions2.git"
+        )
 
         # confirm that remote data is as expected
         remoteData = oc.GetRemoteData()
-        assert (len(remoteData.keys()) == 1)
-        assert (remoteData[remoteName]["url"] == "https://github.com/tianocore/edk2-pytool-extensions2.git")
-        assert (remoteData[remoteName]["displayname"] == "pytools-ext2")
+        assert len(remoteData.keys()) == 1
+        assert (
+            remoteData[remoteName]["url"]
+            == "https://github.com/tianocore/edk2-pytool-extensions2.git"
+        )
+        assert remoteData[remoteName]["displayname"] == "pytools-ext2"
 
         # update a non-existent URL in the cache and confirm error is returned
         ret = oc.UpdateRemote("https://not.a.real.url.com/git")
-        assert (ret != 0)
+        assert ret != 0
 
     def test_omnicache_fetch(self):
         testcache = os.path.join(os.path.abspath(os.getcwd()), test_dir, "testcache")
@@ -376,29 +456,38 @@ class TestOmniCache(unittest.TestCase):
         oc = omnicache.Omnicache(testcache, create=True, convert=False)
 
         (valid, _) = oc._ValidateOmnicache()
-        assert (valid)
+        assert valid
 
         # add a remote with display name
-        ret = oc.AddRemote("https://github.com/tianocore/edk2-pytool-extensions.git", name="pytools-ext")
-        assert (ret == 0)
+        ret = oc.AddRemote(
+            "https://github.com/tianocore/edk2-pytool-extensions.git",
+            name="pytools-ext",
+        )
+        assert ret == 0
 
         # fetch the remote
         ret = oc.Fetch()
-        assert (ret == 0)
+        assert ret == 0
 
         # fetch the remote with 4 jobs
         ret = oc.Fetch(jobs=4)
-        assert (ret == 0)
+        assert ret == 0
 
         # get the remote UUID
-        remoteName = oc._LookupRemoteForUrl("https://github.com/tianocore/edk2-pytool-extensions.git")
-        assert (remoteName is not None)
+        remoteName = oc._LookupRemoteForUrl(
+            "https://github.com/tianocore/edk2-pytool-extensions.git"
+        )
+        assert remoteName is not None
 
         # verify that branches were fetched into the omnicache
-        assert (len(os.listdir(os.path.join(testcache, "refs", "remotes", remoteName))) != 0)
+        assert (
+            len(os.listdir(os.path.join(testcache, "refs", "remotes", remoteName))) != 0
+        )
 
         # verify that tags were fetched into the omnicache
-        assert (len(os.listdir(os.path.join(testcache, "refs", "rtags", remoteName))) != 0)
+        assert (
+            len(os.listdir(os.path.join(testcache, "refs", "rtags", remoteName))) != 0
+        )
 
     def test_omnicache_list(self):
         testcache = os.path.join(os.path.abspath(os.getcwd()), test_dir, "testcache")
@@ -407,13 +496,16 @@ class TestOmniCache(unittest.TestCase):
         oc = omnicache.Omnicache(testcache, create=True, convert=False)
 
         (valid, _) = oc._ValidateOmnicache()
-        assert (valid)
+        assert valid
 
         oc.List()
 
         # add a remote with display name
-        ret = oc.AddRemote("https://github.com/tianocore/edk2-pytool-extensions.git", name="pytools-ext")
-        assert (ret == 0)
+        ret = oc.AddRemote(
+            "https://github.com/tianocore/edk2-pytool-extensions.git",
+            name="pytools-ext",
+        )
+        assert ret == 0
 
         oc.List()
 
@@ -425,36 +517,45 @@ class TestOmniCache(unittest.TestCase):
         oc = omnicache.Omnicache(testcache, create=True, convert=False)
 
         (valid, _) = oc._ValidateOmnicache()
-        assert (valid)
+        assert valid
 
         # add a remote with display name
-        ret = oc.AddRemote("https://github.com/tianocore/edk2-pytool-extensions.git", name="pytools-ext")
-        assert (ret == 0)
+        ret = oc.AddRemote(
+            "https://github.com/tianocore/edk2-pytool-extensions.git",
+            name="pytools-ext",
+        )
+        assert ret == 0
 
         # add a remote with no display name
         ret = oc.AddRemote("https://github.com/tianocore/edk2-pytool-extensions2.git")
-        assert (ret == 0)
+        assert ret == 0
 
         # export yaml cfg
         ret = omnicache.Export(oc, testyaml)
-        assert (ret == 0)
+        assert ret == 0
 
         # inspect the yaml for correctness
         with open(testyaml) as yf:
             content = yaml.safe_load(yf)
 
-        assert ("remotes" in content)
-        assert (len(content["remotes"]) == 2)
+        assert "remotes" in content
+        assert len(content["remotes"]) == 2
         for remote in content["remotes"]:
-            if (remote["url"] == "https://github.com/tianocore/edk2-pytool-extensions.git"):
-                assert (remote["name"] == "pytools-ext")
-            elif (remote["url"] == "https://github.com/tianocore/edk2-pytool-extensions2.git"):
-                assert (omnicache.Omnicache._IsValidUuid(remote["name"]))
+            if (
+                remote["url"]
+                == "https://github.com/tianocore/edk2-pytool-extensions.git"
+            ):
+                assert remote["name"] == "pytools-ext"
+            elif (
+                remote["url"]
+                == "https://github.com/tianocore/edk2-pytool-extensions2.git"
+            ):
+                assert omnicache.Omnicache._IsValidUuid(remote["name"])
                 # remove the "display name" for input test below
                 del remote["name"]
             else:
                 # not one of the URLs we populated above = bad.
-                assert (remote["url"] not in remote.values())
+                assert remote["url"] not in remote.values()
 
         # save the yaml file (since we removed one of the displaynames)
         with open(testyaml, "w") as yf:
@@ -462,26 +563,34 @@ class TestOmniCache(unittest.TestCase):
 
         # remove the remotes
         ret = oc.RemoveRemote("https://github.com/tianocore/edk2-pytool-extensions.git")
-        assert (ret == 0)
-        ret = oc.RemoveRemote("https://github.com/tianocore/edk2-pytool-extensions2.git")
-        assert (ret == 0)
+        assert ret == 0
+        ret = oc.RemoveRemote(
+            "https://github.com/tianocore/edk2-pytool-extensions2.git"
+        )
+        assert ret == 0
 
         # confirm we have no remotes
-        assert (len(oc.GetRemoteData()) == 0)
+        assert len(oc.GetRemoteData()) == 0
 
         # import yaml cfg
         ret = omnicache.ProcessInputConfig(oc, testyaml)
-        assert (ret == 0)
+        assert ret == 0
 
         # check resulting omnicache config
         for remote in oc.GetRemoteData().values():
-            if (remote["url"] == "https://github.com/tianocore/edk2-pytool-extensions.git"):
-                assert (remote["displayname"] == "pytools-ext")
-            elif (remote["url"] == "https://github.com/tianocore/edk2-pytool-extensions2.git"):
-                assert ("displayname" not in remote)
+            if (
+                remote["url"]
+                == "https://github.com/tianocore/edk2-pytool-extensions.git"
+            ):
+                assert remote["displayname"] == "pytools-ext"
+            elif (
+                remote["url"]
+                == "https://github.com/tianocore/edk2-pytool-extensions2.git"
+            ):
+                assert "displayname" not in remote
             else:
                 # not one of the URLs we populated above = bad.
-                assert (remote["url"] not in remote.values())
+                assert remote["url"] not in remote.values()
 
     def test_omnicache_main(self):
         testcache = os.path.join(os.path.abspath(os.getcwd()), test_dir, "testcache")
@@ -489,15 +598,15 @@ class TestOmniCache(unittest.TestCase):
         oldargs = sys.argv
         sys.argv = ["omnicache", "--init", testcache]
         ret = omnicache.main()
-        assert (ret == 0)
+        assert ret == 0
         sys.argv = ["omnicache", "--new", testcache]
         ret = omnicache.main()
-        assert (ret != 0)
+        assert ret != 0
         sys.argv = ["omnicache", "--scan", testcache, testcache]
         ret = omnicache.main()
-        assert (ret == 0)
+        assert ret == 0
         sys.argv = oldargs
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/test_pyopenssl_signer.py
+++ b/edk2toolext/tests/test_pyopenssl_signer.py
@@ -50,7 +50,7 @@ python file as seen below this docstring.
 
 # spell-checker:disable
 # TESTCERT1 has no password
-TESTCERT1 = b'MIIJQQIBAzCCCQcGCSqGSIb3DQEHAaCCCPgEggj0MIII8D\
+TESTCERT1 = b"MIIJQQIBAzCCCQcGCSqGSIb3DQEHAaCCCPgEggj0MIII8D\
 CCA6cGCSqGSIb3DQEHBqCCA5gwggOUAgEAMIIDjQYJKoZIhvcNAQcBMBwGCi\
 qGSIb3DQEMAQYwDgQIlimkkLBfTQ8CAggAgIIDYAGQRMWf8SbXd6nZPL2o11\
 LF1JrXLCCc+RwJCDnAJD8cNFUwq4JrOc4qJOYr6QZwD//3LfHeNLwfsi+3RC\
@@ -102,10 +102,10 @@ UezFsMna+YaA/F2o9WIj9KPB+rdNh/KcbIJhpA2DSbbTPejHAk1TYBWall3B\
 2CfsFEIMjtuid/ggz/pUYCb88PN3BPoQ7GO/jv6Vi6F4oCQz+Y0srbmIStNj\
 qKXmc5OHIJoRkbrbFi4+2BeevncDADGrhl3heGWSmRlbOPxrryNrDPw7cbMS\
 UwIwYJKoZIhvcNAQkVMRYEFILT9pNixD3s66GdK3I48b/dr23DMDEwITAJBg\
-UrDgMCGgUABBTdiDC3a0y1gAbO1eZqveI3Zd0BrwQIFO8dSTjGLhMCAggA'
+UrDgMCGgUABBTdiDC3a0y1gAbO1eZqveI3Zd0BrwQIFO8dSTjGLhMCAggA"
 
 # TESTCERT2 has a password
-TESTCERT2 = b'MIIKaQIBAzCCCiUGCSqGSIb3DQEHAaCCChYEggoSMIIKDj\
+TESTCERT2 = b"MIIKaQIBAzCCCiUGCSqGSIb3DQEHAaCCChYEggoSMIIKDj\
 CCBg8GCSqGSIb3DQEHAaCCBgAEggX8MIIF+DCCBfQGCyqGSIb3DQEMCgECoI\
 IE/jCCBPowHAYKKoZIhvcNAQwBAzAOBAh8sw/XNGIGZwICB9AEggTYeUQ8gJ\
 GII6HPDeBx4bGH2zkS1ybw4hToh8c9UMd3gwDviCobjkSCidTGZPwkvcfPT8\
@@ -164,41 +164,35 @@ b1XMtzJcLPOs1/stapsf2C70KgvJ+zgGxob7xvpGLyHecn8ZlVer7jNkzbxD\
 xUOq2KAMBksmMAg0Tyc44jDOHiinR7sARTUcNncqP5qJ3d7v7DsCCQsiFD1x\
 NEyQpgrD5WAhSaKiZxDvvkj/GNNVXpdiFr8RGa/IlD0+JdiZ3ujt45OduOhs\
 ySr03eOImlzjA7MB8wBwYFKw4DAhoEFKn9FVak9/MKt1kvn+GIpIdTy/+pBB\
-R7oStX6AVc66qjoj9/dgAPJTqLBwICB9A='
+R7oStX6AVc66qjoj9/dgAPJTqLBwICB9A="
 # spell-checker:enable
 
 
 class Test_pyopenssl_signer(unittest.TestCase):
-
     def test_empty(self):
         with self.assertRaises((KeyError, ValueError)):
             pyopenssl_signer.sign(None, {}, {})
 
     def test_proper_options_good_key_no_pass(self):
-        signer = {
-            'key_file_format': 'pkcs12',
-            'key_data': b64decode(TESTCERT1)
-        }
+        signer = {"key_file_format": "pkcs12", "key_data": b64decode(TESTCERT1)}
         signature = {
-            'type': 'bare',
-            'encoding': 'binary',
-            'hash_alg': 'sha256',
-
+            "type": "bare",
+            "encoding": "binary",
+            "hash_alg": "sha256",
         }
         data = "Data for testing signer".encode()
         pyopenssl_signer.sign(data, signature, signer)
 
     def test_proper_options_good_key_pass(self):
         signer = {
-            'key_file_format': 'pkcs12',
-            'key_data': b64decode(TESTCERT2),
-            'key_file_password': 'password'
+            "key_file_format": "pkcs12",
+            "key_data": b64decode(TESTCERT2),
+            "key_file_password": "password",
         }
         signature = {
-            'type': 'bare',
-            'encoding': 'binary',
-            'hash_alg': 'sha256',
-
+            "type": "bare",
+            "encoding": "binary",
+            "hash_alg": "sha256",
         }
         data = "Data for testing signer".encode()
         pyopenssl_signer.sign(data, signature, signer)
@@ -206,15 +200,11 @@ class Test_pyopenssl_signer(unittest.TestCase):
     def test_proper_options_bad_key(self):
         # we're going to assume that we're
         with self.assertRaises(ValueError):
-            signer = {
-                'key_file_format': 'pkcs12',
-                'key_data': "hello there"
-            }
+            signer = {"key_file_format": "pkcs12", "key_data": "hello there"}
             signature = {
-                'type': 'bare',
-                'encoding': 'binary',
-                'hash_alg': 'sha256',
-
+                "type": "bare",
+                "encoding": "binary",
+                "hash_alg": "sha256",
             }
             pyopenssl_signer.sign(None, signature, signer)
 
@@ -222,15 +212,12 @@ class Test_pyopenssl_signer(unittest.TestCase):
         # we're going to assume that we're
         with self.assertRaises(ValueError):
             signature = {
-                'type': 'bad_type',
+                "type": "bad_type",
             }
             pyopenssl_signer.sign(None, signature, {})
 
     def test_invalid_type_options(self):
         # we're going to assume that we're
         with self.assertRaises(ValueError):
-            signature = {
-                'type': 'bare',
-                'type_options': 'not allowed'
-            }
+            signature = {"type": "bare", "type_options": "not allowed"}
             pyopenssl_signer.sign(None, signature, {})

--- a/edk2toolext/tests/test_repo_resolver.py
+++ b/edk2toolext/tests/test_repo_resolver.py
@@ -19,42 +19,42 @@ import pytest
 branch_dependency = {
     "Url": "https://github.com/microsoft/mu",
     "Path": "test_repo",
-    "Branch": "master"
+    "Branch": "master",
 }
 
 sub_branch_dependency = {
     "Url": "https://github.com/microsoft/mu",
     "Path": "test_repo",
-    "Branch": "gh-pages"
+    "Branch": "gh-pages",
 }
 
 commit_dependency = {
     "Url": "https://github.com/microsoft/mu",
     "Path": "test_repo",
-    "Commit": "b1e35a5d2bf05fb7f58f5b641a702c70d6b32a98"
+    "Commit": "b1e35a5d2bf05fb7f58f5b641a702c70d6b32a98",
 }
 
 short_commit_dependency = {
     "Url": "https://github.com/microsoft/mu",
     "Path": "test_repo",
-    "Commit": "b1e35a5"
+    "Commit": "b1e35a5",
 }
 
 commit_later_dependency = {
     "Url": "https://github.com/microsoft/mu",
     "Path": "test_repo",
-    "Commit": "e28910950c52256eb620e35d111945cdf5d002d1"
+    "Commit": "e28910950c52256eb620e35d111945cdf5d002d1",
 }
 
 microsoft_commit_dependency = {
     "Url": "https://github.com/Microsoft/microsoft.github.io",
     "Path": "test_repo",
-    "Commit": "e9153e69c82068b45609359f86554a93569d76f1"
+    "Commit": "e9153e69c82068b45609359f86554a93569d76f1",
 }
 microsoft_branch_dependency = {
     "Url": "https://github.com/Microsoft/microsoft.github.io",
     "Path": "test_repo",
-    "Commit": "e9153e69c82068b45609359f86554a93569d76f1"
+    "Commit": "e9153e69c82068b45609359f86554a93569d76f1",
 }
 
 test_dir = None
@@ -96,7 +96,7 @@ class test_repo_resolver(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        logger = logging.getLogger('')
+        logger = logging.getLogger("")
         logger.setLevel(logging.DEBUG)
         logger.addHandler(logging.NullHandler())
         unittest.installHandler()
@@ -111,8 +111,8 @@ class test_repo_resolver(unittest.TestCase):
         repo_resolver.resolve(test_dir, branch_dependency)
         folder_path = os.path.join(test_dir, branch_dependency["Path"])
         details = repo_resolver.repo_details(folder_path)
-        self.assertEqual(details["Url"], branch_dependency['Url'])
-        self.assertEqual(details["Branch"], branch_dependency['Branch'])
+        self.assertEqual(details["Url"], branch_dependency["Url"])
+        self.assertEqual(details["Branch"], branch_dependency["Branch"])
 
     def test_clone_branch_existing_folder(self):
         # Resolve when folder exists but is empty
@@ -120,16 +120,15 @@ class test_repo_resolver(unittest.TestCase):
         os.makedirs(folder_path)
         repo_resolver.resolve(test_dir, branch_dependency)
         details = repo_resolver.repo_details(folder_path)
-        self.assertEqual(details["Url"], branch_dependency['Url'])
-        self.assertEqual(details["Branch"], branch_dependency['Branch'])
+        self.assertEqual(details["Url"], branch_dependency["Url"])
+        self.assertEqual(details["Branch"], branch_dependency["Branch"])
 
     # don't create a git repo, create the folder, add a file, try to clone in the folder, it should throw an exception
     def test_wont_delete_files(self):
         folder_path = os.path.join(test_dir, commit_dependency["Path"])
         os.makedirs(folder_path)
         file_path = os.path.join(folder_path, "test.txt")
-        file_path = os.path.join(
-            test_dir, branch_dependency["Path"], "test.txt")
+        file_path = os.path.join(test_dir, branch_dependency["Path"], "test.txt")
         out_file = open(file_path, "w+")
         out_file.write("Make sure we don't delete this")
         out_file.close()
@@ -153,7 +152,7 @@ class test_repo_resolver(unittest.TestCase):
         except:
             self.fail("We shouldn't fail when we are forcing")
         details = repo_resolver.repo_details(folder_path)
-        self.assertEqual(details["Url"], commit_dependency['Url'])
+        self.assertEqual(details["Url"], commit_dependency["Url"])
 
     # don't create a git repo, create the folder, add a file, try to clone in the folder, will ignore it.
     def test_will_ignore_files(self):
@@ -207,8 +206,8 @@ class test_repo_resolver(unittest.TestCase):
         folder_path = os.path.join(test_dir, commit_dependency["Path"])
         details = repo_resolver.repo_details(folder_path)
 
-        self.assertEqual(details["Url"], commit_dependency['Url'])
-        self.assertEqual(details["Head"]["HexSha"], commit_dependency['Commit'])
+        self.assertEqual(details["Url"], commit_dependency["Url"])
+        self.assertEqual(details["Head"]["HexSha"], commit_dependency["Commit"])
 
     # check to make sure we support short commits
     def test_clone_short_commit_repo(self):
@@ -216,8 +215,10 @@ class test_repo_resolver(unittest.TestCase):
         folder_path = os.path.join(test_dir, short_commit_dependency["Path"])
         details = repo_resolver.repo_details(folder_path)
 
-        self.assertEqual(details["Url"], short_commit_dependency['Url'])
-        self.assertEqual(details["Head"]["HexShaShort"], short_commit_dependency['Commit'])
+        self.assertEqual(details["Url"], short_commit_dependency["Url"])
+        self.assertEqual(
+            details["Head"]["HexShaShort"], short_commit_dependency["Commit"]
+        )
         # Resolve again, making sure we don't fail if repo already exists.
         repo_resolver.resolve(test_dir, short_commit_dependency)
 
@@ -228,15 +229,15 @@ class test_repo_resolver(unittest.TestCase):
         folder_path = os.path.join(test_dir, commit_dependency["Path"])
         details = repo_resolver.repo_details(folder_path)
 
-        self.assertEqual(details["Url"], commit_dependency['Url'])
-        self.assertEqual(details["Head"]["HexSha"], commit_dependency['Commit'])
+        self.assertEqual(details["Url"], commit_dependency["Url"])
+        self.assertEqual(details["Head"]["HexSha"], commit_dependency["Commit"])
         # first we checkout
         with self.assertRaises(Exception):
             repo_resolver.resolve(test_dir, commit_later_dependency)
 
         details = repo_resolver.repo_details(folder_path)
-        self.assertEqual(details["Url"], commit_dependency['Url'])
-        self.assertEqual(details["Head"]["HexSha"], commit_dependency['Commit'])
+        self.assertEqual(details["Url"], commit_dependency["Url"])
+        self.assertEqual(details["Head"]["HexSha"], commit_dependency["Commit"])
 
     def test_does_update(self):
         # create an empty directory- and set that as the workspace
@@ -246,19 +247,18 @@ class test_repo_resolver(unittest.TestCase):
         logging.info(f"Getting details at {folder_path}")
         details = repo_resolver.repo_details(folder_path)
 
-        self.assertEqual(details["Url"], commit_dependency['Url'])
-        self.assertEqual(details["Head"]["HexSha"], commit_dependency['Commit'])
+        self.assertEqual(details["Url"], commit_dependency["Url"])
+        self.assertEqual(details["Head"]["HexSha"], commit_dependency["Commit"])
         # next we checkout and go to the later commit
         try:
-            repo_resolver.resolve(
-                test_dir, commit_later_dependency, update_ok=True)
+            repo_resolver.resolve(test_dir, commit_later_dependency, update_ok=True)
         except:
             self.fail("We are not supposed to throw an exception")
         details = repo_resolver.repo_details(folder_path)
         logging.info(f"Checking {folder_path} for current git commit")
 
-        self.assertEqual(details["Url"], commit_later_dependency['Url'])
-        self.assertEqual(details["Head"]["HexSha"], commit_later_dependency['Commit'])
+        self.assertEqual(details["Url"], commit_later_dependency["Url"])
+        self.assertEqual(details["Head"]["HexSha"], commit_later_dependency["Commit"])
 
     def test_cant_switch_urls(self):
         # create an empty directory- and set that as the workspace
@@ -267,13 +267,13 @@ class test_repo_resolver(unittest.TestCase):
 
         details = repo_resolver.repo_details(folder_path)
 
-        self.assertEqual(details["Url"], branch_dependency['Url'])
+        self.assertEqual(details["Url"], branch_dependency["Url"])
         # first we checkout
         with self.assertRaises(Exception):
             repo_resolver.resolve(test_dir, microsoft_branch_dependency)
 
         details = repo_resolver.repo_details(folder_path)
-        self.assertEqual(details["Url"], branch_dependency['Url'])
+        self.assertEqual(details["Url"], branch_dependency["Url"])
 
     def test_ignore(self):
         # create an empty directory- and set that as the workspace
@@ -282,14 +282,13 @@ class test_repo_resolver(unittest.TestCase):
 
         details = repo_resolver.repo_details(folder_path)
 
-        self.assertEqual(details["Url"], branch_dependency['Url'])
+        self.assertEqual(details["Url"], branch_dependency["Url"])
         # first we checkout
 
-        repo_resolver.resolve(
-            test_dir, microsoft_branch_dependency, ignore=True)
+        repo_resolver.resolve(test_dir, microsoft_branch_dependency, ignore=True)
 
         details = repo_resolver.repo_details(folder_path)
-        self.assertEqual(details["Url"], branch_dependency['Url'])
+        self.assertEqual(details["Url"], branch_dependency["Url"])
 
     def test_will_switch_urls(self):
         # create an empty directory- and set that as the workspace
@@ -299,28 +298,26 @@ class test_repo_resolver(unittest.TestCase):
 
         details = repo_resolver.repo_details(folder_path)
 
-        self.assertEqual(details["Url"], branch_dependency['Url'])
+        self.assertEqual(details["Url"], branch_dependency["Url"])
         # first we checkout
         try:
-            repo_resolver.resolve(
-                test_dir, microsoft_branch_dependency, force=True)
+            repo_resolver.resolve(test_dir, microsoft_branch_dependency, force=True)
         except:
             self.fail("We shouldn't fail when we are forcing")
 
         details = repo_resolver.repo_details(folder_path)
-        self.assertEqual(details["Url"], microsoft_branch_dependency['Url'])
+        self.assertEqual(details["Url"], microsoft_branch_dependency["Url"])
 
     def test_will_switch_branches(self):
         repo_resolver.resolve(test_dir, branch_dependency)
         folder_path = os.path.join(test_dir, branch_dependency["Path"])
         repo_resolver.resolve(test_dir, sub_branch_dependency, force=True)
         details = repo_resolver.repo_details(folder_path)
-        self.assertEqual(details["Url"], branch_dependency['Url'])
-        self.assertEqual(details["Branch"], sub_branch_dependency['Branch'])
+        self.assertEqual(details["Url"], branch_dependency["Url"])
+        self.assertEqual(details["Branch"], sub_branch_dependency["Branch"])
 
     def test_submodule(self):
-
-        class Submodule():
+        class Submodule:
             def __init__(self, path, recursive):
                 self.path = path
                 self.recursive = recursive
@@ -332,7 +329,7 @@ class test_repo_resolver(unittest.TestCase):
 
         os.mkdir(os.path.join(temp_folder, "Build"))
         tmp_file = os.path.join(temp_folder, "Build", "tempfile.txt")
-        with open(tmp_file, 'x') as f:
+        with open(tmp_file, "x") as f:
             f.write("Temp edit")
             self.assertTrue(os.path.isfile(tmp_file))
 
@@ -352,17 +349,17 @@ def test_resolve_all(tmpdir: pathlib.Path):
         {
             "Url": "https://github.com/octocat/Spoon-Knife",
             "Path": "repo1",
-            "Commit": "a30c19e3f13765a3b48829788bc1cb8b4e95cee4"
+            "Commit": "a30c19e3f13765a3b48829788bc1cb8b4e95cee4",
         },
         {
             "Url": "https://github.com/octocat/Spoon-Knife",
             "Path": "repo2",
-            "Commit": "bb4cc8d3b2e14b3af5df699876dd4ff3acd00b7f"
+            "Commit": "bb4cc8d3b2e14b3af5df699876dd4ff3acd00b7f",
         },
         {
             "Url": "https://github.com/octocat/Spoon-Knife",
             "Path": "repo3",
-            "Commit": "d0dd1f61b33d64e29d8bc1372a94ef6a2fee76a9"
+            "Commit": "d0dd1f61b33d64e29d8bc1372a94ef6a2fee76a9",
         },
     ]
 
@@ -388,14 +385,21 @@ def test_clone_from_with_reference(tmpdir: pathlib.Path):
     # Clone the repo from a bad reference
     repo_path2 = pathlib.Path(tmpdir / "repo2")
     bad_repo_path = pathlib.Path(tmpdir / "bad_repo")
-    dep = {"Url": "https://github.com/octocat/Spoon-Knife", "ReferencePath": bad_repo_path}
+    dep = {
+        "Url": "https://github.com/octocat/Spoon-Knife",
+        "ReferencePath": bad_repo_path,
+    }
     repo_resolver.clone_repo(repo_path2, dep)
     assert len(list(repo_path2.iterdir())) > 0
 
 
 def test_checkout_branch(tmpdir: pathlib.Path):
     # Clone the repo
-    dep = {"Url": "https://github.com/octocat/Spoon-Knife", "Path": tmpdir, "Branch": "main"}
+    dep = {
+        "Url": "https://github.com/octocat/Spoon-Knife",
+        "Path": tmpdir,
+        "Branch": "main",
+    }
     repo_resolver.clone_repo(tmpdir, dep)
     details = repo_resolver.repo_details(tmpdir)
     assert details["Branch"] == "main"
@@ -406,7 +410,11 @@ def test_checkout_branch(tmpdir: pathlib.Path):
     assert details["Branch"] == "main"
 
     # Dep for the rest of the tests
-    dep = {"Url": "https://github.com/octocat/Spoon-Knife", "Path": tmpdir, "Branch": "test-branch"}
+    dep = {
+        "Url": "https://github.com/octocat/Spoon-Knife",
+        "Path": tmpdir,
+        "Branch": "test-branch",
+    }
 
     # Checkout different branch with ignore_dep_state_mismatch
     repo_resolver.checkout(tmpdir, dep, ignore_dep_state_mismatch=True)
@@ -425,13 +433,21 @@ def test_checkout_branch(tmpdir: pathlib.Path):
 
 def test_checkout_bad_branch(tmpdir: pathlib.Path):
     # Clone the repo
-    dep = {"Url": "https://github.com/octocat/Spoon-Knife", "Path": tmpdir, "Branch": "main"}
+    dep = {
+        "Url": "https://github.com/octocat/Spoon-Knife",
+        "Path": tmpdir,
+        "Branch": "main",
+    }
     repo_resolver.clone_repo(tmpdir, dep)
     details = repo_resolver.repo_details(tmpdir)
     assert details["Branch"] == "main"
 
     # Checkout bad branch without forcing
-    dep = {"Url": "https://github.com/octocat/Spoon-Knife", "Path": tmpdir, "Branch": "does not exist"}
+    dep = {
+        "Url": "https://github.com/octocat/Spoon-Knife",
+        "Path": tmpdir,
+        "Branch": "does not exist",
+    }
     with pytest.raises(Exception):
         repo_resolver.checkout(tmpdir, dep)
 

--- a/edk2toolext/tests/test_self_describing_environment.py
+++ b/edk2toolext/tests/test_self_describing_environment.py
@@ -18,7 +18,6 @@ from edk2toolext.environment import version_aggregator
 
 
 class Testself_describing_environment(unittest.TestCase):
-
     def setUp(self):
         self.workspace = pathlib.Path(tempfile.mkdtemp()).resolve()
         # we need to make sure to tear down the version aggregator and the SDE
@@ -30,70 +29,126 @@ class Testself_describing_environment(unittest.TestCase):
         self.assertIsNotNone(sde)
 
     def test_unique_scopes_required(self):
-        ''' make sure the sde will throw exception if duplicate scopes are specified '''
+        """make sure the sde will throw exception if duplicate scopes are specified"""
         scopes = ("corebuild", "corebuild", "testing", "CoreBuild")
         with self.assertRaises(ValueError):
-            self_describing_environment.self_describing_environment(self.workspace, scopes)
+            self_describing_environment.self_describing_environment(
+                self.workspace, scopes
+            )
 
     def test_collect_path_env(self):
-        ''' makes sure the SDE can collect path env '''
+        """makes sure the SDE can collect path env"""
         scopes = ("global",)
         tree = uefi_tree(self.workspace, create_platform=False)
-        tree.create_path_env("testing_corebuild", var_name="hey", flags=["set_path", ])
-        tree.create_path_env("testing_corebuild2", var_name="hey", flags=["set_pypath", ])
-        tree.create_path_env("testing_corebuild3", var_name="hey", flags=["set_build_var", ])
-        tree.create_path_env("testing_corebuild4", var_name="hey", flags=["set_shell_var", ])
-        build_env, shell_env = self_describing_environment.BootstrapEnvironment(self.workspace, scopes)
+        tree.create_path_env(
+            "testing_corebuild",
+            var_name="hey",
+            flags=[
+                "set_path",
+            ],
+        )
+        tree.create_path_env(
+            "testing_corebuild2",
+            var_name="hey",
+            flags=[
+                "set_pypath",
+            ],
+        )
+        tree.create_path_env(
+            "testing_corebuild3",
+            var_name="hey",
+            flags=[
+                "set_build_var",
+            ],
+        )
+        tree.create_path_env(
+            "testing_corebuild4",
+            var_name="hey",
+            flags=[
+                "set_shell_var",
+            ],
+        )
+        build_env, shell_env = self_describing_environment.BootstrapEnvironment(
+            self.workspace, scopes
+        )
         self.assertEqual(len(build_env.paths), 4)
 
     def test_collect_path_env_scoped(self):
-        ''' makes sure the SDE can collect path env with the right scopes '''
+        """makes sure the SDE can collect path env with the right scopes"""
         scopes = ("global", "testing")
         tree = uefi_tree(self.workspace, create_platform=False)
         tree.create_path_env("testing_corebuild", scope="testing")
         tree.create_path_env("testing_corebuild2", scope="not_valid")
-        build_env, shell_env = self_describing_environment.BootstrapEnvironment(self.workspace, scopes)
+        build_env, shell_env = self_describing_environment.BootstrapEnvironment(
+            self.workspace, scopes
+        )
         self.assertEqual(len(build_env.paths), 1)
 
     def test_override_path_env(self):
-        ''' checks the SDE descriptor override system '''
+        """checks the SDE descriptor override system"""
         custom_scope = "global"
         scopes = (custom_scope,)
         tree = uefi_tree(self.workspace, create_platform=False)
-        tree.create_path_env("testing_corebuild", var_name="hey", dir_path="test1", scope=custom_scope)
-        tree.create_path_env("testing_corebuild2", var_name="jokes", scope=custom_scope,
-                             extra_data={"override_id": "testing_corebuild"})
-        build_env, shell_env = self_describing_environment.BootstrapEnvironment(self.workspace, scopes)
+        tree.create_path_env(
+            "testing_corebuild", var_name="hey", dir_path="test1", scope=custom_scope
+        )
+        tree.create_path_env(
+            "testing_corebuild2",
+            var_name="jokes",
+            scope=custom_scope,
+            extra_data={"override_id": "testing_corebuild"},
+        )
+        build_env, shell_env = self_describing_environment.BootstrapEnvironment(
+            self.workspace, scopes
+        )
         self.assertEqual(len(build_env.paths), 1)
 
     def test_multiple_override_path_env(self):
-        ''' checks the SDE descriptor override system will throw an error on multiple overrides'''
+        """checks the SDE descriptor override system will throw an error on multiple overrides"""
         custom_scope = "global"
         scopes = (custom_scope,)
         tree = uefi_tree(self.workspace, create_platform=False)
-        tree.create_path_env("testing_corebuild", var_name="hey", dir_path="test1", scope=custom_scope)
-        tree.create_path_env("testing_corebuild2", var_name="jokes", scope=custom_scope,
-                             extra_data={"override_id": "testing_corebuild"})
-        tree.create_path_env("testing_corebuild3", var_name="laughs", scope=custom_scope,
-                             extra_data={"override_id": "testing_corebuild"})
+        tree.create_path_env(
+            "testing_corebuild", var_name="hey", dir_path="test1", scope=custom_scope
+        )
+        tree.create_path_env(
+            "testing_corebuild2",
+            var_name="jokes",
+            scope=custom_scope,
+            extra_data={"override_id": "testing_corebuild"},
+        )
+        tree.create_path_env(
+            "testing_corebuild3",
+            var_name="laughs",
+            scope=custom_scope,
+            extra_data={"override_id": "testing_corebuild"},
+        )
         # we should get an exception because we have two overrides
         with self.assertRaises(RuntimeError):
-            build_env, shell_env = self_describing_environment.BootstrapEnvironment(self.workspace, scopes)
+            build_env, shell_env = self_describing_environment.BootstrapEnvironment(
+                self.workspace, scopes
+            )
             self.fail()
 
     def test_override_path_env_swapped_order(self):
-        ''' checks the SDE descriptor override system with reversed paths so they are discovered in opposite order'''
+        """checks the SDE descriptor override system with reversed paths so they are discovered in opposite order"""
         custom_scope = "global"
         scopes = (custom_scope,)
         tree = uefi_tree(self.workspace, create_platform=False)
         tree.create_path_env("testing_corebuild", var_name="hey", scope=custom_scope)
-        tree.create_path_env(var_name="jokes", dir_path="test1", scope=custom_scope,
-                             extra_data={"override_id": "testing_corebuild"})
-        build_env, shell_env = self_describing_environment.BootstrapEnvironment(self.workspace, scopes)
+        tree.create_path_env(
+            var_name="jokes",
+            dir_path="test1",
+            scope=custom_scope,
+            extra_data={"override_id": "testing_corebuild"},
+        )
+        build_env, shell_env = self_describing_environment.BootstrapEnvironment(
+            self.workspace, scopes
+        )
         self.assertEqual(len(build_env.paths), 1)
 
     def test_duplicate_id_path_env(self):
-        ''' check that the SDE will throw an exception if path_env have duplicate id's '''
+        """check that the SDE will throw an exception if path_env have duplicate id's"""
         custom_scope = "global"
         scopes = (custom_scope,)
         tree = uefi_tree(self.workspace, create_platform=False)
@@ -104,9 +159,9 @@ class Testself_describing_environment(unittest.TestCase):
             self.fail()
 
     def test_duplicate_id_path_env_2(self):
-        ''' check that the SDE will throw an exception if path env have duplicate id's.
+        """check that the SDE will throw an exception if path env have duplicate id's.
         Since id is not a required member of path env make sure it can handle case where one of the path
-        env files doesn't define an id'''
+        env files doesn't define an id"""
         custom_scope = "global"
         scopes = (custom_scope,)
         tree = uefi_tree(self.workspace, create_platform=False)
@@ -135,35 +190,53 @@ class Testself_describing_environment(unittest.TestCase):
         self.assertEqual(len(repo.branches), 1)
 
         repo.git.worktree("add", "my_worktree")
-        self_describing_environment.BootstrapEnvironment(self.workspace, ('global',))
+        self_describing_environment.BootstrapEnvironment(self.workspace, ("global",))
 
     def test_no_verify_extdep(self):
         tree = uefi_tree(self.workspace, create_platform=False)
-        tree.create_ext_dep(dep_type="git",
-                            scope="global",
-                            name="HelloWorld",
-                            source="https://github.com/octocat/Hello-World.git",
-                            version="7fd1a60b01f91b314f59955a4e4d4e80d8edf11d")
+        tree.create_ext_dep(
+            dep_type="git",
+            scope="global",
+            name="HelloWorld",
+            source="https://github.com/octocat/Hello-World.git",
+            version="7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+        )
 
         # Bootstrap the environment
         self_describing_environment.BootstrapEnvironment(self.workspace, ("global",))
-        self_describing_environment.UpdateDependencies(self.workspace, scopes=("global",))
-        self_describing_environment.VerifyEnvironment(self.workspace, scopes=("global",))
+        self_describing_environment.UpdateDependencies(
+            self.workspace, scopes=("global",)
+        )
+        self_describing_environment.VerifyEnvironment(
+            self.workspace, scopes=("global",)
+        )
 
         # Delete the readme to make the repo dirty then verify it fails
-        readme = os.path.join(tree.get_workspace(), "HelloWorld_extdep", "HelloWorld", "README")
+        readme = os.path.join(
+            tree.get_workspace(), "HelloWorld_extdep", "HelloWorld", "README"
+        )
         os.remove(readme)
-        self.assertFalse(self_describing_environment.VerifyEnvironment(self.workspace, scopes=("global",)))
+        self.assertFalse(
+            self_describing_environment.VerifyEnvironment(
+                self.workspace, scopes=("global",)
+            )
+        )
 
         # Update the state file to not verify the specific external dependency then verify it passes
-        state_file = os.path.join(tree.get_workspace(), "HelloWorld_extdep", "extdep_state.yaml")
-        with open(state_file, 'r+') as f:
+        state_file = os.path.join(
+            tree.get_workspace(), "HelloWorld_extdep", "extdep_state.yaml"
+        )
+        with open(state_file, "r+") as f:
             content = yaml.safe_load(f)
             f.seek(0)
             content["verify"] = False
             yaml.safe_dump(content, f)
-        self.assertTrue(self_describing_environment.VerifyEnvironment(self.workspace, scopes=("global",)))
+        self.assertTrue(
+            self_describing_environment.VerifyEnvironment(
+                self.workspace, scopes=("global",)
+            )
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/test_shell_environment.py
+++ b/edk2toolext/tests/test_shell_environment.py
@@ -14,11 +14,12 @@ import edk2toolext.environment.shell_environment as SE
 
 
 class TestShellEnvironmentAssumptions(unittest.TestCase):
-
     def test_shell_should_be_a_singleton(self):
         shell_a = SE.ShellEnvironment()
         shell_b = SE.ShellEnvironment()
-        self.assertIs(shell_a, shell_b, "two instances of ShellEnvironment should be identical")
+        self.assertIs(
+            shell_a, shell_b, "two instances of ShellEnvironment should be identical"
+        )
 
     def test_shell_tests_need_to_be_able_to_clear_singleton(self):
         # This is not currently achievable, and may never be achievable.
@@ -26,123 +27,180 @@ class TestShellEnvironmentAssumptions(unittest.TestCase):
 
     def test_shell_should_always_have_an_initial_checkpoint(self):
         shell_env = SE.ShellEnvironment()
-        self.assertTrue((len(shell_env.checkpoints) > 0),
-                        "a new instance of ShellEnvironment should have at least one checkpoint")
+        self.assertTrue(
+            (len(shell_env.checkpoints) > 0),
+            "a new instance of ShellEnvironment should have at least one checkpoint",
+        )
 
 
 class TestBasicEnvironmentManipulation(unittest.TestCase):
-
     def test_can_set_os_vars(self):
         shell_env = SE.ShellEnvironment()
         # Remove the test var, if it exists.
         os.environ.pop("SE-TEST-VAR-1", None)
         # Set a new value and get it directly from the environment.
-        new_value = 'Dummy'
-        shell_env.set_shell_var('SE-TEST-VAR-1', new_value)
-        self.assertEqual(os.environ['SE-TEST-VAR-1'], new_value)
+        new_value = "Dummy"
+        shell_env.set_shell_var("SE-TEST-VAR-1", new_value)
+        self.assertEqual(os.environ["SE-TEST-VAR-1"], new_value)
 
         with self.assertRaises(ValueError):
-            shell_env.set_shell_var('SE-TEST-VAR-FAIL', None)
+            shell_env.set_shell_var("SE-TEST-VAR-FAIL", None)
 
     def test_can_get_os_vars(self):
         shell_env = SE.ShellEnvironment()
-        new_value = 'Dummy2'
-        shell_env.set_shell_var('SE-TEST-VAR-2', new_value)
-        self.assertEqual(shell_env.get_shell_var('SE-TEST-VAR-2'), new_value)
+        new_value = "Dummy2"
+        shell_env.set_shell_var("SE-TEST-VAR-2", new_value)
+        self.assertEqual(shell_env.get_shell_var("SE-TEST-VAR-2"), new_value)
 
     def test_set_path_string(self):
         shell_env = SE.ShellEnvironment()
 
         # Test pass 1.
-        testpath_elems = ['MY_PATH']
+        testpath_elems = ["MY_PATH"]
         testpath_string = os.pathsep.join(testpath_elems)
         shell_env.set_path(testpath_string)
-        self.assertEqual(os.environ['PATH'], testpath_string, "the final string should be correct")
+        self.assertEqual(
+            os.environ["PATH"], testpath_string, "the final string should be correct"
+        )
         for elem in testpath_elems:
-            self.assertIn(elem, shell_env.active_path, "the active path should contain all elements")
+            self.assertIn(
+                elem,
+                shell_env.active_path,
+                "the active path should contain all elements",
+            )
 
         # Test pass 2.
-        testpath_elems = ['/bin/bash', 'new_path', '/root']
+        testpath_elems = ["/bin/bash", "new_path", "/root"]
         testpath_string = os.pathsep.join(testpath_elems)
         shell_env.set_path(testpath_string)
-        self.assertEqual(os.environ['PATH'], testpath_string, "the final string should be correct")
+        self.assertEqual(
+            os.environ["PATH"], testpath_string, "the final string should be correct"
+        )
         for elem in testpath_elems:
-            self.assertIn(elem, shell_env.active_path, "the active path should contain all elements")
+            self.assertIn(
+                elem,
+                shell_env.active_path,
+                "the active path should contain all elements",
+            )
 
     def test_set_path_elements(self):
         shell_env = SE.ShellEnvironment()
 
         # Test pass 1.
-        testpath_elems = ['MY_PATH']
+        testpath_elems = ["MY_PATH"]
         testpath_string = os.pathsep.join(testpath_elems)
         shell_env.set_path(testpath_elems)
-        self.assertEqual(os.environ['PATH'], testpath_string, "the final string should be correct")
+        self.assertEqual(
+            os.environ["PATH"], testpath_string, "the final string should be correct"
+        )
         for elem in testpath_elems:
-            self.assertIn(elem, shell_env.active_path, "the active path should contain all elements")
+            self.assertIn(
+                elem,
+                shell_env.active_path,
+                "the active path should contain all elements",
+            )
 
         # Test pass 2.
-        testpath_elems = ['/bin/bash', 'new_path', '/root']
+        testpath_elems = ["/bin/bash", "new_path", "/root"]
         testpath_string = os.pathsep.join(testpath_elems)
         shell_env.set_path(testpath_elems)
-        self.assertEqual(os.environ['PATH'], testpath_string, "the final string should be correct")
+        self.assertEqual(
+            os.environ["PATH"], testpath_string, "the final string should be correct"
+        )
         for elem in testpath_elems:
-            self.assertIn(elem, shell_env.active_path, "the active path should contain all elements")
+            self.assertIn(
+                elem,
+                shell_env.active_path,
+                "the active path should contain all elements",
+            )
 
     def test_set_pypath_string(self):
         shell_env = SE.ShellEnvironment()
 
         # Test pass 1.
-        testpath_elems = ['MY_PATH']
+        testpath_elems = ["MY_PATH"]
         testpath_string = os.pathsep.join(testpath_elems)
         shell_env.set_pypath(testpath_string)
-        self.assertEqual(os.environ['PYTHONPATH'], testpath_string, "the final string should be correct")
+        self.assertEqual(
+            os.environ["PYTHONPATH"],
+            testpath_string,
+            "the final string should be correct",
+        )
         for elem in testpath_elems:
-            self.assertIn(elem, shell_env.active_pypath, "the active path should contain all elements")
+            self.assertIn(
+                elem,
+                shell_env.active_pypath,
+                "the active path should contain all elements",
+            )
             self.assertIn(elem, sys.path, "the sys path should contain all elements")
 
         # Test pass 2.
-        testpath_elems = ['/bin/bash', 'new_path', '/root']
+        testpath_elems = ["/bin/bash", "new_path", "/root"]
         testpath_string = os.pathsep.join(testpath_elems)
         shell_env.set_pypath(testpath_string)
-        self.assertEqual(os.environ['PYTHONPATH'], testpath_string, "the final string should be correct")
+        self.assertEqual(
+            os.environ["PYTHONPATH"],
+            testpath_string,
+            "the final string should be correct",
+        )
         for elem in testpath_elems:
-            self.assertIn(elem, shell_env.active_pypath, "the active path should contain all elements")
+            self.assertIn(
+                elem,
+                shell_env.active_pypath,
+                "the active path should contain all elements",
+            )
             self.assertIn(elem, sys.path, "the sys path should contain all elements")
 
     def test_set_pypath_elements(self):
         shell_env = SE.ShellEnvironment()
 
         # Test pass 1.
-        testpath_elems = ['MY_PATH']
+        testpath_elems = ["MY_PATH"]
         testpath_string = os.pathsep.join(testpath_elems)
         shell_env.set_pypath(testpath_elems)
-        self.assertEqual(os.environ['PYTHONPATH'], testpath_string, "the final string should be correct")
+        self.assertEqual(
+            os.environ["PYTHONPATH"],
+            testpath_string,
+            "the final string should be correct",
+        )
         for elem in testpath_elems:
-            self.assertIn(elem, shell_env.active_pypath, "the active path should contain all elements")
+            self.assertIn(
+                elem,
+                shell_env.active_pypath,
+                "the active path should contain all elements",
+            )
             self.assertIn(elem, sys.path, "the sys path should contain all elements")
 
         # Test pass 2.
-        testpath_elems = ['/bin/bash', 'new_path', '/root']
+        testpath_elems = ["/bin/bash", "new_path", "/root"]
         testpath_string = os.pathsep.join(testpath_elems)
         shell_env.set_pypath(testpath_elems)
-        self.assertEqual(os.environ['PYTHONPATH'], testpath_string, "the final string should be correct")
+        self.assertEqual(
+            os.environ["PYTHONPATH"],
+            testpath_string,
+            "the final string should be correct",
+        )
         for elem in testpath_elems:
-            self.assertIn(elem, shell_env.active_pypath, "the active path should contain all elements")
+            self.assertIn(
+                elem,
+                shell_env.active_pypath,
+                "the active path should contain all elements",
+            )
             self.assertIn(elem, sys.path, "the sys path should contain all elements")
 
     def test_insert_append_remove_replace_path(self):
         shell_env = SE.ShellEnvironment()
 
         # Start with a known PATH
-        mid_elem = 'MIDDLEPATH'
+        mid_elem = "MIDDLEPATH"
         shell_env.set_path(mid_elem)
         self.assertEqual(1, len(shell_env.active_path))
         self.assertIn(mid_elem, shell_env.active_path)
         # Add an element to the end.
-        end_elem = 'ENDPATH'
+        end_elem = "ENDPATH"
         shell_env.append_path(end_elem)
         # Add an element to the beginning.
-        start_elem = 'STARTPATH'
+        start_elem = "STARTPATH"
         shell_env.insert_path(start_elem)
 
         # Test for the realities.
@@ -168,7 +226,7 @@ class TestBasicEnvironmentManipulation(unittest.TestCase):
         self.assertEqual(shell_env.active_path[2], end_elem)
 
         # Test replacing an element on the path
-        new_mid_elem = 'NEWMIDDLEPATH'
+        new_mid_elem = "NEWMIDDLEPATH"
         shell_env.replace_path_element(mid_elem, new_mid_elem)
         self.assertEqual(shell_env.active_path[1], new_mid_elem)
 
@@ -193,15 +251,15 @@ class TestBasicEnvironmentManipulation(unittest.TestCase):
         shell_env = SE.ShellEnvironment()
 
         # Start with a known PATH
-        mid_elem = 'MIDDLEPATH'
+        mid_elem = "MIDDLEPATH"
         shell_env.set_pypath(mid_elem)
         self.assertEqual(1, len(shell_env.active_pypath))
         self.assertIn(mid_elem, shell_env.active_pypath)
         # Add an element to the end.
-        end_elem = 'ENDPATH'
+        end_elem = "ENDPATH"
         shell_env.append_pypath(end_elem)
         # Add an element to the beginning.
-        start_elem = 'STARTPATH'
+        start_elem = "STARTPATH"
         shell_env.insert_pypath(start_elem)
 
         # Test for the realities.
@@ -214,7 +272,7 @@ class TestBasicEnvironmentManipulation(unittest.TestCase):
             self.assertIn(elem, sys.path)
 
         # Test replacing an element on the pypath
-        new_mid_elem = 'NEWMIDDLEPATH'
+        new_mid_elem = "NEWMIDDLEPATH"
         shell_env.replace_pypath_element(mid_elem, new_mid_elem)
         self.assertEqual(shell_env.active_pypath[1], new_mid_elem)
 
@@ -230,21 +288,33 @@ class TestBasicEnvironmentManipulation(unittest.TestCase):
     def test_can_set_and_get_build_vars(self):
         shell_env = SE.ShellEnvironment()
 
-        var_name = 'SE-TEST-VAR-3'
-        var_data = 'Dummy3'
+        var_name = "SE-TEST-VAR-3"
+        var_data = "Dummy3"
         # Make sure it doesn't exist beforehand.
-        self.assertIs(shell_env.get_build_var(var_name), None, "test var should not exist before creation")
+        self.assertIs(
+            shell_env.get_build_var(var_name),
+            None,
+            "test var should not exist before creation",
+        )
         shell_env.set_build_var(var_name, var_data)
-        self.assertEqual(shell_env.get_build_var(var_name), var_data, "get var data should match set var data")
+        self.assertEqual(
+            shell_env.get_build_var(var_name),
+            var_data,
+            "get var data should match set var data",
+        )
 
     def test_set_build_vars_should_default_overrideable(self):
         shell_env = SE.ShellEnvironment()
 
-        var_name = 'SE_TEST_VAR_4'
-        var_data = 'NewData1'
-        var_data2 = 'NewerData1'
+        var_name = "SE_TEST_VAR_4"
+        var_data = "NewData1"
+        var_data2 = "NewerData1"
 
-        self.assertIs(shell_env.get_build_var(var_name), None, "test var should not exist before creation")
+        self.assertIs(
+            shell_env.get_build_var(var_name),
+            None,
+            "test var should not exist before creation",
+        )
         shell_env.set_build_var(var_name, var_data)
         shell_env.set_build_var(var_name, var_data2)
 
@@ -252,40 +322,49 @@ class TestBasicEnvironmentManipulation(unittest.TestCase):
 
 
 class TestShellEnvironmenCheckpoints(unittest.TestCase):
-
     def setUp(self):
         # Grab the singleton and restore the initial checkpoint.
         shell_env = SE.ShellEnvironment()
         shell_env.restore_initial_checkpoint()
         # For testing, purge all checkpoints each time.
-        shell_env.checkpoints = [shell_env.checkpoints[SE.ShellEnvironment.INITIAL_CHECKPOINT]]
+        shell_env.checkpoints = [
+            shell_env.checkpoints[SE.ShellEnvironment.INITIAL_CHECKPOINT]
+        ]
 
     def test_restore_initial_checkpoint_should_erase_changes(self):
         shell_env = SE.ShellEnvironment()
 
         # Check to make sure the change doesn't exist.
-        test_path_change = '/SE/TEST/PATH/1'
-        self.assertNotIn(test_path_change, shell_env.active_path, "starting condition should not have the test change")
+        test_path_change = "/SE/TEST/PATH/1"
+        self.assertNotIn(
+            test_path_change,
+            shell_env.active_path,
+            "starting condition should not have the test change",
+        )
 
         # Make the change and verify.
         shell_env.append_path(test_path_change)
         self.assertIn(test_path_change, shell_env.active_path)
 
         # Add a shell_var while we're at it.
-        self.assertEqual(shell_env.get_shell_var('i_should_not_exist'), None)
-        shell_env.set_shell_var('i_should_not_exist', 'a_value')
-        self.assertEqual(shell_env.get_shell_var('i_should_not_exist'), 'a_value')
+        self.assertEqual(shell_env.get_shell_var("i_should_not_exist"), None)
+        shell_env.set_shell_var("i_should_not_exist", "a_value")
+        self.assertEqual(shell_env.get_shell_var("i_should_not_exist"), "a_value")
 
         # Restore initial checkpoint and verify change is gone.
         shell_env.restore_initial_checkpoint()
-        self.assertNotIn(test_path_change, shell_env.active_path, "restoring checkpoint should remove test change")
-        self.assertEqual(shell_env.get_shell_var('i_should_not_exist'), None)
+        self.assertNotIn(
+            test_path_change,
+            shell_env.active_path,
+            "restoring checkpoint should remove test change",
+        )
+        self.assertEqual(shell_env.get_shell_var("i_should_not_exist"), None)
 
     def test_checkpoint_indices_should_be_unique(self):
         shell_env = SE.ShellEnvironment()
-        shell_env.append_path('/SE/TEST/PATH/1')
+        shell_env.append_path("/SE/TEST/PATH/1")
         check_point1 = shell_env.checkpoint()
-        shell_env.append_path('/SE/TEST/PATH/2')
+        shell_env.append_path("/SE/TEST/PATH/2")
         check_point2 = shell_env.checkpoint()
 
         self.assertNotEqual(check_point1, SE.ShellEnvironment.INITIAL_CHECKPOINT)
@@ -296,8 +375,12 @@ class TestShellEnvironmenCheckpoints(unittest.TestCase):
         shell_env = SE.ShellEnvironment()
 
         # Check to make sure the change doesn't exist.
-        test_path_change = '/SE/TEST/PATH/3'
-        self.assertNotIn(test_path_change, shell_env.active_path, "starting condition should not have the test change")
+        test_path_change = "/SE/TEST/PATH/3"
+        self.assertNotIn(
+            test_path_change,
+            shell_env.active_path,
+            "starting condition should not have the test change",
+        )
 
         # Make the change and checkpoint.
         shell_env.append_path(test_path_change)
@@ -306,25 +389,32 @@ class TestShellEnvironmenCheckpoints(unittest.TestCase):
 
         # Restore initial checkpoint and verify change is gone.
         shell_env.restore_initial_checkpoint()
-        self.assertNotIn(test_path_change, shell_env.active_path,
-                         "restoring initial checkpoint should remove test change")
+        self.assertNotIn(
+            test_path_change,
+            shell_env.active_path,
+            "restoring initial checkpoint should remove test change",
+        )
 
         # Restore new checkpoint and verify change is back.
         shell_env.restore_checkpoint(check_point1)
-        self.assertIn(test_path_change, shell_env.active_path, "restoring new checkpoint should restore test change")
+        self.assertIn(
+            test_path_change,
+            shell_env.active_path,
+            "restoring new checkpoint should restore test change",
+        )
 
     def test_checkpointed_objects_should_behave_correctly(self):
         shell_env = SE.ShellEnvironment()
 
         # This test is to make sure that pass-by-reference elements don't persist unexpectedly.
 
-        test_var1_name = 'SE_TEST_VAR_3'
-        test_var1_data = 'MyData1'
-        test_var1_data2 = 'RevisedData1'
-        test_var1_data3 = 'MoreRevisedData1'
+        test_var1_name = "SE_TEST_VAR_3"
+        test_var1_data = "MyData1"
+        test_var1_data2 = "RevisedData1"
+        test_var1_data3 = "MoreRevisedData1"
 
-        test_var2_name = 'SE_TEST_VAR_4'
-        test_var2_data = 'MyData2'
+        test_var2_name = "SE_TEST_VAR_4"
+        test_var2_data = "MyData2"
 
         # Set the first data and make a checkpoint.
         shell_env.set_build_var(test_var1_name, test_var1_data)
@@ -354,22 +444,23 @@ class TestShellEnvironmenCheckpoints(unittest.TestCase):
 
 
 class TestShellEnvironmenSpecialBuildVars(unittest.TestCase):
-
     def setUp(self):
         # Grab the singleton and restore the initial checkpoint.
         shell_env = SE.ShellEnvironment()
         shell_env.restore_initial_checkpoint()
         # For testing, purge all checkpoints each time.
-        shell_env.checkpoints = [shell_env.checkpoints[SE.ShellEnvironment.INITIAL_CHECKPOINT]]
+        shell_env.checkpoints = [
+            shell_env.checkpoints[SE.ShellEnvironment.INITIAL_CHECKPOINT]
+        ]
 
     def test_get_build_vars_should_update_vars(self):
         shell_env = SE.ShellEnvironment()
         build_vars = SE.GetBuildVars()
 
-        test_var_name = 'SE_TEST_VAR_4'
-        test_var_data = 'NewData1'
+        test_var_name = "SE_TEST_VAR_4"
+        test_var_data = "NewData1"
 
-        build_vars.SetValue(test_var_name, test_var_data, 'random set')
+        build_vars.SetValue(test_var_name, test_var_data, "random set")
 
         self.assertEqual(shell_env.get_build_var(test_var_name), test_var_data)
 
@@ -377,12 +468,12 @@ class TestShellEnvironmenSpecialBuildVars(unittest.TestCase):
         shell_env = SE.ShellEnvironment()
         build_vars = SE.GetBuildVars()
 
-        test_var_name = 'SE_TEST_VAR_4'
-        test_var_data = 'NewData1'
-        test_var_data2 = 'NewerData1'
+        test_var_name = "SE_TEST_VAR_4"
+        test_var_data = "NewData1"
+        test_var_data2 = "NewerData1"
 
-        build_vars.SetValue(test_var_name, test_var_data, 'random set')
-        build_vars.SetValue(test_var_name, test_var_data2, 'another random set')
+        build_vars.SetValue(test_var_name, test_var_data, "random set")
+        build_vars.SetValue(test_var_name, test_var_data2, "another random set")
 
         self.assertEqual(shell_env.get_build_var(test_var_name), test_var_data)
 
@@ -390,20 +481,26 @@ class TestShellEnvironmenSpecialBuildVars(unittest.TestCase):
         shell_env = SE.ShellEnvironment()
         build_vars = SE.GetBuildVars()
 
-        test_var1_name = 'SE_TEST_VAR_update_current1'
-        test_var1_data = 'NewData1'
-        test_var1_data2 = 'NewerData1'
+        test_var1_name = "SE_TEST_VAR_update_current1"
+        test_var1_data = "NewData1"
+        test_var1_data2 = "NewerData1"
 
-        test_var2_name = 'SE_TEST_VAR_update_current2'
-        test_var2_data = 'NewData2'
+        test_var2_name = "SE_TEST_VAR_update_current2"
+        test_var2_data = "NewData2"
 
         # Make a change and checkpoint.
-        build_vars.SetValue(test_var1_name, test_var1_data, 'var1 set', overridable=True)
+        build_vars.SetValue(
+            test_var1_name, test_var1_data, "var1 set", overridable=True
+        )
         shell_env.checkpoint()
 
         # Make a couple more changes.
-        build_vars.SetValue(test_var1_name, test_var1_data2, 'var1 set', overridable=True)
-        build_vars.SetValue(test_var2_name, test_var2_data, 'var2 set', overridable=True)
+        build_vars.SetValue(
+            test_var1_name, test_var1_data2, "var1 set", overridable=True
+        )
+        build_vars.SetValue(
+            test_var2_name, test_var2_data, "var2 set", overridable=True
+        )
 
         # Make sure that the newer changes are valid.
         self.assertEqual(shell_env.get_build_var(test_var1_name), test_var1_data2)
@@ -416,21 +513,27 @@ class TestShellEnvironmenSpecialBuildVars(unittest.TestCase):
         # This test is basically a rehash of the object checkpointing test,
         # but this time with the special vars.
 
-        test_var1_name = 'SE_TEST_VAR_3'
-        test_var1_data = 'MyData1'
-        test_var1_data2 = 'RevisedData1'
-        test_var1_data3 = 'MoreRevisedData1'
+        test_var1_name = "SE_TEST_VAR_3"
+        test_var1_data = "MyData1"
+        test_var1_data2 = "RevisedData1"
+        test_var1_data3 = "MoreRevisedData1"
 
-        test_var2_name = 'SE_TEST_VAR_4'
-        test_var2_data = 'MyData2'
+        test_var2_name = "SE_TEST_VAR_4"
+        test_var2_data = "MyData2"
 
         # Set the first data and make a checkpoint.
-        build_vars.SetValue(test_var1_name, test_var1_data, 'var1 set', overridable=True)
+        build_vars.SetValue(
+            test_var1_name, test_var1_data, "var1 set", overridable=True
+        )
         check_point1 = shell_env.checkpoint()
 
         # Update previous value and set second data. Then checkpoint.
-        build_vars.SetValue(test_var1_name, test_var1_data2, 'var1 set', overridable=True)
-        build_vars.SetValue(test_var2_name, test_var2_data, 'var2 set', overridable=True)
+        build_vars.SetValue(
+            test_var1_name, test_var1_data2, "var1 set", overridable=True
+        )
+        build_vars.SetValue(
+            test_var2_name, test_var2_data, "var2 set", overridable=True
+        )
         check_point2 = shell_env.checkpoint()
 
         # Restore the first checkpoint and verify values.
@@ -439,9 +542,14 @@ class TestShellEnvironmenSpecialBuildVars(unittest.TestCase):
         self.assertIs(shell_env.get_build_var(test_var2_name), None)
 
         # Make a change to be tested later.
-        build_vars.SetValue(test_var1_name, test_var1_data3, 'var1 set', overridable=True)
-        self.assertEqual(shell_env.get_build_var(test_var1_name), test_var1_data3,
-                         'even after restore, special build vars should always update current')
+        build_vars.SetValue(
+            test_var1_name, test_var1_data3, "var1 set", overridable=True
+        )
+        self.assertEqual(
+            shell_env.get_build_var(test_var1_name),
+            test_var1_data3,
+            "even after restore, special build vars should always update current",
+        )
 
         # Restore the second checkpoint and verify values.
         shell_env.restore_checkpoint(check_point2)
@@ -453,5 +561,5 @@ class TestShellEnvironmenSpecialBuildVars(unittest.TestCase):
         self.assertEqual(shell_env.get_build_var(test_var1_name), test_var1_data)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/test_signtool_signer.py
+++ b/edk2toolext/tests/test_signtool_signer.py
@@ -12,7 +12,6 @@ from edk2toolext.capsule import signtool_signer
 
 
 class Test_signtool_signer(unittest.TestCase):
-
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_get_path(self):
         path = signtool_signer.get_signtool_path()
@@ -20,9 +19,7 @@ class Test_signtool_signer(unittest.TestCase):
 
     @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
     def test_sign_with_bad_options(self):
-        signature = {
-            "type": "test"
-        }
+        signature = {"type": "test"}
         signer = {}
         with self.assertRaises(ValueError):
             signtool_signer.sign(None, signature, signer)
@@ -33,12 +30,9 @@ class Test_signtool_signer(unittest.TestCase):
             "type": "pkcs7",
             "type_options": ["embedded"],
             "encoding": "DER",
-            "hash_alg": "sha256"
+            "hash_alg": "sha256",
         }
-        signer = {
-            "key_file": "file.txt",
-            "key_file_format": "pkcs12"
-        }
+        signer = {"key_file": "file.txt", "key_file_format": "pkcs12"}
         with self.assertRaises(RuntimeError):
             signtool_signer.sign(b"data", signature, signer)
 
@@ -46,7 +40,7 @@ class Test_signtool_signer(unittest.TestCase):
     def test_sign_with_mutually_exclusive_options(self):
         signature = {
             "type": "pkcs7",
-            "type_options": ["embedded", "detachedSignedData"]
+            "type_options": ["embedded", "detachedSignedData"],
         }
         signer = {}
         with self.assertRaises(ValueError):
@@ -54,7 +48,7 @@ class Test_signtool_signer(unittest.TestCase):
 
         signature = {
             "type": "pkcs7",
-            "type_options": ["pkcs7DetachedSignedData", "detachedSignedData"]
+            "type_options": ["pkcs7DetachedSignedData", "detachedSignedData"],
         }
         signer = {}
         with self.assertRaises(ValueError):
@@ -62,7 +56,7 @@ class Test_signtool_signer(unittest.TestCase):
 
         signature = {
             "type": "pkcs7",
-            "type_options": ["pkcs7DetachedSignedData", "embedded"]
+            "type_options": ["pkcs7DetachedSignedData", "embedded"],
         }
         signer = {}
         with self.assertRaises(ValueError):
@@ -70,7 +64,11 @@ class Test_signtool_signer(unittest.TestCase):
 
         signature = {
             "type": "pkcs7",
-            "type_options": ["detachedSignedData", "pkcs7DetachedSignedData", "embedded"]
+            "type_options": [
+                "detachedSignedData",
+                "pkcs7DetachedSignedData",
+                "embedded",
+            ],
         }
         signer = {}
         with self.assertRaises(ValueError):

--- a/edk2toolext/tests/test_uefi_build.py
+++ b/edk2toolext/tests/test_uefi_build.py
@@ -20,7 +20,6 @@ from edk2toolext.environment import shell_environment
 
 
 class TestUefiBuild(unittest.TestCase):
-
     def setUp(self):
         self.WORKSPACE = tempfile.mkdtemp()
         TestUefiBuild.create_min_uefi_build_tree(self.WORKSPACE)
@@ -54,16 +53,22 @@ class TestUefiBuild(unittest.TestCase):
         conf_folder = os.path.join(root, "Conf")
         os.makedirs(conf_folder)
         target_path = os.path.join(conf_folder, "target.template")
-        TestUefiBuild.write_to_file(target_path, ["ACTIVE_PLATFORM = Test.dsc\n",
-                                                  "TOOL_CHAIN_TAG = test\n",
-                                                  "TARGET = DEBUG\n"])
+        TestUefiBuild.write_to_file(
+            target_path,
+            [
+                "ACTIVE_PLATFORM = Test.dsc\n",
+                "TOOL_CHAIN_TAG = test\n",
+                "TARGET = DEBUG\n",
+            ],
+        )
         tools_path = os.path.join(conf_folder, "tools_def.template")
         TestUefiBuild.write_to_file(tools_path, ["hello"])
         build_path = os.path.join(conf_folder, "build_rule.template")
         TestUefiBuild.write_to_file(build_path, ["hello"])
         platform_path = os.path.join(root, "Test.dsc")
-        TestUefiBuild.write_to_file(platform_path, ["[Defines]\n",
-                                                    "OUTPUT_DIRECTORY = Build"])
+        TestUefiBuild.write_to_file(
+            platform_path, ["[Defines]\n", "OUTPUT_DIRECTORY = Build"]
+        )
 
     def test_commandline_options(self):
         builder = uefi_build.UefiBuilder()
@@ -77,7 +82,7 @@ class TestUefiBuild(unittest.TestCase):
             ["--UPDATECONF"],
             ["--FLASHONLY"],
             ["--SKIPPREBUILD"],
-            ["--SKIPPOSTBUILD"]
+            ["--SKIPPOSTBUILD"],
         ]
         for argpart in args:
             results = parserObj.parse_args(argpart)
@@ -89,7 +94,9 @@ class TestUefiBuild(unittest.TestCase):
         builder.SkipBuild = True
         builder.SkipBuild = True
         manager = PluginManager()
-        shell_environment.GetBuildVars().SetValue("EDK_TOOLS_PATH", self.WORKSPACE, "empty")
+        shell_environment.GetBuildVars().SetValue(
+            "EDK_TOOLS_PATH", self.WORKSPACE, "empty"
+        )
         helper = uefi_helper_plugin.HelperFunctions()
         ret = builder.Go(self.WORKSPACE, "", helper, manager)
         self.assertEqual(ret, 0)
@@ -103,12 +110,12 @@ class TestUefiBuild(unittest.TestCase):
 
         # Some basic build variables need to be set to make it through
         # the build preamble to the point the wrapper gets called.
-        shell_environment.GetBuildVars().SetValue("TARGET_ARCH",
-                                                  "IA32",
-                                                  "Set in build wrapper test")
-        shell_environment.GetBuildVars().SetValue("EDK_TOOLS_PATH",
-                                                  self.WORKSPACE,
-                                                  "Set in build wrapper test")
+        shell_environment.GetBuildVars().SetValue(
+            "TARGET_ARCH", "IA32", "Set in build wrapper test"
+        )
+        shell_environment.GetBuildVars().SetValue(
+            "EDK_TOOLS_PATH", self.WORKSPACE, "Set in build wrapper test"
+        )
 
         # "build_wrapper" -> The actual build_wrapper script
         # "test_file" -> An empty file written by build_wrapper
@@ -134,20 +141,23 @@ class TestUefiBuild(unittest.TestCase):
         build_wrapper_params = os.path.normpath(build_wrapper_path)
 
         TestUefiBuild.write_to_file(
-            build_wrapper_path,
-            cleandoc(build_wrapper_file_content))
+            build_wrapper_path, cleandoc(build_wrapper_file_content)
+        )
 
         if GetHostInfo().os == "Linux":
-            os.chmod(build_wrapper_path,
-                     os.stat(build_wrapper_path).st_mode | stat.S_IEXEC)
+            os.chmod(
+                build_wrapper_path, os.stat(build_wrapper_path).st_mode | stat.S_IEXEC
+            )
 
         # This is the main point of this test. The wrapper file should be
         # executed instead of the build command. In real scenarios, the wrapper
         # script would subsequently call the build command.
         shell_environment.GetBuildVars().SetValue(
-            "EDK_BUILD_CMD", build_wrapper_cmd, "Set in build wrapper test")
+            "EDK_BUILD_CMD", build_wrapper_cmd, "Set in build wrapper test"
+        )
         shell_environment.GetBuildVars().SetValue(
-            "EDK_BUILD_PARAMS", build_wrapper_params, "Set in build wrapper test")
+            "EDK_BUILD_PARAMS", build_wrapper_params, "Set in build wrapper test"
+        )
 
         manager = PluginManager()
         helper = uefi_helper_plugin.HelperFunctions()
@@ -163,5 +173,5 @@ class TestUefiBuild(unittest.TestCase):
     # TODO finish unit test
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/test_var_dict.py
+++ b/edk2toolext/tests/test_var_dict.py
@@ -102,7 +102,9 @@ class TestVarDict(unittest.TestCase):
     def test_var_dict_build_value_when_type_para_used(self):
         v = var_dict.VarDict()
         v.SetValue("bld_debug_test1", "build_d_value1", "build debug test 1 comment")
-        v.SetValue("bld_release_test1", "build_r_value1", "build release test 1 comment")
+        v.SetValue(
+            "bld_release_test1", "build_r_value1", "build release test 1 comment"
+        )
         ## confirm with correct build type debug
         vv = v.GetBuildValue("TEST1", "DEBUG")
         self.assertEqual("build_d_value1", vv)
@@ -210,5 +212,5 @@ class TestVarDict(unittest.TestCase):
         self.assertTrue(v.GetValue("var2"), "Should return True")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/test_version_aggregator.py
+++ b/edk2toolext/tests/test_version_aggregator.py
@@ -51,12 +51,16 @@ class TestVersionAggregator(unittest.TestCase):
         # we're good to report the same thing twice as long as it matches
         version1.ReportVersion("test", "test", version_aggregator.VersionTypes.TOOL)
         with self.assertRaises(ValueError):
-            version1.ReportVersion("test", "test2", version_aggregator.VersionTypes.INFO)
+            version1.ReportVersion(
+                "test", "test2", version_aggregator.VersionTypes.INFO
+            )
 
     def test_GetInformation(self):
         version1 = version_aggregator.version_aggregator()
         test_ver = ["I think", "I exist"]
-        version1.ReportVersion("I think", "therefore", version_aggregator.VersionTypes.INFO)
+        version1.ReportVersion(
+            "I think", "therefore", version_aggregator.VersionTypes.INFO
+        )
         version1.ReportVersion("I exist", "proof", version_aggregator.VersionTypes.INFO)
         test2_ver = list(version1.GetAggregatedVersionInformation().keys())
         self.assertListEqual(test_ver, test2_ver)
@@ -81,5 +85,5 @@ class TestVersionAggregator(unittest.TestCase):
         self.assertEqual(len(version1.GetAggregatedVersionInformation()), 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/test_versioninfo.py
+++ b/edk2toolext/tests/test_versioninfo.py
@@ -18,10 +18,10 @@ from io import StringIO
 from edk2toolext.versioninfo import versioninfo_tool
 from edk2toollib.utility_functions import RunCmd
 
-DUMMY_EXE_FILE_NAME = 'dummy_exe'
-DUMMY_JSON_FILE_NAME = 'dummy_json_file'
-VERSIONINFO_JSON_FILE_NAME = 'VERSIONINFO'
-BAD_JSON_FILE_NAME = 'bad_json'
+DUMMY_EXE_FILE_NAME = "dummy_exe"
+DUMMY_JSON_FILE_NAME = "dummy_json_file"
+VERSIONINFO_JSON_FILE_NAME = "VERSIONINFO"
+BAD_JSON_FILE_NAME = "bad_json"
 
 DUMMY_VALID_JSON = {
     "Minimal": "False",
@@ -40,17 +40,15 @@ DUMMY_VALID_JSON = {
         "InternalName": "Test Name",
         "LegalCopyright": "(C) 2048 Dummy Driver",
         "OriginalFilename": "Dummy.sys",
-        "ProductName": "Dummy Driver"
+        "ProductName": "Dummy Driver",
     },
-    "VarFileInfo": {
-        "Translation": "0x0409 0x04b0"
-    }
+    "VarFileInfo": {"Translation": "0x0409 0x04b0"},
 }
 
 DUMMY_MINIMAL_JSON = {
     "Fileversion": "1,0,0,0",
     "OriginalFilename": "Test Name",
-    "CompanyName": "Test Company"
+    "CompanyName": "Test Company",
 }
 
 DUMMY_MINIMAL_DECODED = {
@@ -61,13 +59,8 @@ DUMMY_MINIMAL_DECODED = {
     "FileOS": "VOS_UNKNOWN",
     "FileType": "VFT_UNKNOWN",
     "FileSubtype": "VFT2_UNKNOWN",
-    "StringFileInfo": {
-        "CompanyName": "Test Company",
-        "OriginalFilename": "Test Name"
-    },
-    "VarFileInfo": {
-        "Translation": "0x0409 0x04b0"
-    }
+    "StringFileInfo": {"CompanyName": "Test Company", "OriginalFilename": "Test Name"},
+    "VarFileInfo": {"Translation": "0x0409 0x04b0"},
 }
 
 
@@ -79,12 +72,16 @@ def check_for_err_helper(cls, temp_dir, json_input, err_msg, decode=False):
         returned_error = False
 
         if decode:
-            returned_error = not versioninfo_tool.decode_version_info_dump_json(json_input, temp_dir)
+            returned_error = not versioninfo_tool.decode_version_info_dump_json(
+                json_input, temp_dir
+            )
         else:
-            returned_error = not versioninfo_tool.encode_version_info_dump_rc(json_input, temp_dir)
+            returned_error = not versioninfo_tool.encode_version_info_dump_rc(
+                json_input, temp_dir
+            )
 
         logging.getLogger().removeHandler(log_handler)
-        cls.assertFalse(os.path.isfile(os.path.join(temp_dir, 'VERSIONINFO.rc')))
+        cls.assertFalse(os.path.isfile(os.path.join(temp_dir, "VERSIONINFO.rc")))
         cls.assertTrue(err_msg in log_stream.getvalue())
         cls.assertTrue(returned_error)
 
@@ -93,14 +90,14 @@ def compared_decoded_version_info(self, json_file_path, reference):
     try:
         generated_json = open(json_file_path)
         generated_dict = json.load(generated_json)
-        self.assertTrue('Signature' in generated_dict)
-        del generated_dict['Signature']
-        self.assertTrue('StrucVersion' in generated_dict)
-        del generated_dict['StrucVersion']
-        if 'FileDateMS' in generated_dict:
-            del generated_dict['FileDateMS']
-        if 'FileDateLS' in generated_dict:
-            del generated_dict['FileDateLS']
+        self.assertTrue("Signature" in generated_dict)
+        del generated_dict["Signature"]
+        self.assertTrue("StrucVersion" in generated_dict)
+        del generated_dict["StrucVersion"]
+        if "FileDateMS" in generated_dict:
+            del generated_dict["FileDateMS"]
+        if "FileDateLS" in generated_dict:
+            del generated_dict["FileDateLS"]
         ref = copy.deepcopy(reference)
         if "Minimal" in ref:
             del ref["Minimal"]
@@ -112,16 +109,21 @@ def compared_decoded_version_info(self, json_file_path, reference):
 
 
 class TestVersioninfo(unittest.TestCase):
-
     def test_encode_decode_full(self):
         temp_dir = tempfile.mkdtemp()
         # Create the EXE file
-        versioned_exe_path = os.path.join(temp_dir, DUMMY_EXE_FILE_NAME) + '.exe'
-        source_exe_path = os.path.join(os.path.dirname(__file__), "testdata", "versioninfo_full_exe.data")
+        versioned_exe_path = os.path.join(temp_dir, DUMMY_EXE_FILE_NAME) + ".exe"
+        source_exe_path = os.path.join(
+            os.path.dirname(__file__), "testdata", "versioninfo_full_exe.data"
+        )
         shutil.copyfile(source_exe_path, versioned_exe_path)
         # Create the parameters that will go to the service request function
-        version_info_output_path = os.path.join(temp_dir, VERSIONINFO_JSON_FILE_NAME + '.json')
-        versioninfo_tool.decode_version_info_dump_json(versioned_exe_path, version_info_output_path)
+        version_info_output_path = os.path.join(
+            temp_dir, VERSIONINFO_JSON_FILE_NAME + ".json"
+        )
+        versioninfo_tool.decode_version_info_dump_json(
+            versioned_exe_path, version_info_output_path
+        )
 
         # then we compare to make sure it matches what it should be
         compared_decoded_version_info(self, version_info_output_path, DUMMY_VALID_JSON)
@@ -129,15 +131,23 @@ class TestVersioninfo(unittest.TestCase):
     def test_encode_decode_minimal(self):
         temp_dir = tempfile.mkdtemp()
         # Create the EXE file
-        versioned_exe_path = os.path.join(temp_dir, DUMMY_EXE_FILE_NAME) + '.exe'
-        source_exe_path = os.path.join(os.path.dirname(__file__), "testdata", "versioninfo_minimal_exe.data")
+        versioned_exe_path = os.path.join(temp_dir, DUMMY_EXE_FILE_NAME) + ".exe"
+        source_exe_path = os.path.join(
+            os.path.dirname(__file__), "testdata", "versioninfo_minimal_exe.data"
+        )
         shutil.copyfile(source_exe_path, versioned_exe_path)
         # Create the parameters that will go to the service request function
-        version_info_output_path = os.path.join(temp_dir, VERSIONINFO_JSON_FILE_NAME + '.json')
-        versioninfo_tool.decode_version_info_dump_json(versioned_exe_path, version_info_output_path)
+        version_info_output_path = os.path.join(
+            temp_dir, VERSIONINFO_JSON_FILE_NAME + ".json"
+        )
+        versioninfo_tool.decode_version_info_dump_json(
+            versioned_exe_path, version_info_output_path
+        )
 
         # then we compare to make sure it matches what it should be
-        compared_decoded_version_info(self, version_info_output_path, DUMMY_MINIMAL_DECODED)
+        compared_decoded_version_info(
+            self, version_info_output_path, DUMMY_MINIMAL_DECODED
+        )
 
     def test_encode_minimal(self):
         temp_dir = tempfile.mkdtemp()
@@ -150,234 +160,310 @@ class TestVersioninfo(unittest.TestCase):
 
     def test_missing_varinfo(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        del bad_json['VarFileInfo']
-        with open(bad_json_file, 'w') as bad_file:
+        del bad_json["VarFileInfo"]
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Missing required parameter: VARFILEINFO')
+        check_for_err_helper(
+            self, temp_dir, bad_json_file, "Missing required parameter: VARFILEINFO"
+        )
 
     def test_missing_translation(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        del bad_json['VarFileInfo']['Translation']
-        with open(bad_json_file, 'w') as bad_file:
+        del bad_json["VarFileInfo"]["Translation"]
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Missing required parameter in VarFileInfo: Translation')
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            "Missing required parameter in VarFileInfo: Translation",
+        )
 
     def test_invalid_varfileinfo(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['VarFileInfo']['FileVersion'] = "1.2.1.2"
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["VarFileInfo"]["FileVersion"] = "1.2.1.2"
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Invalid VarFileInfo parameter: FileVersion')
+        check_for_err_helper(
+            self, temp_dir, bad_json_file, "Invalid VarFileInfo parameter: FileVersion"
+        )
 
     def test_missing_companyname(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        del bad_json['StringFileInfo']['CompanyName']
-        with open(bad_json_file, 'w') as bad_file:
+        del bad_json["StringFileInfo"]["CompanyName"]
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Missing required StringFileInfo parameter: CompanyName')
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            "Missing required StringFileInfo parameter: CompanyName",
+        )
 
     def test_version_overflow(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['ProductVersion'] = '65536.0.0.0'
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["ProductVersion"] = "65536.0.0.0"
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Integer overflow in version string')
+        check_for_err_helper(
+            self, temp_dir, bad_json_file, "Integer overflow in version string"
+        )
 
     def test_invalid_version(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['ProductVersion'] = 'Version 1.0.1.0'
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["ProductVersion"] = "Version 1.0.1.0"
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Version must be in form " INTEGER.INTEGER.INTEGER.INTEGER"')  # noqa
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            'Version must be in form " INTEGER.INTEGER.INTEGER.INTEGER"',
+        )  # noqa
 
     def test_bad_version_format(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['ProductVersion'] = '1.234'
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["ProductVersion"] = "1.234"
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Version must be in form "INTEGER.INTEGER.INTEGER.INTEGER"')  # noqa
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            'Version must be in form "INTEGER.INTEGER.INTEGER.INTEGER"',
+        )  # noqa
 
     def test_invalid_language_code_value(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['VarFileInfo']['Translation'] = '"0x0009 0x04b0"'
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["VarFileInfo"]["Translation"] = '"0x0009 0x04b0"'
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file,
-                             f"Invalid language code: {bad_json['VarFileInfo']['Translation']}")
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            f"Invalid language code: {bad_json['VarFileInfo']['Translation']}",
+        )
 
     def test_invalid_language_code_string(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['VarFileInfo']['Translation'] = '"utf-8 US"'
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["VarFileInfo"]["Translation"] = '"utf-8 US"'
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file,
-                             f"Invalid language code: {bad_json['VarFileInfo']['Translation']}")
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            f"Invalid language code: {bad_json['VarFileInfo']['Translation']}",
+        )
 
     def test_invalid_language_code_format(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['VarFileInfo']['Translation'] = '"0x400904b0"'
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["VarFileInfo"]["Translation"] = '"0x400904b0"'
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Translation field must contain 2 space delimited hexidecimal bytes')  # noqa
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            "Translation field must contain 2 space delimited hexidecimal bytes",
+        )  # noqa
 
     def test_invalid_language_code_no_hex(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['VarFileInfo']['Translation'] = '"4009 04b0"'
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["VarFileInfo"]["Translation"] = '"4009 04b0"'
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Invalid language code: '
-                             + bad_json['VarFileInfo']['Translation'])
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            "Invalid language code: " + bad_json["VarFileInfo"]["Translation"],
+        )
 
     def test_invalid_fileos_hex(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['FileOS'] = '0x12391'
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["FileOS"] = "0x12391"
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Invalid FILEOS value: ' + bad_json['FileOS'])
+        check_for_err_helper(
+            self, temp_dir, bad_json_file, "Invalid FILEOS value: " + bad_json["FileOS"]
+        )
 
     def test_invalid_fileos_string(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['FileOS'] = 'INVALID'
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["FileOS"] = "INVALID"
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Invalid FILEOS value: ' + bad_json['FileOS'])
+        check_for_err_helper(
+            self, temp_dir, bad_json_file, "Invalid FILEOS value: " + bad_json["FileOS"]
+        )
 
     def test_invalid_filetype_hex(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['FileType'] = '0x12391'
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["FileType"] = "0x12391"
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Invalid FILESUBTYPE value for FILETYPE ' + bad_json['FileType'])  # noqa
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            "Invalid FILESUBTYPE value for FILETYPE " + bad_json["FileType"],
+        )  # noqa
 
     def test_invalid_filetype_string(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['FileType'] = 'INVALID'
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["FileType"] = "INVALID"
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Invalid FILESUBTYPE value for FILETYPE ' + bad_json['FileType'])  # noqa
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            "Invalid FILESUBTYPE value for FILETYPE " + bad_json["FileType"],
+        )  # noqa
 
     def test_invalid_filesubtype_drv(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['FileType'] = 'VFT_DRV'
-        bad_json['FileSubtype'] = 'VFT2_FONT_RASTER'
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["FileType"] = "VFT_DRV"
+        bad_json["FileSubtype"] = "VFT2_FONT_RASTER"
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Invalid FILESUBTYPE value for FILETYPE VFT_DRV: VFT2_FONT_RASTER')  # noqa
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            "Invalid FILESUBTYPE value for FILETYPE VFT_DRV: VFT2_FONT_RASTER",
+        )  # noqa
 
     def test_invalid_filesubtype_font(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        bad_json['FileType'] = 'VFT_FONT'
-        bad_json['FileSubtype'] = 'VFT2_DRV_SOUND'
-        with open(bad_json_file, 'w') as bad_file:
+        bad_json["FileType"] = "VFT_FONT"
+        bad_json["FileSubtype"] = "VFT2_DRV_SOUND"
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Invalid FILESUBTYPE value for FILETYPE VFT_FONT: VFT2_DRV_SOUND')  # noqa
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            "Invalid FILESUBTYPE value for FILETYPE VFT_FONT: VFT2_DRV_SOUND",
+        )  # noqa
 
     def test_missing_filetype(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        del bad_json['FileType']
-        with open(bad_json_file, 'w') as bad_file:
+        del bad_json["FileType"]
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file,
-                             'Missing parameter: must have FileType if FileSubtype defined')
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            "Missing parameter: must have FileType if FileSubtype defined",
+        )
 
     def test_no_stringinfo_header(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = copy.deepcopy(DUMMY_VALID_JSON)
-        err_str = ''
-        for key in bad_json['StringFileInfo']:
-            if key == 'FileVersion':
+        err_str = ""
+        for key in bad_json["StringFileInfo"]:
+            if key == "FileVersion":
                 continue
 
-            bad_json[key] = bad_json['StringFileInfo'][key]
-            err_str += 'Invalid parameter: ' + key.upper() + '.\n'
+            bad_json[key] = bad_json["StringFileInfo"][key]
+            err_str += "Invalid parameter: " + key.upper() + ".\n"
 
-        del bad_json['StringFileInfo']
-        err_str += 'Missing required parameter: STRINGFILEINFO'
-        with open(bad_json_file, 'w') as bad_file:
+        del bad_json["StringFileInfo"]
+        err_str += "Missing required parameter: STRINGFILEINFO"
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
         check_for_err_helper(self, temp_dir, bad_json_file, err_str)
 
     def test_bad_input_path(self):
-        ''' check to make sure we throw an exception '''
+        """check to make sure we throw an exception"""
         try:
-            check_for_err_helper(self, ".", "bad/path/to/file.json", "Could not find bad/path/to/file.json\n")
+            check_for_err_helper(
+                self,
+                ".",
+                "bad/path/to/file.json",
+                "Could not find bad/path/to/file.json\n",
+            )
             self.fail("We shouldn't have found the file")
         except FileNotFoundError:
             pass
 
     def test_command_line_interface(self):
-        ''' makes sure the command line interface is working correctly '''
-        ret = RunCmd('versioninfo_tool', '-h', logging_level=logging.ERROR)
+        """makes sure the command line interface is working correctly"""
+        ret = RunCmd("versioninfo_tool", "-h", logging_level=logging.ERROR)
         self.assertEqual(ret, 0)
 
     def test_non_pe_file(self):
         temp_dir = tempfile.mkdtemp()
-        bad_pe = os.path.join(temp_dir, DUMMY_JSON_FILE_NAME + '.bad')
+        bad_pe = os.path.join(temp_dir, DUMMY_JSON_FILE_NAME + ".bad")
 
-        with open(bad_pe, 'w') as bad_file:
+        with open(bad_pe, "w") as bad_file:
             json.dump(DUMMY_VALID_JSON, bad_file)
 
         check_for_err_helper(self, temp_dir, bad_pe, "DOS Header magic not found", True)
 
     def test_invalid_json_format1(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = """
             "FileVersion": "1.2.3.4",
             "ProductVersion": "1.2.3.4",
@@ -401,14 +487,16 @@ class TestVersioninfo(unittest.TestCase):
             }
         """
 
-        with open(bad_json_file, 'w') as bad_file:
+        with open(bad_json_file, "w") as bad_file:
             bad_file.write(bad_json)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, "Invalid JSON format, Extra data")
+        check_for_err_helper(
+            self, temp_dir, bad_json_file, "Invalid JSON format, Extra data"
+        )
 
     def test_invalid_json_format2(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = """ {
             FileVersion: 1.2.3.4,
             ProductVersion: 1.2.3.4,
@@ -433,14 +521,19 @@ class TestVersioninfo(unittest.TestCase):
         }
         """
 
-        with open(bad_json_file, 'w') as bad_file:
+        with open(bad_json_file, "w") as bad_file:
             bad_file.write(bad_json)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, "Invalid JSON format, Expecting property name enclosed in double quotes")  # noqa
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            "Invalid JSON format, Expecting property name enclosed in double quotes",
+        )  # noqa
 
     def test_invalid_json_format3(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = """ {
             "FileVersion": "1.2.3.4",
             "ProductVersion": "1.2.3.4",
@@ -465,35 +558,47 @@ class TestVersioninfo(unittest.TestCase):
         }
         """
 
-        with open(bad_json_file, 'w') as bad_file:
+        with open(bad_json_file, "w") as bad_file:
             bad_file.write(bad_json)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, "Invalid JSON format, Expecting ',' delimiter")  # noqa
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            "Invalid JSON format, Expecting ',' delimiter",
+        )  # noqa
 
     def test_invalid_minimal_fields(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = {
             "Minimal": "True",
             "FileVersion": "1.2.3.4",
             "CompanyName": "Test Company",
             "FileType": "VFT_DRV",
         }
-        with open(bad_json_file, 'w') as bad_file:
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, 'Invalid minimal parameter: FILETYPE')
+        check_for_err_helper(
+            self, temp_dir, bad_json_file, "Invalid minimal parameter: FILETYPE"
+        )
 
     def test_invalid_minimal_value(self):
         temp_dir = tempfile.mkdtemp()
-        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + '.json')
+        bad_json_file = os.path.join(temp_dir, BAD_JSON_FILE_NAME + ".json")
         bad_json = {
             "Minimal": "Yes",
             "FileVersion": "1.2.3.4",
             "CompanyName": "Test Company",
             "FileType": "VFT_DRV",
         }
-        with open(bad_json_file, 'w') as bad_file:
+        with open(bad_json_file, "w") as bad_file:
             json.dump(bad_json, bad_file)
 
-        check_for_err_helper(self, temp_dir, bad_json_file, "Invalid value for 'Minimal', must be boolean.")
+        check_for_err_helper(
+            self,
+            temp_dir,
+            bad_json_file,
+            "Invalid value for 'Minimal', must be boolean.",
+        )

--- a/edk2toolext/tests/test_web_dependency.py
+++ b/edk2toolext/tests/test_web_dependency.py
@@ -20,7 +20,7 @@ from edk2toolext.environment import environment_descriptor_files as EDF
 from edk2toolext.environment.extdeptypes.web_dependency import WebDependency
 
 test_dir = None
-bad_json_file = '''
+bad_json_file = """
 {
   "scope": "global",
   "type": "web",
@@ -32,7 +32,7 @@ bad_json_file = '''
   "compression_type":"tar",
   "sha256":"68f2335344c3f7689f8d69125d182404a3515b8daa53a9c330f115739889f998"
 }
-'''
+"""
 # JSON file that describes a single file to download from the internet
 # bing.com was choosen as it's probably not going anywhere soon and it's small file to download
 single_file_extdep = {
@@ -42,7 +42,7 @@ single_file_extdep = {
     "source": "https://www.bing.com/",
     "version": "20190805",
     "flags": [],
-    "internal_path": "test.txt"
+    "internal_path": "test.txt",
 }
 # Use the github release
 zip_directory_extdep = {
@@ -53,7 +53,7 @@ zip_directory_extdep = {
     "source": "https://github.com/lexxmark/winflexbison/releases/download/v2.4.7/win_flex_bison-2.4.7.zip",
     "version": "2.4.7",
     "sha256": "7553a2d6738c799e101ec38a6ad073885ead892826f87bc1a24e78bcd7ac2a8c",
-    "internal_path": "/."
+    "internal_path": "/.",
 }
 # Use the GNU FTP
 tar_directory_extdep = {
@@ -75,7 +75,7 @@ jquery_json_file = {
     "version": "3.4.1",
     "flags": [],
     "sha256": "5A93A88493AA32AAB228BF4571C01207D3B42B0002409A454D404B4D8395BD55",
-    "internal_path": "jquery.js"
+    "internal_path": "jquery.js",
 }
 
 
@@ -106,7 +106,7 @@ class TestWebDependency(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        logger = logging.getLogger('')
+        logger = logging.getLogger("")
         logger.addHandler(logging.NullHandler())
         unittest.installHandler()
 
@@ -120,7 +120,9 @@ class TestWebDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(bad_json_file)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = WebDependency(ext_dep_descriptor)
         with self.assertRaises(urllib.error.HTTPError):
             ext_dep.fetch()
@@ -132,12 +134,16 @@ class TestWebDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(json.dumps(single_file_extdep))  # dump to a file
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = WebDependency(ext_dep_descriptor)
         ext_dep.fetch()
 
-        ext_dep_name = single_file_extdep['name'] + "_extdep"
-        file_path = os.path.join(test_dir, ext_dep_name, single_file_extdep['internal_path'])
+        ext_dep_name = single_file_extdep["name"] + "_extdep"
+        file_path = os.path.join(
+            test_dir, ext_dep_name, single_file_extdep["internal_path"]
+        )
         if not os.path.isfile(file_path):
             self.fail("The downloaded file isn't there")
 
@@ -148,11 +154,13 @@ class TestWebDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(json.dumps(zip_directory_extdep))  # dump to a file
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = WebDependency(ext_dep_descriptor)
         ext_dep.fetch()
 
-        ext_dep_name = zip_directory_extdep['name'] + "_extdep"
+        ext_dep_name = zip_directory_extdep["name"] + "_extdep"
         folder_path = os.path.join(test_dir, ext_dep_name)
         if not os.path.exists(os.path.join(folder_path, "README.txt")):
             logging.warning(folder_path)
@@ -165,11 +173,13 @@ class TestWebDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(json.dumps(tar_directory_extdep))  # dump to a file
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = WebDependency(ext_dep_descriptor)
         ext_dep.fetch()
 
-        ext_dep_name = tar_directory_extdep['name'] + "_extdep"
+        ext_dep_name = tar_directory_extdep["name"] + "_extdep"
         folder_path = os.path.join(test_dir, ext_dep_name)
         if not os.path.exists(os.path.join(folder_path, "README")):
             logging.warning(folder_path)
@@ -185,12 +195,14 @@ class TestWebDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(json.dumps(jquery_json))  # dump to a file
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = WebDependency(ext_dep_descriptor)
         ext_dep.fetch()
 
-        ext_dep_name = jquery_json['name'] + "_extdep"
-        file_path = os.path.join(test_dir, ext_dep_name, jquery_json['internal_path'])
+        ext_dep_name = jquery_json["name"] + "_extdep"
+        file_path = os.path.join(test_dir, ext_dep_name, jquery_json["internal_path"])
         if not os.path.isfile(file_path):
             self.fail("The downloaded file isn't there")
 
@@ -202,12 +214,14 @@ class TestWebDependency(unittest.TestCase):
         with open(ext_dep_file_path, "w+") as ext_dep_file:
             ext_dep_file.write(json.dumps(jquery_json))  # dump to a file
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+        ext_dep_descriptor = EDF.ExternDepDescriptor(
+            ext_dep_file_path
+        ).descriptor_contents
         ext_dep = WebDependency(ext_dep_descriptor)
         ext_dep.fetch()
 
-        ext_dep_name = jquery_json['name'] + "_extdep"
-        file_path = os.path.join(test_dir, ext_dep_name, jquery_json['internal_path'])
+        ext_dep_name = jquery_json["name"] + "_extdep"
+        file_path = os.path.join(test_dir, ext_dep_name, jquery_json["internal_path"])
         if not os.path.isfile(file_path):
             self.fail("The downloaded file isn't there")
 
@@ -223,13 +237,15 @@ class TestWebDependency(unittest.TestCase):
         with open(file_path, "w+") as ext_dep_file:
             ext_dep_file.write(bad_json_file)
 
-        with zipfile.ZipFile(compressed_file_path, 'w') as _zip:
+        with zipfile.ZipFile(compressed_file_path, "w") as _zip:
             _zip.write(file_path, arcname=os.path.basename(file_path))
 
         os.remove(file_path)
         self.assertFalse(os.path.isfile(file_path))
 
-        WebDependency.unpack(compressed_file_path, destination, internal_path, compression_type)
+        WebDependency.unpack(
+            compressed_file_path, destination, internal_path, compression_type
+        )
         self.assertTrue(os.path.isfile(file_path))
 
     # Test that a single file tar volume is able to be processed by unpack.
@@ -250,7 +266,9 @@ class TestWebDependency(unittest.TestCase):
         os.remove(file_path)
         self.assertFalse(os.path.isfile(file_path))
 
-        WebDependency.unpack(compressed_file_path, destination, internal_path, compression_type)
+        WebDependency.unpack(
+            compressed_file_path, destination, internal_path, compression_type
+        )
         self.assertTrue(os.path.isfile(file_path))
 
     # Test that a zipped directory is processed correctly by unpack.
@@ -258,7 +276,6 @@ class TestWebDependency(unittest.TestCase):
     # Files in test_dir\first_dir\second_dir should be located.
     # Files in test_dir\first_dir should not be unpacked.
     def test_unpack_zip_directory(self):
-
         first_level_dir_name = "first_dir"
         second_level_dir_name = "second_dir"
         first_level_path = os.path.join(test_dir, first_level_dir_name)
@@ -272,21 +289,25 @@ class TestWebDependency(unittest.TestCase):
 
         # only files inside internal_path should be there after unpack
         # (file path, is this file expected to be unpacked?)
-        test_files = [(os.path.join(test_dir, internal_path, "bad_json_file.json"), True),
-                      (os.path.join(test_dir, first_level_dir_name, "json_file.json"), False)]
+        test_files = [
+            (os.path.join(test_dir, internal_path, "bad_json_file.json"), True),
+            (os.path.join(test_dir, first_level_dir_name, "json_file.json"), False),
+        ]
 
         for test_file in test_files:
             with open(test_file[0], "w+") as ext_dep_file:
                 ext_dep_file.write(bad_json_file)
 
-        with zipfile.ZipFile(compressed_file_path, 'w') as _zip:
+        with zipfile.ZipFile(compressed_file_path, "w") as _zip:
             for test_file in test_files:
                 _zip.write(test_file[0], arcname=test_file[0].split(test_dir)[1])
 
         shutil.rmtree(first_level_path)
         self.assertFalse(os.path.isdir(first_level_path))
 
-        WebDependency.unpack(compressed_file_path, destination, internal_path, compression_type)
+        WebDependency.unpack(
+            compressed_file_path, destination, internal_path, compression_type
+        )
 
         for test_file in test_files:
             if test_file[1]:
@@ -312,8 +333,10 @@ class TestWebDependency(unittest.TestCase):
 
         # only files inside internal_path should be there after unpack
         # (file path, is this file expected to be unpacked?)
-        test_files = [(os.path.join(test_dir, internal_path, "bad_json_file.json"), True),
-                      (os.path.join(test_dir, first_level_dir_name, "json_file.json"), False)]
+        test_files = [
+            (os.path.join(test_dir, internal_path, "bad_json_file.json"), True),
+            (os.path.join(test_dir, first_level_dir_name, "json_file.json"), False),
+        ]
 
         for test_file in test_files:
             with open(test_file[0], "w+") as ext_dep_file:
@@ -326,7 +349,9 @@ class TestWebDependency(unittest.TestCase):
         shutil.rmtree(first_level_path)
         self.assertFalse(os.path.isdir(first_level_path))
 
-        WebDependency.unpack(compressed_file_path, destination, internal_path, compression_type)
+        WebDependency.unpack(
+            compressed_file_path, destination, internal_path, compression_type
+        )
 
         for test_file in test_files:
             if test_file[1]:
@@ -353,7 +378,7 @@ class TestWebDependency(unittest.TestCase):
         #           >>> testtesttest/
         #            >>>> testtesttesttest/
         for i in range(1, number_of_layers):
-            internal_path = (directory_name * i)
+            internal_path = directory_name * i
             if i - 1 > 0:
                 internal_path = os.path.join(internal_paths[i - 1], internal_path)
             internal_paths.insert(i, internal_path)
@@ -370,8 +395,14 @@ class TestWebDependency(unittest.TestCase):
             # create files in each folder
             files = [""]
             for file_list_counter in range(1, number_of_layers):
-                files.insert(file_list_counter,
-                             os.path.join(test_dir, internal_paths[file_list_counter], file_name * file_list_counter))
+                files.insert(
+                    file_list_counter,
+                    os.path.join(
+                        test_dir,
+                        internal_paths[file_list_counter],
+                        file_name * file_list_counter,
+                    ),
+                )
                 with open(files[file_list_counter], "w+") as ext_dep_file:
                     ext_dep_file.write(bad_json_file)
 
@@ -386,7 +417,9 @@ class TestWebDependency(unittest.TestCase):
             # The internal path moves down the directory structure each iteration
             internal_path = internal_paths[internal_path_level]
 
-            WebDependency.unpack(compressed_file_path, destination, internal_path, compression_type)
+            WebDependency.unpack(
+                compressed_file_path, destination, internal_path, compression_type
+            )
 
             # the file should be unpacked if file_list_counter >= internal_path_level
             for file_list_counter in range(1, number_of_layers):
@@ -417,10 +450,10 @@ class TestWebDependency(unittest.TestCase):
         with open(test_file, "w+") as ext_dep_file:
             ext_dep_file.write(bad_json_file)
 
-        with zipfile.ZipFile(compressed_file_path, 'w') as _zip:
+        with zipfile.ZipFile(compressed_file_path, "w") as _zip:
             _zip.write(test_file, arcname=test_file.split(test_dir)[1])
 
-        with zipfile.ZipFile(compressed_file_path, 'r') as _zip:
+        with zipfile.ZipFile(compressed_file_path, "r") as _zip:
             namelist = _zip.namelist()
 
         self.assertTrue(len(namelist) == 1)
@@ -457,5 +490,5 @@ class TestWebDependency(unittest.TestCase):
         self.assertTrue(WebDependency.linuxize_path(internal_path_win) in namelist[0])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/edk2toolext/tests/uefi_tree.py
+++ b/edk2toolext/tests/uefi_tree.py
@@ -31,7 +31,7 @@ class uefi_tree:
         if workspace is None:
             workspace = os.path.abspath(tempfile.mkdtemp())
         self.workspace = workspace
-        if (create_platform):
+        if create_platform:
             self._create_tree()
         if with_repo:
             self._create_repo()
@@ -50,12 +50,12 @@ class uefi_tree:
 
     def _create_repo(self):
         repo = git.Repo.init(self.workspace)
-        repo.create_remote('origin', 'https://github.com/username/repo.git')
-        repo.git.config('--global', 'user.email', '"johndoe@example.com"')
-        repo.git.config('--global', 'user.name', '"John Doe"')
-        repo.git.checkout('-b', "master")
-        repo.git.add('.')
-        repo.git.commit('-m', '"Initial commit"')
+        repo.create_remote("origin", "https://github.com/username/repo.git")
+        repo.git.config("--global", "user.email", '"johndoe@example.com"')
+        repo.git.config("--global", "user.name", '"John Doe"')
+        repo.git.checkout("-b", "master")
+        repo.git.add(".")
+        repo.git.commit("-m", '"Initial commit"')
 
     def _create_tree(self):
         """Creates a settings.py, test.dsc, Conf folder (with build_rule, target, and tools_def)."""
@@ -91,7 +91,15 @@ class uefi_tree:
             return os.path.abspath(optional_path)
         raise ValueError(f"Optional file not found {file}")
 
-    def create_path_env(self, id=None, flags=[], var_name=None, scope="global", dir_path="", extra_data=None):
+    def create_path_env(
+        self,
+        id=None,
+        flags=[],
+        var_name=None,
+        scope="global",
+        dir_path="",
+        extra_data=None,
+    ):
         """Creates an ext dep in your workspace."""
         data = {
             "scope": scope,
@@ -117,7 +125,16 @@ class uefi_tree:
         """Creates an Edk2TestUpdate ext dep in your workspace."""
         self.create_ext_dep("nuget", "Edk2TestUpdate", version, extra_data=extra_data)
 
-    def create_ext_dep(self, dep_type, name, version, source=None, scope="global", dir_path="", extra_data=None):
+    def create_ext_dep(
+        self,
+        dep_type,
+        name,
+        version,
+        source=None,
+        scope="global",
+        dir_path="",
+        extra_data=None,
+    ):
         """Creates an ext dep in your workspace."""
         dep_type = dep_type.lower()
         if source is None and dep_type == "nuget":
@@ -130,7 +147,7 @@ class uefi_tree:
             "name": name,
             "version": version,
             "source": source,
-            "flags": []
+            "flags": [],
         }
         if extra_data is not None:
             data.update(extra_data)
@@ -144,7 +161,7 @@ class uefi_tree:
         uefi_tree.write_to_file(output_path, text)
         return output_path
 
-    _settings_file_text = '''
+    _settings_file_text = """
 # @file settings.py
 # This contains a settingsmanger for testing
 ##
@@ -205,16 +222,16 @@ class TestBuilder(UefiBuilder):
     def SetPlatformEnv(self):
         self.env.SetValue("EDK2_BASE_TOOLS_DIR", self.ws, "empty")
         return 0
-    '''
+    """
 
-    _dsc_file_text = '''
+    _dsc_file_text = """
 [Defines]
 OUTPUT_DIRECTORY = Build
-    '''
+    """
 
-    _target_file_text = '''
+    _target_file_text = """
 ACTIVE_PLATFORM = Test.dsc
 TOOL_CHAIN_TAG = test
 TARGET_ARCH = X64
 TARGET = DEBUG
-    '''
+    """

--- a/edk2toolext/uefi/sig_db_tool.py
+++ b/edk2toolext/uefi/sig_db_tool.py
@@ -17,7 +17,9 @@ It can dump the database as-is, or a sorted & deduplicated canonical form, or ju
 """
 
 import argparse
-from edk2toollib.uefi.authenticated_variables_structure_support import EfiSignatureDatabase
+from edk2toollib.uefi.authenticated_variables_structure_support import (
+    EfiSignatureDatabase,
+)
 
 
 def main():
@@ -26,10 +28,10 @@ def main():
     Parses command-line parameters using ArgumentParser delegating to helper
     functions to fulfill the requests.
     """
-    filenameHelp = 'Filename containing a UEFI Signature Database, \
-        a concatenation of EFI_SIGNATURE_LISTs as read from GetVariable([PK, KEK, db, dbx])'
+    filenameHelp = "Filename containing a UEFI Signature Database, \
+        a concatenation of EFI_SIGNATURE_LISTs as read from GetVariable([PK, KEK, db, dbx])"
 
-    sig_db_examples = '''
+    sig_db_examples = """
 examples:
 
 sig_db dump dbx_before.bin
@@ -39,30 +41,50 @@ sig_db --compact dump dbx_after.bin
 sig_db --compact get_dupes dbx_with_dupes.bin
 
 sig_db --compact get_canonical mixed_up_dbx.bin
-'''
+"""
 
-    parser = argparse.ArgumentParser(description='UEFI Signature database inspection tool',
-                                     formatter_class=argparse.RawDescriptionHelpFormatter,
-                                     epilog=sig_db_examples)
+    parser = argparse.ArgumentParser(
+        description="UEFI Signature database inspection tool",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=sig_db_examples,
+    )
 
-    parser.add_argument('--compact', action='store_true',
-                        help='Compact, 1 line per data element output for easier diff-ing')
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Compact, 1 line per data element output for easier diff-ing",
+    )
 
-    subparsers = parser.add_subparsers(required=False, dest='action')
+    subparsers = parser.add_subparsers(required=False, dest="action")
 
-    parser_dump = subparsers.add_parser('dump', help='Print a UEFI Signature Database as-is in human-readable form')
-    parser_dump.add_argument('file', type=str, help=filenameHelp)
+    parser_dump = subparsers.add_parser(
+        "dump", help="Print a UEFI Signature Database as-is in human-readable form"
+    )
+    parser_dump.add_argument("file", type=str, help=filenameHelp)
 
-    parser_get_dupes = subparsers.add_parser('get_dupes', help='Find duplicate signature entries in a UEFI Signature \
+    parser_get_dupes = subparsers.add_parser(
+        "get_dupes",
+        help="Find duplicate signature entries in a UEFI Signature \
         Database. The test for duplication ignores SignatureOwner, testing only the SignatureData field. \
-        Print them in UEFI Signature Database format, ordering is NOT maintained, output is NOT itself deduplicated')
-    parser_get_dupes.add_argument('file', type=str, help='Filename of a UEFI Signature Database \
-        (concatenation of EFI_SIGNATURE_LISTs as read from GetVariable() )')
+        Print them in UEFI Signature Database format, ordering is NOT maintained, output is NOT itself deduplicated",
+    )
+    parser_get_dupes.add_argument(
+        "file",
+        type=str,
+        help="Filename of a UEFI Signature Database \
+        (concatenation of EFI_SIGNATURE_LISTs as read from GetVariable() )",
+    )
 
-    parser_get_canonical = subparsers.add_parser('get_canonical', help='Reduce a UEFI Signature Database to a \
-        canonical (de-duplicated, sorted) form and print it')
-    parser_get_canonical.add_argument('file', type=str,
-                                      help='The name of the UEFI Signature Database file to get_canonical')
+    parser_get_canonical = subparsers.add_parser(
+        "get_canonical",
+        help="Reduce a UEFI Signature Database to a \
+        canonical (de-duplicated, sorted) form and print it",
+    )
+    parser_get_canonical.add_argument(
+        "file",
+        type=str,
+        help="The name of the UEFI Signature Database file to get_canonical",
+    )
 
     options = parser.parse_args()
 
@@ -71,11 +93,11 @@ sig_db --compact get_canonical mixed_up_dbx.bin
         return
 
     try:
-        with open(options.file, 'rb') as f:
+        with open(options.file, "rb") as f:
             esd = EfiSignatureDatabase(f)
-            if (options.action == 'get_dupes'):
+            if options.action == "get_dupes":
                 esd = esd.GetDuplicates()
-            elif (options.action == 'get_canonical'):
+            elif options.action == "get_canonical":
                 esd = esd.GetCanonical()
 
             esd.Print(compact=options.compact)
@@ -84,5 +106,5 @@ sig_db --compact get_canonical mixed_up_dbx.bin
         print('ERROR:  File not found: "{0}"'.format(options.file))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/edk2toolext/versioninfo/versioninfo_helper.py
+++ b/edk2toolext/versioninfo/versioninfo_helper.py
@@ -44,7 +44,7 @@ class PEStrings(object):
         0x00010004: "VOS_DOS_WINDOWS32",
         0x00040004: "VOS_NT_WINDOWS32",
         0x00020002: "VOS_OS216_PM16",
-        0x00030003: "VOS_OS232_PM32"
+        0x00030003: "VOS_OS232_PM32",
     }
 
     FILE_TYPE_STRINGS = {
@@ -54,7 +54,7 @@ class PEStrings(object):
         0x00000004: "VFT_FONT",
         0x00000007: "VFT_STATIC_LIB",
         0x00000000: "VFT_UNKNOWN",
-        0x00000005: "VFT_VXD"
+        0x00000005: "VFT_VXD",
     }
 
     FILE_SUBTYPE_NOFONT_STRINGS = {
@@ -69,17 +69,17 @@ class PEStrings(object):
         0x00000009: "VFT2_DRV_SOUND",
         0x00000007: "VFT2_DRV_SYSTEM",
         0x0000000C: "VFT2_DRV_VERSIONED_PRINTER",
-        0x00000000: "VFT2_UNKNOWN"
+        0x00000000: "VFT2_UNKNOWN",
     }
 
     FILE_SUBTYPE_FONT_STRINGS = {
         0x00000001: "VFT2_FONT_RASTER",
         0x00000003: "VFT2_FONT_TRUETYPE",
         0x00000002: "VFT2_FONT_VECTOR",
-        0x00000000: "VFT2_UNKNOWN"
+        0x00000000: "VFT2_UNKNOWN",
     }
 
-    VALID_SIGNATURE = 0xfeef04bd
+    VALID_SIGNATURE = 0xFEEF04BD
     DEFAULT_TRANSLATION = "0x0409,0x04b0"
     DEFAULT_BLOCK_HEADER = "040904b0"
 
@@ -130,7 +130,7 @@ class PEStrings(object):
     VERSIONFILE_REQUIRED_FIELDS = {
         FILE_VERSION_STR,
         STRING_FILE_INFO_STR,
-        VAR_FILE_INFO_STR
+        VAR_FILE_INFO_STR,
     }
 
     VERSIONFILE_ALLOWED_FIELDS = {
@@ -147,7 +147,7 @@ class PEStrings(object):
         STRUC_VERSION_STR,
         FILE_DATE_STR,
         FILE_DATE_MS_STR,
-        FILE_DATE_LS_STR
+        FILE_DATE_LS_STR,
     }
 
     COMPANY_NAME_STR = "CompanyName"
@@ -172,7 +172,7 @@ class PEStrings(object):
         "PrivateBuild",
         "ProductName",
         "ProductVersion",
-        "SpecialBuild"
+        "SpecialBuild",
     }
 
     VALID_FILE_OS_VALUES = {
@@ -183,7 +183,7 @@ class PEStrings(object):
         "VOS__WINDOWS32",
         "VOS_DOS_WINDOWS16",
         "VOS_DOS_WINDOWS32",
-        "VOS_NT_WINDOWS32"
+        "VOS_NT_WINDOWS32",
     }
 
     VALID_FILE_TYPE_VALUES = {
@@ -193,7 +193,7 @@ class PEStrings(object):
         "VFT_FONT",
         "VFT_STATIC_LIB",
         "VFT_UNKNOWN",
-        "VFT_VXD"
+        "VFT_VXD",
     }
 
     VALID_SUBTYPE_VFT_DRV = {
@@ -208,49 +208,77 @@ class PEStrings(object):
         "VFT2_DRV_SYSTEM",
         "VFT2_DRV_INSTALLABLE",
         "VFT2_DRV_SOUND",
-        "VFT2_DRV_VERSIONED_PRINTER"
+        "VFT2_DRV_VERSIONED_PRINTER",
     }
 
     VALID_SUBTYPE_VFT_FONT = {
         "VFT2_UNKNOWN",
         "VFT2_FONT_RASTER",
         "VFT2_FONT_VECTOR",
-        "VFT2_FONT_TRUETYPE"
+        "VFT2_FONT_TRUETYPE",
     }
 
     VALID_LANG_ID = {
-        0x0401, 0x0402,
-        0x0403, 0x0404,
-        0x0405, 0x0406,
-        0x0407, 0x0408,
-        0x0409, 0x040A,
-        0x040B, 0x040C,
-        0x040D, 0x040E,
-        0x040F, 0x0410,
-        0x0411, 0x0412,
-        0x0413, 0x0414,
-        0x0415, 0x0416,
-        0x0417, 0x0418,
-        0x0419, 0x041A,
-        0x041B, 0x041C,
-        0x041D, 0x041E,
-        0x041F, 0x0420,
-        0x0421, 0x0804,
-        0x0807, 0x0809,
-        0x080A, 0x080C,
-        0x0C0C, 0x100C,
-        0x0816, 0x081A,
-        0x0810, 0x0813,
-        0x0814
+        0x0401,
+        0x0402,
+        0x0403,
+        0x0404,
+        0x0405,
+        0x0406,
+        0x0407,
+        0x0408,
+        0x0409,
+        0x040A,
+        0x040B,
+        0x040C,
+        0x040D,
+        0x040E,
+        0x040F,
+        0x0410,
+        0x0411,
+        0x0412,
+        0x0413,
+        0x0414,
+        0x0415,
+        0x0416,
+        0x0417,
+        0x0418,
+        0x0419,
+        0x041A,
+        0x041B,
+        0x041C,
+        0x041D,
+        0x041E,
+        0x041F,
+        0x0420,
+        0x0421,
+        0x0804,
+        0x0807,
+        0x0809,
+        0x080A,
+        0x080C,
+        0x0C0C,
+        0x100C,
+        0x0816,
+        0x081A,
+        0x0810,
+        0x0813,
+        0x0814,
     }
 
     VALID_CHARSET_ID = {
-        0x0000, 0x03A4,
-        0x03B5, 0x03B6,
-        0x04B0, 0x04E2,
-        0x04E3, 0x04E4,
-        0x04E5, 0x04E6,
-        0x04E7, 0x04E8
+        0x0000,
+        0x03A4,
+        0x03B5,
+        0x03B6,
+        0x04B0,
+        0x04E2,
+        0x04E3,
+        0x04E4,
+        0x04E5,
+        0x04E6,
+        0x04E7,
+        0x04E8,
     }
 
 
@@ -263,13 +291,17 @@ def validate_version_number(version_str: str) -> bool:
     Returns:
         (bool): if the version string is valid or not
     """
-    if version_str.count('.') != 3 and version_str.count(',') != 3:
-        logging.error("Invalid version string: " + version_str + ". Version must be in form "
-                      + "\"INTEGER.INTEGER.INTEGER.INTEGER\".")
+    if version_str.count(".") != 3 and version_str.count(",") != 3:
+        logging.error(
+            "Invalid version string: "
+            + version_str
+            + ". Version must be in form "
+            + '"INTEGER.INTEGER.INTEGER.INTEGER".'
+        )
         return False
 
     split = None
-    if version_str.count('.') == 3:
+    if version_str.count(".") == 3:
         split = version_str.split(".")
     else:
         split = version_str.split(",")
@@ -277,11 +309,17 @@ def validate_version_number(version_str: str) -> bool:
     for substr in split:
         try:
             if int(substr) > 65535:
-                logging.error("Integer overflow in version string: " + version_str + ".")
+                logging.error(
+                    "Integer overflow in version string: " + version_str + "."
+                )
                 return False
         except ValueError:
-            logging.error("Invalid version string: " + version_str + ". Version must be in form \""
-                          + " INTEGER.INTEGER.INTEGER.INTEGER\".")
+            logging.error(
+                "Invalid version string: "
+                + version_str
+                + '. Version must be in form "'
+                + ' INTEGER.INTEGER.INTEGER.INTEGER".'
+            )
             return False
 
     return True
@@ -299,7 +337,7 @@ def version_str_to_int(version_str: str) -> Tuple[int, int]:
         (Tuple[int, int]): (32 MS bits, 32 LS bits)
     """
     split = None
-    if version_str.count('.') == 3:
+    if version_str.count(".") == 3:
         split = version_str.split(".")
     else:
         split = version_str.split(",")
@@ -318,7 +356,7 @@ def hex_to_version_str(val: int) -> str:
     Returns:
         (str): string represention
     """
-    return str(((val & ~0) >> 16) & 0xffff) + "." + str(val & 0xffff)
+    return str(((val & ~0) >> 16) & 0xFFFF) + "." + str(val & 0xFFFF)
 
 
 class PEObject(object):
@@ -326,6 +364,7 @@ class PEObject(object):
 
     Gives functionality for reading VS_VERSIONINFO metadata and .rsrc section.
     """
+
     _pe: pefile.PE = None
 
     def __init__(self, filepath: str) -> None:
@@ -376,7 +415,10 @@ class PEObject(object):
             (bool): whether a .rsrc section exists in the PE
         """
         for section in self._pe.sections:
-            if section.Name.decode(PEStrings.PE_ENCODING).replace("\x00", "") == PEStrings.RSRC_STR:
+            if (
+                section.Name.decode(PEStrings.PE_ENCODING).replace("\x00", "")
+                == PEStrings.RSRC_STR
+            ):
                 return True
         return False
 
@@ -395,41 +437,77 @@ class PEObject(object):
             vs_fixedfileinfo_dict = self._pe.VS_FIXEDFILEINFO[0].dump_dict()
             for key in vs_fixedfileinfo_dict.keys():
                 # Skip sections that have dependencies
-                if key == PEStrings.PE_STRUCT_STR or \
-                   key == PEStrings.FILE_SUBTYPE_PEFILE or \
-                   key == PEStrings.FILE_VERSION_LS_PEFILE or \
-                   key == PEStrings.PRODUCT_VERSION_LS_PEFILE or \
-                   key == PEStrings.FILE_DATE_LS_PEFILE:
+                if (
+                    key == PEStrings.PE_STRUCT_STR
+                    or key == PEStrings.FILE_SUBTYPE_PEFILE
+                    or key == PEStrings.FILE_VERSION_LS_PEFILE
+                    or key == PEStrings.PRODUCT_VERSION_LS_PEFILE
+                    or key == PEStrings.FILE_DATE_LS_PEFILE
+                ):
                     continue
 
-                self._populate_entry(key, vs_fixedfileinfo_dict[key][PEStrings.PE_VALUE_STR], result)
+                self._populate_entry(
+                    key, vs_fixedfileinfo_dict[key][PEStrings.PE_VALUE_STR], result
+                )
 
             # Resolve dependent fields
-            if PEStrings.FILE_VERSION_MS_PEFILE in vs_fixedfileinfo_dict.keys() and \
-               PEStrings.FILE_VERSION_LS_PEFILE in vs_fixedfileinfo_dict.keys():
-                self._populate_entry(PEStrings.FILE_VERSION_LS_PEFILE,
-                                     vs_fixedfileinfo_dict[PEStrings.FILE_VERSION_LS_PEFILE][PEStrings.PE_VALUE_STR], result) # noqa
+            if (
+                PEStrings.FILE_VERSION_MS_PEFILE in vs_fixedfileinfo_dict.keys()
+                and PEStrings.FILE_VERSION_LS_PEFILE in vs_fixedfileinfo_dict.keys()
+            ):
+                self._populate_entry(
+                    PEStrings.FILE_VERSION_LS_PEFILE,
+                    vs_fixedfileinfo_dict[PEStrings.FILE_VERSION_LS_PEFILE][
+                        PEStrings.PE_VALUE_STR
+                    ],
+                    result,
+                )  # noqa
 
-            if PEStrings.PRODUCT_VERSION_MS_PEFILE in vs_fixedfileinfo_dict.keys() and \
-               PEStrings.PRODUCT_VERSION_LS_PEFILE in vs_fixedfileinfo_dict.keys():
-                self._populate_entry(PEStrings.PRODUCT_VERSION_LS_PEFILE,
-                                     vs_fixedfileinfo_dict[PEStrings.PRODUCT_VERSION_LS_PEFILE][PEStrings.PE_VALUE_STR], result) # noqa
+            if (
+                PEStrings.PRODUCT_VERSION_MS_PEFILE in vs_fixedfileinfo_dict.keys()
+                and PEStrings.PRODUCT_VERSION_LS_PEFILE in vs_fixedfileinfo_dict.keys()
+            ):
+                self._populate_entry(
+                    PEStrings.PRODUCT_VERSION_LS_PEFILE,
+                    vs_fixedfileinfo_dict[PEStrings.PRODUCT_VERSION_LS_PEFILE][
+                        PEStrings.PE_VALUE_STR
+                    ],
+                    result,
+                )  # noqa
 
-            if PEStrings.FILE_DATE_MS_PEFILE in vs_fixedfileinfo_dict.keys() and \
-               PEStrings.FILE_DATE_LS_PEFILE in vs_fixedfileinfo_dict.keys():
-                self._populate_entry(PEStrings.FILE_DATE_LS_PEFILE,
-                                     vs_fixedfileinfo_dict[PEStrings.FILE_DATE_LS_PEFILE][PEStrings.PE_VALUE_STR], result) # noqa
+            if (
+                PEStrings.FILE_DATE_MS_PEFILE in vs_fixedfileinfo_dict.keys()
+                and PEStrings.FILE_DATE_LS_PEFILE in vs_fixedfileinfo_dict.keys()
+            ):
+                self._populate_entry(
+                    PEStrings.FILE_DATE_LS_PEFILE,
+                    vs_fixedfileinfo_dict[PEStrings.FILE_DATE_LS_PEFILE][
+                        PEStrings.PE_VALUE_STR
+                    ],
+                    result,
+                )  # noqa
 
             if PEStrings.FILE_SUBTYPE_PEFILE in vs_fixedfileinfo_dict.keys():
-                file_subtype = vs_fixedfileinfo_dict[PEStrings.FILE_SUBTYPE_PEFILE][PEStrings.PE_VALUE_STR]
-                if PEStrings.FILE_TYPE_STR in result and result[PEStrings.FILE_TYPE_STR] == PEStrings.VFT_FONT_STR:
+                file_subtype = vs_fixedfileinfo_dict[PEStrings.FILE_SUBTYPE_PEFILE][
+                    PEStrings.PE_VALUE_STR
+                ]
+                if (
+                    PEStrings.FILE_TYPE_STR in result
+                    and result[PEStrings.FILE_TYPE_STR] == PEStrings.VFT_FONT_STR
+                ):
                     if file_subtype in PEStrings.FILE_SUBTYPE_FONT_STRINGS:
-                        result[PEStrings.FILE_SUBTYPE_PEFILE] = PEStrings.FILE_SUBTYPE_FONT_STRINGS[PEStrings.file_subtype] # noqa
+                        result[
+                            PEStrings.FILE_SUBTYPE_PEFILE
+                        ] = PEStrings.FILE_SUBTYPE_FONT_STRINGS[
+                            PEStrings.file_subtype
+                        ]  # noqa
                     else:
                         result[PEStrings.FILE_SUBTYPE_PEFILE] = file_subtype
                 else:
                     if file_subtype in PEStrings.FILE_SUBTYPE_NOFONT_STRINGS.keys():
-                        result[PEStrings.FILE_SUBTYPE_PEFILE] = PEStrings.FILE_SUBTYPE_NOFONT_STRINGS[file_subtype]
+                        result[
+                            PEStrings.FILE_SUBTYPE_PEFILE
+                        ] = PEStrings.FILE_SUBTYPE_NOFONT_STRINGS[file_subtype]
                     else:
                         result[PEStrings.FILE_SUBTYPE_PEFILE] = file_subtype
 
@@ -439,17 +517,29 @@ class PEObject(object):
         if self.contains_rsrc():
             for fileinfo in self._pe.FileInfo:
                 for entry in fileinfo:
-                    if entry.Key.decode(PEStrings.PE_ENCODING).replace("\x00", "") == PEStrings.STRING_FILE_INFO_STR:
+                    if (
+                        entry.Key.decode(PEStrings.PE_ENCODING).replace("\x00", "")
+                        == PEStrings.STRING_FILE_INFO_STR
+                    ):
                         stringfileinfo_dict = {}
                         for strTable in entry.StringTable:
                             for item in strTable.entries.items():
-                                stringfileinfo_dict[item[0].decode(PEStrings.PE_ENCODING)] = item[1].decode(PEStrings.PE_ENCODING) # noqa
+                                stringfileinfo_dict[
+                                    item[0].decode(PEStrings.PE_ENCODING)
+                                ] = item[1].decode(
+                                    PEStrings.PE_ENCODING
+                                )  # noqa
                         result[PEStrings.STRING_FILE_INFO_STR] = stringfileinfo_dict
-                    elif entry.Key.decode(PEStrings.PE_ENCODING).replace("\x00", "") == PEStrings.VAR_FILE_INFO_STR:
+                    elif (
+                        entry.Key.decode(PEStrings.PE_ENCODING).replace("\x00", "")
+                        == PEStrings.VAR_FILE_INFO_STR
+                    ):
                         varfileinfo_dict = {}
                         for var in entry.Var:
                             for item in var.entry.items():
-                                varfileinfo_dict[item[0].decode(PEStrings.PE_ENCODING)] = item[1]
+                                varfileinfo_dict[
+                                    item[0].decode(PEStrings.PE_ENCODING)
+                                ] = item[1]
                         result[PEStrings.VAR_FILE_INFO_STR] = varfileinfo_dict
         else:
             logging.warning("File does not contain .rsrc section.")
@@ -502,10 +592,11 @@ class VERSIONINFOGenerator(object):
         "OriginalFilename": "ExampleApp.efi"
     }
     """
+
     _minimal_required_fields = {
         PEStrings.FILE_VERSION_STR.upper(),
         PEStrings.COMPANY_NAME_STR.upper(),
-        PEStrings.ORIGINAL_FILENAME_STR.upper()
+        PEStrings.ORIGINAL_FILENAME_STR.upper(),
     }
 
     _version_dict = None
@@ -525,7 +616,9 @@ class VERSIONINFOGenerator(object):
                 #
                 # Convert all keys to UPPERCASE for consistant usage
                 #
-                self._version_dict = dict({k.upper(): v for k, v in json.loads(data).items()})
+                self._version_dict = dict(
+                    {k.upper(): v for k, v in json.loads(data).items()}
+                )
             except json.decoder.JSONDecodeError as e:
                 logging.error("Invalid JSON format, " + str(e))
 
@@ -559,7 +652,9 @@ class VERSIONINFOGenerator(object):
                     required_string_fields.remove(key)
 
             for remaining in required_string_fields:
-                logging.error("Missing required StringFileInfo parameter: " + remaining + ".")
+                logging.error(
+                    "Missing required StringFileInfo parameter: " + remaining + "."
+                )
                 valid = False
 
         if not valid:
@@ -568,61 +663,131 @@ class VERSIONINFOGenerator(object):
         # Second pass: Check to see if fields are valid
         valid = validate_version_number(self._version_dict[PEStrings.FILE_VERSION_STR])
         if PEStrings.PRODUCT_VERSION_STR in self._version_dict:
-            valid = valid and validate_version_number(self._version_dict[PEStrings.PRODUCT_VERSION_STR])
+            valid = valid and validate_version_number(
+                self._version_dict[PEStrings.PRODUCT_VERSION_STR]
+            )
 
         if PEStrings.FILE_OS_STR in self._version_dict:
             try:
-                if int(self._version_dict[PEStrings.FILE_OS_STR], 0) not in PEStrings.FILE_OS_STRINGS.keys():
+                if (
+                    int(self._version_dict[PEStrings.FILE_OS_STR], 0)
+                    not in PEStrings.FILE_OS_STRINGS.keys()
+                ):
                     valid = False
-                    logging.error("Invalid FILEOS value: " + self._version_dict[PEStrings.FILE_OS_STR] + ".")
+                    logging.error(
+                        "Invalid FILEOS value: "
+                        + self._version_dict[PEStrings.FILE_OS_STR]
+                        + "."
+                    )
             except ValueError:
-                if self._version_dict[PEStrings.FILE_OS_STR] not in PEStrings.VALID_FILE_OS_VALUES:
+                if (
+                    self._version_dict[PEStrings.FILE_OS_STR]
+                    not in PEStrings.VALID_FILE_OS_VALUES
+                ):
                     valid = False
-                    logging.error("Invalid FILEOS value: " + self._version_dict[PEStrings.FILE_OS_STR] + ".")
+                    logging.error(
+                        "Invalid FILEOS value: "
+                        + self._version_dict[PEStrings.FILE_OS_STR]
+                        + "."
+                    )
 
         if PEStrings.FILE_TYPE_STR in self._version_dict:
             try:
-                if int(self._version_dict[PEStrings.FILE_TYPE_STR], 0) not in PEStrings.FILE_TYPE_STRINGS.keys():
+                if (
+                    int(self._version_dict[PEStrings.FILE_TYPE_STR], 0)
+                    not in PEStrings.FILE_TYPE_STRINGS.keys()
+                ):
                     valid = False
-                    logging.error("Invalid FILETYPE value: " + self._version_dict[PEStrings.FILE_TYPE_STR] + ".")
+                    logging.error(
+                        "Invalid FILETYPE value: "
+                        + self._version_dict[PEStrings.FILE_TYPE_STR]
+                        + "."
+                    )
             except ValueError:
-                if self._version_dict[PEStrings.FILE_TYPE_STR] not in PEStrings.VALID_FILE_TYPE_VALUES:
+                if (
+                    self._version_dict[PEStrings.FILE_TYPE_STR]
+                    not in PEStrings.VALID_FILE_TYPE_VALUES
+                ):
                     valid = False
-                    logging.error("Invalid FILETYPE value: " + self._version_dict[PEStrings.FILE_TYPE_STR] + ".")
+                    logging.error(
+                        "Invalid FILETYPE value: "
+                        + self._version_dict[PEStrings.FILE_TYPE_STR]
+                        + "."
+                    )
             if PEStrings.FILE_SUBTYPE_STR in self._version_dict:
                 if self._version_dict[PEStrings.FILE_TYPE_STR] == "VFT_DRV":
-                    if self._version_dict[PEStrings.FILE_SUBTYPE_STR] not in PEStrings.VALID_SUBTYPE_VFT_DRV:
-                        logging.error("Invalid FILESUBTYPE value for FILETYPE VFT_DRV: "
-                                      + self._version_dict[PEStrings.FILE_SUBTYPE_STR] + ".")
+                    if (
+                        self._version_dict[PEStrings.FILE_SUBTYPE_STR]
+                        not in PEStrings.VALID_SUBTYPE_VFT_DRV
+                    ):
+                        logging.error(
+                            "Invalid FILESUBTYPE value for FILETYPE VFT_DRV: "
+                            + self._version_dict[PEStrings.FILE_SUBTYPE_STR]
+                            + "."
+                        )
                         valid = False
                 elif self._version_dict[PEStrings.FILE_TYPE_STR] == "VFT_FONT":
-                    if self._version_dict[PEStrings.FILE_SUBTYPE_STR] not in PEStrings.VALID_SUBTYPE_VFT_FONT:
-                        logging.error("Invalid FILESUBTYPE value for FILETYPE VFT_FONT: "
-                                      + self._version_dict[PEStrings.FILE_SUBTYPE_STR] + ".")
+                    if (
+                        self._version_dict[PEStrings.FILE_SUBTYPE_STR]
+                        not in PEStrings.VALID_SUBTYPE_VFT_FONT
+                    ):
+                        logging.error(
+                            "Invalid FILESUBTYPE value for FILETYPE VFT_FONT: "
+                            + self._version_dict[PEStrings.FILE_SUBTYPE_STR]
+                            + "."
+                        )
                         valid = False
-                elif (self._version_dict[PEStrings.FILE_TYPE_STR] != "VFT_VXD"
-                      and self._version_dict[PEStrings.FILE_SUBTYPE_STR] != 0):
-                    logging.error("Invalid FILESUBTYPE value for FILETYPE "
-                                  + self._version_dict[PEStrings.FILE_TYPE_STR] + ", value must be 0.")
+                elif (
+                    self._version_dict[PEStrings.FILE_TYPE_STR] != "VFT_VXD"
+                    and self._version_dict[PEStrings.FILE_SUBTYPE_STR] != 0
+                ):
+                    logging.error(
+                        "Invalid FILESUBTYPE value for FILETYPE "
+                        + self._version_dict[PEStrings.FILE_TYPE_STR]
+                        + ", value must be 0."
+                    )
                     valid = False
         elif PEStrings.FILE_SUBTYPE_STR in self._version_dict:
-            logging.error("Missing parameter: must have FileType if FileSubtype defined.")
+            logging.error(
+                "Missing parameter: must have FileType if FileSubtype defined."
+            )
             valid = False
 
-        if PEStrings.TRANSLATION_STR in self._version_dict[PEStrings.VAR_FILE_INFO_STR.upper()]:
-            langid_set = self._version_dict[PEStrings.VAR_FILE_INFO_STR.upper()][PEStrings.TRANSLATION_STR].split(" ")
+        if (
+            PEStrings.TRANSLATION_STR
+            in self._version_dict[PEStrings.VAR_FILE_INFO_STR.upper()]
+        ):
+            langid_set = self._version_dict[PEStrings.VAR_FILE_INFO_STR.upper()][
+                PEStrings.TRANSLATION_STR
+            ].split(" ")
             try:
                 if len(langid_set) != 2:
-                    logging.error("Translation field must contain 2 space delimited hexidecimal bytes.")
+                    logging.error(
+                        "Translation field must contain 2 space delimited hexidecimal bytes."
+                    )
                     valid = False
-                elif (int(langid_set[0].replace('"', ''), 0) not in PEStrings.VALID_LANG_ID
-                      or int(langid_set[1].replace('"', ''), 0) not in PEStrings.VALID_CHARSET_ID):
-                    logging.error("Invalid language code: "
-                                  + self._version_dict[PEStrings.VAR_FILE_INFO_STR.upper()][PEStrings.TRANSLATION_STR] + ".") # noqa
+                elif (
+                    int(langid_set[0].replace('"', ""), 0)
+                    not in PEStrings.VALID_LANG_ID
+                    or int(langid_set[1].replace('"', ""), 0)
+                    not in PEStrings.VALID_CHARSET_ID
+                ):
+                    logging.error(
+                        "Invalid language code: "
+                        + self._version_dict[PEStrings.VAR_FILE_INFO_STR.upper()][
+                            PEStrings.TRANSLATION_STR
+                        ]
+                        + "."
+                    )  # noqa
                     valid = False
             except ValueError:
-                logging.error("Invalid language code: "
-                              + self._version_dict[PEStrings.VAR_FILE_INFO_STR.upper()][PEStrings.TRANSLATION_STR] + ".") # noqa
+                logging.error(
+                    "Invalid language code: "
+                    + self._version_dict[PEStrings.VAR_FILE_INFO_STR.upper()][
+                        PEStrings.TRANSLATION_STR
+                    ]
+                    + "."
+                )  # noqa
                 valid = False
         else:
             logging.error("Missing required parameter in VarFileInfo: Translation.")
@@ -683,25 +848,71 @@ class VERSIONINFOGenerator(object):
         version = self._version_dict[PEStrings.FILE_VERSION_STR.upper()].split(".")
         if len(version) != 4:
             version = self._version_dict[PEStrings.FILE_VERSION_STR.upper()].split(",")
-        out_str += version[0] + ',' + version[1] + ',' + version[2] + ',' + version[3] + "\n"
+        out_str += (
+            version[0] + "," + version[1] + "," + version[2] + "," + version[3] + "\n"
+        )
 
         # StringFileInfo
-        out_str += "\n" + PEStrings.BEGIN_STR + "\n\t" \
-                   + PEStrings.BLOCK_STR + " \"" + PEStrings.STRING_FILE_INFO_STR \
-                   + "\"\n\t" + PEStrings.BEGIN_STR + "\n" + "\t\t" \
-                   + PEStrings.BLOCK_STR + " \"" + PEStrings.DEFAULT_BLOCK_HEADER \
-                   + "\"\n\t\t" + PEStrings.BEGIN_STR + "\n" + "\t\t" + PEStrings.VALUE_STR \
-                   + ' "' + PEStrings.COMPANY_NAME_STR + '",\t"' \
-                   + self._version_dict[PEStrings.COMPANY_NAME_STR.upper()] + "\"\n" \
-                   + "\t\t" + PEStrings.VALUE_STR + ' "' + PEStrings.ORIGINAL_FILENAME_STR + '",\t"' \
-                   + self._version_dict[PEStrings.ORIGINAL_FILENAME_STR.upper()] + "\"\n" \
-                   + "\t\t" + PEStrings.END_STR + "\n\t" + PEStrings.END_STR + "\n\n"
+        out_str += (
+            "\n"
+            + PEStrings.BEGIN_STR
+            + "\n\t"
+            + PEStrings.BLOCK_STR
+            + ' "'
+            + PEStrings.STRING_FILE_INFO_STR
+            + '"\n\t'
+            + PEStrings.BEGIN_STR
+            + "\n"
+            + "\t\t"
+            + PEStrings.BLOCK_STR
+            + ' "'
+            + PEStrings.DEFAULT_BLOCK_HEADER
+            + '"\n\t\t'
+            + PEStrings.BEGIN_STR
+            + "\n"
+            + "\t\t"
+            + PEStrings.VALUE_STR
+            + ' "'
+            + PEStrings.COMPANY_NAME_STR
+            + '",\t"'
+            + self._version_dict[PEStrings.COMPANY_NAME_STR.upper()]
+            + '"\n'
+            + "\t\t"
+            + PEStrings.VALUE_STR
+            + ' "'
+            + PEStrings.ORIGINAL_FILENAME_STR
+            + '",\t"'
+            + self._version_dict[PEStrings.ORIGINAL_FILENAME_STR.upper()]
+            + '"\n'
+            + "\t\t"
+            + PEStrings.END_STR
+            + "\n\t"
+            + PEStrings.END_STR
+            + "\n\n"
+        )
 
         # VarFileInfo
-        out_str += "\t" + PEStrings.BLOCK_STR + " \"" + PEStrings.VAR_FILE_INFO_STR + '"\n\t' \
-                   + PEStrings.BEGIN_STR + "\n" + "\t\t" + PEStrings.VALUE_STR + ' "' \
-                   + PEStrings.TRANSLATION_STR + '",\t' + PEStrings.DEFAULT_TRANSLATION + "\n" \
-                   + "\t" + PEStrings.END_STR + "\n" + PEStrings.END_STR + "\n#endif"
+        out_str += (
+            "\t"
+            + PEStrings.BLOCK_STR
+            + ' "'
+            + PEStrings.VAR_FILE_INFO_STR
+            + '"\n\t'
+            + PEStrings.BEGIN_STR
+            + "\n"
+            + "\t\t"
+            + PEStrings.VALUE_STR
+            + ' "'
+            + PEStrings.TRANSLATION_STR
+            + '",\t'
+            + PEStrings.DEFAULT_TRANSLATION
+            + "\n"
+            + "\t"
+            + PEStrings.END_STR
+            + "\n"
+            + PEStrings.END_STR
+            + "\n#endif"
+        )
 
         with open(path, "w") as out:
             out.write(out_str)
@@ -724,7 +935,9 @@ class VERSIONINFOGenerator(object):
             logging.error("Invalid input, aborted.")
             return False
 
-        self._version_dict = dict((key.upper(), val) for key, val in self._version_dict.items())
+        self._version_dict = dict(
+            (key.upper(), val) for key, val in self._version_dict.items()
+        )
 
         minimal = True
         for key in self._version_dict:
@@ -757,38 +970,89 @@ class VERSIONINFOGenerator(object):
         # Header fields
         out_str += "VS_VERSION_INFO\tVERSIONINFO\n"
         for param in self._version_dict.keys():
-            if (param == PEStrings.STRING_FILE_INFO_STR.upper()
-               or param == PEStrings.VAR_FILE_INFO_STR.upper()):
+            if (
+                param == PEStrings.STRING_FILE_INFO_STR.upper()
+                or param == PEStrings.VAR_FILE_INFO_STR.upper()
+            ):
                 continue
-            if param == PEStrings.PRODUCT_VERSION_STR or param == PEStrings.FILE_VERSION_STR:
+            if (
+                param == PEStrings.PRODUCT_VERSION_STR
+                or param == PEStrings.FILE_VERSION_STR
+            ):
                 out_str += param.upper() + "\t"
                 version = self._version_dict[param].split(".")
-                out_str += version[0] + ',' + version[1] + ',' + version[2] + ',' + version[3] + "\n"
+                out_str += (
+                    version[0]
+                    + ","
+                    + version[1]
+                    + ","
+                    + version[2]
+                    + ","
+                    + version[3]
+                    + "\n"
+                )
             else:
                 out_str += param.upper() + "\t" + str(self._version_dict[param]) + "\n"
 
         # StringFileInfo
         out_str += "\n" + PEStrings.BEGIN_STR + "\n\t"
-        out_str += PEStrings.BLOCK_STR + " \"" + PEStrings.STRING_FILE_INFO_STR + "\"\n\t" + PEStrings.BEGIN_STR + "\n"
+        out_str += (
+            PEStrings.BLOCK_STR
+            + ' "'
+            + PEStrings.STRING_FILE_INFO_STR
+            + '"\n\t'
+            + PEStrings.BEGIN_STR
+            + "\n"
+        )
 
         language_code = ""
-        for code in self._version_dict[PEStrings.VAR_FILE_INFO_STR.upper()][PEStrings.TRANSLATION_STR].split(" "):
+        for code in self._version_dict[PEStrings.VAR_FILE_INFO_STR.upper()][
+            PEStrings.TRANSLATION_STR
+        ].split(" "):
             language_code += code.split("0x", 1)[1]
 
-        out_str += "\t\t" + PEStrings.BLOCK_STR + " \"" + language_code + "\"\n\t\t" + PEStrings.BEGIN_STR + "\n"
+        out_str += (
+            "\t\t"
+            + PEStrings.BLOCK_STR
+            + ' "'
+            + language_code
+            + '"\n\t\t'
+            + PEStrings.BEGIN_STR
+            + "\n"
+        )
         for field in self._version_dict[PEStrings.STRING_FILE_INFO_STR.upper()].keys():
-            out_str += "\t\t" + PEStrings.VALUE_STR + " \"" + field + "\",\t\"" \
-                       + self._version_dict[PEStrings.STRING_FILE_INFO_STR.upper()][field] + "\"\n"
+            out_str += (
+                "\t\t"
+                + PEStrings.VALUE_STR
+                + ' "'
+                + field
+                + '",\t"'
+                + self._version_dict[PEStrings.STRING_FILE_INFO_STR.upper()][field]
+                + '"\n'
+            )
 
         out_str += "\t\t" + PEStrings.END_STR + "\n\t" + PEStrings.END_STR + "\n\n"
 
         # VarFileInfo
         out_str += "\t" + PEStrings.BLOCK_STR
-        out_str += " \"" + PEStrings.VAR_FILE_INFO_STR + "\"\n\t" + PEStrings.BEGIN_STR + "\n"
-        language_tokens = self._version_dict[PEStrings.VAR_FILE_INFO_STR.upper()][PEStrings.TRANSLATION_STR].split(" ")
+        out_str += (
+            ' "' + PEStrings.VAR_FILE_INFO_STR + '"\n\t' + PEStrings.BEGIN_STR + "\n"
+        )
+        language_tokens = self._version_dict[PEStrings.VAR_FILE_INFO_STR.upper()][
+            PEStrings.TRANSLATION_STR
+        ].split(" ")
         for field in self._version_dict[PEStrings.VAR_FILE_INFO_STR.upper()].keys():
-            out_str += "\t\t" + PEStrings.VALUE_STR + " \"" + field + "\",\t" + language_tokens[0] + "," \
-                       + language_tokens[1] + "\n"
+            out_str += (
+                "\t\t"
+                + PEStrings.VALUE_STR
+                + ' "'
+                + field
+                + '",\t'
+                + language_tokens[0]
+                + ","
+                + language_tokens[1]
+                + "\n"
+            )
 
         out_str += "\t" + PEStrings.END_STR + "\n" + PEStrings.END_STR + "\n#endif"
 

--- a/edk2toolext/versioninfo/versioninfo_tool.py
+++ b/edk2toolext/versioninfo/versioninfo_tool.py
@@ -41,7 +41,11 @@ An example to encode json to rc file might look like:
 
 An example to decode a binary efi file and output the rsrc in json might look like:
 %s -d /path/to/app.efi /path/to/output.JSON
-""" % (TOOL_VERSION, os.path.basename(sys.argv[0]), os.path.basename(sys.argv[0]))
+""" % (
+    TOOL_VERSION,
+    os.path.basename(sys.argv[0]),
+    os.path.basename(sys.argv[0]),
+)
 
 
 def get_cli_options(args=None):
@@ -50,18 +54,37 @@ def get_cli_options(args=None):
     Will parse the primary options from the command line. If provided, will take the options as
     an array in the first parameter
     """
-    parser = argparse.ArgumentParser(description=TOOL_DESCRIPTION, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument('input_file', type=str,
-                        help='a filesystem path to a json/PE file to load')
-    parser.add_argument('output_file', type=str,
-                        help='a filesystem path to the output file. if file does not exist, entire directory path will be created. if file does exist, contents will be overwritten')  # noqa
+    parser = argparse.ArgumentParser(
+        description=TOOL_DESCRIPTION,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "input_file", type=str, help="a filesystem path to a json/PE file to load"
+    )
+    parser.add_argument(
+        "output_file",
+        type=str,
+        help="a filesystem path to the output file. if file does not exist, entire directory path will be created. if file does exist, contents will be overwritten",
+    )  # noqa
 
     command_group = parser.add_mutually_exclusive_group()
-    command_group.add_argument('-e', '--encode', action='store_const', const='e', dest='mode',
-                               help='(default) outputs VERSIONINFO.rc of given json file')
-    command_group.add_argument('-d', '--dump', action='store_const', dest='mode', const='d',
-                               help='outputs json file of VERSIONINFO given PE file')
-    parser.set_defaults(mode='e')
+    command_group.add_argument(
+        "-e",
+        "--encode",
+        action="store_const",
+        const="e",
+        dest="mode",
+        help="(default) outputs VERSIONINFO.rc of given json file",
+    )
+    command_group.add_argument(
+        "-d",
+        "--dump",
+        action="store_const",
+        dest="mode",
+        const="d",
+        help="outputs json file of VERSIONINFO given PE file",
+    )
+    parser.set_defaults(mode="e")
     return parser.parse_args(args=args)
 
 
@@ -134,11 +157,11 @@ def main():
         logging.error("Could not find " + args.input_file)
         sys.exit(1)
 
-    if args.mode == 'd':
+    if args.mode == "d":
         # we need to dump
         if not decode_version_info_dump_json(args.input_file, args.output_file):
             sys.exit(1)
-    elif args.mode == 'e':
+    elif args.mode == "e":
         # we need to encode
         if not encode_version_info_dump_rc(args.input_file, args.output_file):
             sys.exit(1)
@@ -148,5 +171,5 @@ def main():
         sys.exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/edk2toolext/windows/policy/firmware_policy_tool.py
+++ b/edk2toolext/windows/policy/firmware_policy_tool.py
@@ -15,7 +15,7 @@ import argparse
 def PrintPolicy(filename: str) -> None:
     """Attempts to parse filename as a Windows Firmware Policy and print it."""
     try:
-        with open(filename, 'rb') as f:
+        with open(filename, "rb") as f:
             policy = FirmwarePolicy(fs=f)
             policy.Print()
 
@@ -23,20 +23,30 @@ def PrintPolicy(filename: str) -> None:
         print('ERROR:  File not found: "{0}"'.format(filename))
 
 
-def CreatePolicyFromParameters(filename: str, manufacturer: str, product: str,
-                               sn: str, nonce: int, oem1: str, oem2: str, devicePolicy: int) -> None:
+def CreatePolicyFromParameters(
+    filename: str,
+    manufacturer: str,
+    product: str,
+    sn: str,
+    nonce: int,
+    oem1: str,
+    oem2: str,
+    devicePolicy: int,
+) -> None:
     """Populates a Windows FirmwarePolicy object with the provided parameters and serializes it to filename.
 
     WARNING: Filename must be a new file, will not overwrite existing files.
     """
-    with open(filename, 'xb') as f:
+    with open(filename, "xb") as f:
         policy = FirmwarePolicy()
-        TargetInfo = {'Manufacturer': manufacturer,
-                      'Product': product,
-                      'SerialNumber': sn,
-                      'OEM_01': oem1,
-                      'OEM_02': oem2,
-                      'Nonce': nonce}
+        TargetInfo = {
+            "Manufacturer": manufacturer,
+            "Product": product,
+            "SerialNumber": sn,
+            "OEM_01": oem1,
+            "OEM_02": oem2,
+            "Nonce": nonce,
+        }
         policy.SetDeviceTarget(TargetInfo)
         policy.SetDevicePolicy(devicePolicy)
         policy.SerializeToStream(stream=f)
@@ -45,43 +55,81 @@ def CreatePolicyFromParameters(filename: str, manufacturer: str, product: str,
 
 def main():
     """Parses command-line parameters using ArgumentParser, passing them to helper functions to perform the requests."""
-    parser = argparse.ArgumentParser(description='Firmware Policy Tool')
-    subparsers = parser.add_subparsers(required=True, dest='action')
+    parser = argparse.ArgumentParser(description="Firmware Policy Tool")
+    subparsers = parser.add_subparsers(required=True, dest="action")
 
-    parser_create = subparsers.add_parser('create', help='Create a firmware policy')
-    parser_create.add_argument('PolicyFilename', type=str, help='The name of the new binary policy file to create '
-                               '- will not overwrite existing files')
+    parser_create = subparsers.add_parser("create", help="Create a firmware policy")
     parser_create.add_argument(
-        'Manufacturer', type=str, help='Manufacturer Name, for example, "Contoso Computers, LLC".  '
-        'Should match the EV Certificate Subject CN="Manufacturer"')
-    parser_create.add_argument('Product', type=str, help='Product Name, for example, "Laptop Foo"')
+        "PolicyFilename",
+        type=str,
+        help="The name of the new binary policy file to create "
+        "- will not overwrite existing files",
+    )
     parser_create.add_argument(
-        'SerialNumber', type=str, help='Serial Number, for example "F0013-000243546-X02".  Should match '
-        'SmbiosSystemSerialNumber, SMBIOS System Information (Type 1 Table) -> Serial Number')
-    parser_create.add_argument('NonceHex', type=str, help='The nonce in hexadecimal, for example "0x0123456789abcdef"')
-    parser_create.add_argument('--OEM1', type=str, default='',
-                               help='Optional OEM Field 1, an arbitrary length string, for example "ODM foo"')
-    parser_create.add_argument('--OEM2', type=str, default='', help='Optional OEM Field 2, an arbitrary length string')
-    parser_create.add_argument('DevicePolicyHex', type=str, help='The device policy in hexadecimal,'
-                               ' for example to clear the TPM and delete Secure Boot keys: 0x3')
+        "Manufacturer",
+        type=str,
+        help='Manufacturer Name, for example, "Contoso Computers, LLC".  '
+        'Should match the EV Certificate Subject CN="Manufacturer"',
+    )
+    parser_create.add_argument(
+        "Product", type=str, help='Product Name, for example, "Laptop Foo"'
+    )
+    parser_create.add_argument(
+        "SerialNumber",
+        type=str,
+        help='Serial Number, for example "F0013-000243546-X02".  Should match '
+        "SmbiosSystemSerialNumber, SMBIOS System Information (Type 1 Table) -> Serial Number",
+    )
+    parser_create.add_argument(
+        "NonceHex",
+        type=str,
+        help='The nonce in hexadecimal, for example "0x0123456789abcdef"',
+    )
+    parser_create.add_argument(
+        "--OEM1",
+        type=str,
+        default="",
+        help='Optional OEM Field 1, an arbitrary length string, for example "ODM foo"',
+    )
+    parser_create.add_argument(
+        "--OEM2",
+        type=str,
+        default="",
+        help="Optional OEM Field 2, an arbitrary length string",
+    )
+    parser_create.add_argument(
+        "DevicePolicyHex",
+        type=str,
+        help="The device policy in hexadecimal,"
+        " for example to clear the TPM and delete Secure Boot keys: 0x3",
+    )
 
-    parser_print = subparsers.add_parser('parse', help='Parse a firmware policy and print in human readable form')
-    parser_print.add_argument('filename', help='Filename to parse and print')
+    parser_print = subparsers.add_parser(
+        "parse", help="Parse a firmware policy and print in human readable form"
+    )
+    parser_print.add_argument("filename", help="Filename to parse and print")
 
     options = parser.parse_args()
 
-    print('Options: ', options)
+    print("Options: ", options)
 
-    if options.action == 'create':
+    if options.action == "create":
         nonceInt = int(options.NonceHex, 16)
         devicePolicy = int(options.DevicePolicyHex, 16)
-        CreatePolicyFromParameters(options.PolicyFilename, options.Manufacturer,
-                                   options.Product, options.SerialNumber, nonceInt,
-                                   options.OEM1, options.OEM2, devicePolicy)
+        CreatePolicyFromParameters(
+            options.PolicyFilename,
+            options.Manufacturer,
+            options.Product,
+            options.SerialNumber,
+            nonceInt,
+            options.OEM1,
+            options.OEM2,
+            devicePolicy,
+        )
 
-    elif options.action == 'parse':
+    elif options.action == "parse":
         PrintPolicy(options.filename)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest == 7.2.2
-flake8 == 6.0.0
+black == 23.1.0
 pydocstyle == 6.3.0
 coverage == 7.2.1
 pyopenssl == 23.0.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ with open("readme.md", "r") as fh:
 
 class PostSdistCommand(sdist):
     """Post-sdist."""
-    def run(self): # noqa
+
+    def run(self):  # noqa
         # we need to download nuget so throw the exception if we don't get it
         DownloadNuget()
         sdist.run(self)
@@ -27,7 +28,8 @@ class PostSdistCommand(sdist):
 
 class PostInstallCommand(install):
     """Post-install."""
-    def run(self): # noqa
+
+    def run(self):  # noqa
         try:
             DownloadNuget()
         except Exception:
@@ -37,7 +39,8 @@ class PostInstallCommand(install):
 
 class PostDevCommand(develop):
     """Post-develop."""
-    def run(self): # noqa
+
+    def run(self):  # noqa
         try:
             DownloadNuget()
         except Exception:
@@ -53,43 +56,43 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/tianocore/edk2-pytool-extensions",
-    license='BSD-2-Clause-Patent',
+    license="BSD-2-Clause-Patent",
     packages=setuptools.find_packages(),
     use_scm_version=True,
-    setup_requires=['setuptools_scm'],
+    setup_requires=["setuptools_scm"],
     python_requires=">=3.9.0",
     cmdclass={
-        'sdist': PostSdistCommand,
-        'install': PostInstallCommand,
-        'develop': PostDevCommand,
+        "sdist": PostSdistCommand,
+        "install": PostInstallCommand,
+        "develop": PostDevCommand,
     },
     include_package_data=True,
     entry_points={
-        'console_scripts': ['stuart_setup=edk2toolext.invocables.edk2_setup:main',
-                            'stuart_update=edk2toolext.invocables.edk2_update:main',
-                            'stuart_build=edk2toolext.invocables.edk2_platform_build:main',
-                            'stuart_ci_build=edk2toolext.invocables.edk2_ci_build:main',
-                            'stuart_ci_setup=edk2toolext.invocables.edk2_ci_setup:main',
-                            'stuart_pr_eval=edk2toolext.invocables.edk2_pr_eval:main',
-                            'omnicache=edk2toolext.omnicache:main',
-                            'nuget-publish=edk2toolext.nuget_publishing:go',
-                            'sig_db_tool=edk2toolext.uefi.sig_db_tool:main',
-                            'firmware_policy_tool=edk2toolext.windows.policy.firmware_policy_tool:main',
-                            'edk2_capsule_tool=edk2toolext.capsule.capsule_tool:main',
-                            'versioninfo_tool=edk2toolext.versioninfo.versioninfo_tool:main',
-                            'validate_image_tool=edk2toolext.image_validation:main']
+        "console_scripts": [
+            "stuart_setup=edk2toolext.invocables.edk2_setup:main",
+            "stuart_update=edk2toolext.invocables.edk2_update:main",
+            "stuart_build=edk2toolext.invocables.edk2_platform_build:main",
+            "stuart_ci_build=edk2toolext.invocables.edk2_ci_build:main",
+            "stuart_ci_setup=edk2toolext.invocables.edk2_ci_setup:main",
+            "stuart_pr_eval=edk2toolext.invocables.edk2_pr_eval:main",
+            "omnicache=edk2toolext.omnicache:main",
+            "nuget-publish=edk2toolext.nuget_publishing:go",
+            "sig_db_tool=edk2toolext.uefi.sig_db_tool:main",
+            "firmware_policy_tool=edk2toolext.windows.policy.firmware_policy_tool:main",
+            "edk2_capsule_tool=edk2toolext.capsule.capsule_tool:main",
+            "versioninfo_tool=edk2toolext.versioninfo.versioninfo_tool:main",
+            "validate_image_tool=edk2toolext.image_validation:main",
+        ]
     },
     install_requires=[
-        'pyyaml>=6.0.0',
-        'edk2-pytool-library>=0.14.0',
-        'pefile>=2023.2.7',
-        'semantic_version>=2.10.0',
-        'GitPython>=3.1.30',
-        'cryptography >= 39.0.1'
+        "pyyaml>=6.0.0",
+        "edk2-pytool-library>=0.14.0",
+        "pefile>=2023.2.7",
+        "semantic_version>=2.10.0",
+        "GitPython>=3.1.30",
+        "cryptography >= 39.0.1",
     ],
-    extras_require={
-        'openssl': ['pyopenssl']
-    },
+    extras_require={"openssl": ["pyopenssl"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",
@@ -98,6 +101,6 @@ setuptools.setup(
         "Intended Audience :: Developers",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11"
-    ]
+        "Programming Language :: Python :: 3.11",
+    ],
 )


### PR DESCRIPTION
This commit chain switches form flake8 to black. While flake8 and black are different (flake8 is a format checker while black is an auto-formatter [that meets PEP8 requirements that flake8 checks for]), black can also be a format checker. This commit change sets up auto format on save for any person using vscode, and now verifies format compliance during CI via black instead of flake8.