### PR TITLE
Fixed setup --force when submodules don't exist

### DIFF
--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -418,6 +418,22 @@ def clean(abs_file_system_path, ignore_files=[]):
         repo.git.clean(*params)
 
 
+def submodule_clean(abs_file_system_path, submodule, ignore_files=None):
+    """Resets and cleans a submodule of the repo.
+
+    Args:
+        abs_file_system_path (PathLike): repo directory
+        submodule (obj): object containing path (relative) attribute
+        ignore_files (list, optional): list of files to ignore when performing a clean. Defaults to [].
+    """
+    submodule_path = Path(submodule.path).as_posix()
+    with Repo(abs_file_system_path) as repo:
+        if repo.submodule(submodule_path).module_exists():
+            clean(os.path.join(abs_file_system_path, submodule.path), ignore_files or [])
+        else:
+            logger.debug(f"Submodule {submodule_path} didn't exist/wasn't initialized.")
+
+
 def submodule_resolve(abs_file_system_path, submodule, omnicache_path=None):
     """Resolves a submodule to the specified branch and commit in .gitmodules.
 

--- a/edk2toolext/invocables/edk2_setup.py
+++ b/edk2toolext/invocables/edk2_setup.py
@@ -16,7 +16,7 @@ import logging
 from typing import List
 from edk2toolext import edk2_logging
 from edk2toolext.environment.repo_resolver import submodule_resolve, clean, submodule_clean, repo_details
-from edk2toolext.environment.repo_resolver import InvalidGitRepositoryError
+from edk2toolext.environment.repo_resolver import InvalidGitRepositoryError, GitCommandError
 from edk2toolext.environment import version_aggregator
 from edk2toolext.invocables.edk2_multipkg_aware_invocable import Edk2MultiPkgAwareInvocable
 from edk2toolext.invocables.edk2_multipkg_aware_invocable import MultiPkgAwareSettingsInterface
@@ -145,6 +145,10 @@ class Edk2PlatformSetup(Edk2MultiPkgAwareInvocable):
                     logging.error(f"Error when trying to clean {submodule_path}")
                     logging.error(f"Invalid Git Repository at {submodule_path}")
                     return -1
+                except ValueError as e:
+                    logging.error(f"Error when trying to clean {submodule_path}")
+                    logging.error(e)
+                    return -1
 
         # Resolve all of the submodules to the specifed branch and commit. i.e. sync, then update
         for submodule in required_submodules:
@@ -164,6 +168,10 @@ class Edk2PlatformSetup(Edk2MultiPkgAwareInvocable):
             except InvalidGitRepositoryError:
                 logging.error(f"Error when trying to resolve {submodule.path}")
                 logging.error(f"Invalid Git Repository at {submodule.path}")
+                return -1
+            except GitCommandError as e:
+                logging.error(f"Error when trying to resolve {submodule.path}")
+                logging.error(e)
                 return -1
 
         return 0

--- a/edk2toolext/invocables/edk2_setup.py
+++ b/edk2toolext/invocables/edk2_setup.py
@@ -15,7 +15,7 @@ import os
 import logging
 from typing import List
 from edk2toolext import edk2_logging
-from edk2toolext.environment.repo_resolver import submodule_resolve, clean, repo_details
+from edk2toolext.environment.repo_resolver import submodule_resolve, clean, submodule_clean, repo_details
 from edk2toolext.environment.repo_resolver import InvalidGitRepositoryError
 from edk2toolext.environment import version_aggregator
 from edk2toolext.invocables.edk2_multipkg_aware_invocable import Edk2MultiPkgAwareInvocable
@@ -139,7 +139,7 @@ class Edk2PlatformSetup(Edk2MultiPkgAwareInvocable):
                 try:
                     submodule_path = os.path.join(workspace_path, required_submodule.path)
                     edk2_logging.log_progress(f'## Cleaning Git Submodule: {required_submodule.path}')
-                    clean(submodule_path)
+                    submodule_clean(workspace_path, required_submodule)
                     edk2_logging.log_progress('## Done.\n')
                 except InvalidGitRepositoryError:
                     logging.error(f"Error when trying to clean {submodule_path}")

--- a/edk2toolext/tests/test_edk2_setup.py
+++ b/edk2toolext/tests/test_edk2_setup.py
@@ -96,7 +96,7 @@ class Settings(SetupSettingsManager):
 
     def GetRequiredSubmodules(self) -> list[RequiredSubmodule]:
         return [
-            RequiredSubmodule('Platforms', True)
+            RequiredSubmodule('Common\BAD_REPO', True)
         ]
 
     def GetPackagesSupported(self) -> list[str]:


### PR DESCRIPTION
If `stuart_setup` was called with the `--force` option when the submodules aren't initialized (either new clone or they were deinit'd), the setup would fail. This fixes that problem.