### PR TITLE
edk2_pr_eval: Add Policy 5

### DIFF
--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -310,7 +310,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
 
         #
         # Policy 5: If a file changed is a Library INF file, then build all packages that depend on that Library
-        # Only supported on packages with a ci.dsc file which contains a Compiler Plugin dsc path
+        # Only supported on packages with a ci.dsc file which contains PrEval.DscPath section.
         #
         for f in filter(lambda f: Path(f).suffix == ".inf", files):
             for p in remaining_packages[:]:
@@ -515,7 +515,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
             data = yaml.safe_load(f)
             dsc = data.get("PrEval", {"DscPath": None})["DscPath"]
             dsc = str(pkg_path / dsc) if dsc else None
-            defines = data.get("Defines", None)
+            defines = data.get("Defines", {})
             return (dsc, defines)
 
 

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -322,6 +322,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
                 
                 if f in dsc_parser.Libs:
                     packages_to_build[p] = f"Policy 5 - Package depends on Library {f}"
+                    remaining_packages.remove(p)
 
         # All done now return result
 

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -313,10 +313,10 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
         # Policy 5: If a file changed is a Library INF file, then build all packages that depend on that Library
         # Only supported on packages with a ci.dsc file which contains a Compiler Plugin dsc path
         #
-        for f in filter(lambda f: Path(f).is_file() and Path(f).suffix == ".inf", files):
+        for f in filter(lambda f: Path(f).suffix == ".inf", files):
             for p in remaining_packages[:]:
                 dsc = self._get_pkg_dsc_path(p)
-                if dsc is None:
+                if not dsc:
                     logging.debug(f"Policy 5 - Package {p} skipped due to missing ci.dsc file or missing Compiler "
                                   "Plugin DSC path.")
                     continue

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -318,7 +318,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
                 if not dsc.exists():
                     self.logger.warning(f"Failed to find DSC file for package {p}")
                     break
-   
+
                 dsc_parser = DscParser()
                 dsc_parser.SetBaseAbsPath(self.edk2_path_obj.WorkspacePath)
                 dsc_parser.SetPackagePaths(self.edk2_path_obj.PackagePathList)

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -508,10 +508,9 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
         pkg_path = Path(self.edk2_path_obj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(pkg_name))
         ci_file = pkg_path.joinpath(f'{pkg_name}.ci.yaml')
 
-
         if not ci_file.exists():
             return None
-        
+
         with open(ci_file, 'r') as f:
             data = yaml.safe_load(f)
             try:

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -313,8 +313,12 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
         #
         for f in filter(lambda f: Path(f).suffix == ".inf", files):
             for p in remaining_packages[:]:
-                dsc = next(Path(self.edk2_path_obj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(p)).glob('*.dsc'))
-                
+                try: # Next() will throw a StopIteration error if there was no match to the glob pattern.
+                    dsc = next(Path(self.edk2_path_obj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(p)).glob(f'{p}.dsc'))
+                except StopIteration:
+                    self.logger.warning(f"Failed to find DSC file for package {p}")
+                    break
+   
                 dsc_parser = DscParser()
                 dsc_parser.SetBaseAbsPath(self.edk2_path_obj.WorkspacePath)
                 dsc_parser.SetPackagePaths(self.edk2_path_obj.PackagePathList)

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -323,7 +323,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
                 dsc_parser.SetBaseAbsPath(self.edk2_path_obj.WorkspacePath)
                 dsc_parser.SetPackagePaths(self.edk2_path_obj.PackagePathList)
                 dsc_parser.ParseFile(dsc)
-                
+
                 if f in dsc_parser.Libs:
                     packages_to_build[p] = f"Policy 5 - Package depends on Library {f}"
                     remaining_packages.remove(p)

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -313,11 +313,9 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
         # Policy 5: If a file changed is a Library INF file, then build all packages that depend on that Library
         # Only supported on packages with a ci.dsc file which contains a Compiler Plugin dsc path
         #
-        logging.warning(files)
         for f in filter(lambda f: Path(f).suffix == ".inf", files):
             for p in remaining_packages[:]:
                 dsc = self._get_pkg_dsc_path(p)
-                logging.warning(dsc)
                 if not dsc:
                     logging.debug(f"Policy 5 - Package {p} skipped due to missing ci.dsc file or missing Compiler "
                                   "Plugin DSC path.")
@@ -516,7 +514,8 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
         with open(ci_file, 'r') as f:
             data = yaml.safe_load(f)
             try:
-                return str(pkg_path / data["CompilerPlugin"]["DscPath"])
+                dsc = data["CompilerPlugin"]["DscPath"]
+                return str(pkg_path / dsc) if dsc else None
             except KeyError:
                 return None
 

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -313,7 +313,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
         # Policy 5: If a file changed is a Library INF file, then build all packages that depend on that Library
         # Only supported on packages with a ci.dsc file which contains a Compiler Plugin dsc path
         #
-        for f in filter(lambda f: Path(f).suffix == ".inf", files):
+        for f in filter(lambda f: Path(f).is_file() and Path(f).suffix == ".inf", files):
             for p in remaining_packages[:]:
                 dsc = self._get_pkg_dsc_path(p)
                 if dsc is None:

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -308,6 +308,21 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
                         remaining_packages.remove(p)  # remove from remaining packages
                         break
 
+        #
+        # Policy 5: If a file changed is a Library INF file, then build all packages that depend on that Library
+        #
+        for f in filter(lambda f: Path(f).suffix == ".inf", files):
+            for p in remaining_packages[:]:
+                dsc = next(Path(self.edk2_path_obj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(p)).glob('*.dsc'))
+                
+                dsc_parser = DscParser()
+                dsc_parser.SetBaseAbsPath(self.edk2_path_obj.WorkspacePath)
+                dsc_parser.SetPackagePaths(self.edk2_path_obj.PackagePathList)
+                dsc_parser.ParseFile(dsc)
+                
+                if f in dsc_parser.Libs:
+                    packages_to_build[p] = f"Policy 5 - Package depends on Library {f}"
+
         # All done now return result
 
         return packages_to_build

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -313,9 +313,11 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
         # Policy 5: If a file changed is a Library INF file, then build all packages that depend on that Library
         # Only supported on packages with a ci.dsc file which contains a Compiler Plugin dsc path
         #
+        logging.warning(files)
         for f in filter(lambda f: Path(f).suffix == ".inf", files):
             for p in remaining_packages[:]:
                 dsc = self._get_pkg_dsc_path(p)
+                logging.warning(dsc)
                 if not dsc:
                     logging.debug(f"Policy 5 - Package {p} skipped due to missing ci.dsc file or missing Compiler "
                                   "Plugin DSC path.")

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -313,7 +313,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
         #
         for f in filter(lambda f: Path(f).suffix == ".inf", files):
             for p in remaining_packages[:]:
-                try: # Next() will throw a StopIteration error if there was no match to the glob pattern.
+                try: # next() will raise a StopIteration exception if there was no match to the glob pattern.
                     dsc = next(Path(self.edk2_path_obj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(p)).glob(f'{p}.dsc'))
                 except StopIteration:
                     self.logger.warning(f"Failed to find DSC file for package {p}")

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -313,9 +313,9 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
         #
         for f in filter(lambda f: Path(f).suffix == ".inf", files):
             for p in remaining_packages[:]:
-                try: # next() will raise a StopIteration exception if there was no match to the glob pattern.
-                    dsc = next(Path(self.edk2_path_obj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(p)).glob(f'{p}.dsc'))
-                except StopIteration:
+                dsc = Path(self.edk2_path_obj.GetAbsolutePathOnThisSystemFromEdk2RelativePath(p)) / f'{p}.dsc'
+
+                if not dsc.exists():
                     self.logger.warning(f"Failed to find DSC file for package {p}")
                     break
    

--- a/tests.integration/edk2_stuart_pr_eval.robot
+++ b/tests.integration/edk2_stuart_pr_eval.robot
@@ -64,11 +64,11 @@ Test Stuart PR for Policy 1 special files in PrEvalSettingsManager
 
     [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
-Test Stuart PR for Policy 2 in package change of private inf file
+Test Stuart PR for Policy 2 in package change of private file
     [Tags]           PrEval  Edk2
 
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
-    ${file_to_modify}=   Set Variable    MdePkg${/}Library${/}BaseLib${/}BaseLib.inf
+    ${file_to_modify}=   Set Variable    MdePkg${/}Library${/}BaseLib${/}Cpu.c
 
     Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
@@ -192,6 +192,31 @@ Test Stuart PR for Policy 4 module c file changed that platform dsc does not dep
     # Platform CI test DSC dependency on implementation file # Policy 4
     ${pkgs}=  Stuart pr evaluation  ${platform_ci_file}  OvmfPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Should Be Empty    ${pkgs}
+
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
+
+Test Stuart PR for Policy 5 library inf changed
+    [Tags]           PrEval  Edk2
+
+    ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
+    ${file_to_modify}=   Set Variable    MdePkg${/}Library${/}BaseLib${/}BaseLib.inf
+
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+    Make new branch  ${branch_name}  ${ws_root}
+
+    Append To File  ${ws_root}${/}${file_to_modify}
+    ...  Hello World!! Making a change for fun.
+
+    Stage changed file  ${file_to_modify}  ${ws_root}
+    Commit changes  "Changes"  ${ws_root}
+
+    # Core CI test same package  # policy 2
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg  ${default_branch}  ${EMPTY}  ${ws_root}
+    Confirm same contents  ${pkgs}  MdePkg
+
+    # Core CI test another package and make sure a it doesn't need to build
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdeModulePkg  ${default_branch}  ${EMPTY}  ${ws_root}
+    Confirm same contents    ${pkgs}  MdeModulePkg
 
     [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 

--- a/tests.integration/mu_stuart_pr_eval.robot
+++ b/tests.integration/mu_stuart_pr_eval.robot
@@ -220,9 +220,9 @@ Test Stuart PR using ProjectMu for all policies when a PR contains a deleted fol
     Stage changed file  ${file_to_modify}  ${ws_root}
     Commit changes  "Changes"  ${ws_root}
 
-    # Platform CI test DSC dependency on implementation file # Policy 4
+    # PcAtChipsetPkg uses BasePrintLib/BasePrintLib.inf, Policy 5 requires it be built
     ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  PcAtChipsetPkg  ${default_branch}  ${EMPTY}  ${ws_root}
-    Should Be Empty    ${pkgs}
+    Confirm same contents  ${pkgs}  PcAtChipsetPkg
 
     [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 

--- a/tests.integration/mu_stuart_pr_eval.robot
+++ b/tests.integration/mu_stuart_pr_eval.robot
@@ -73,11 +73,11 @@ Test Stuart PR using ProjectMu for Policy 1 special files in PrEvalSettingsManag
 
     [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 
-Test Stuart PR using ProjectMu for Policy 2 in package change of private inf file
+Test Stuart PR using ProjectMu for Policy 2 in package change of private file
     [Tags]           PrEval  ProjectMu
 
     ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
-    ${file_to_modify}=   Set Variable    MdePkg${/}Library${/}BaseLib${/}BaseLib.inf
+    ${file_to_modify}=   Set Variable    MdePkg${/}Library${/}BaseLib${/}Cpu.c
 
     Reset git repo to default branch  ${ws_root}  ${default_branch}
     Make new branch  ${branch_name}  ${ws_root}
@@ -159,6 +159,31 @@ Test Stuart PR using ProjectMu for Policy 3 for package dependency on change of 
     # Core CI test  package dependency # Policy 3
     ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg,MdeModulePkg,PcAtChipsetPkg  ${default_branch}  ${EMPTY}  ${ws_root}
     Confirm same contents  ${pkgs}  PcAtChipsetPkg
+
+    [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
+
+Test Stuart PR using ProjectMu for Policy 5 library inf changed
+    [Tags]           PrEval  ProjectMu
+
+    ${branch_name}=      Set Variable    PR_Rand_${{random.randint(0, 10000)}}
+    ${file_to_modify}=   Set Variable    MdePkg${/}Library${/}BaseLib${/}BaseLib.inf
+
+    Reset git repo to default branch  ${ws_root}  ${default_branch}
+    Make new branch  ${branch_name}  ${ws_root}
+
+    Append To File  ${ws_root}${/}${file_to_modify}
+    ...  Hello World!! Making a change for fun.
+
+    Stage changed file  ${file_to_modify}  ${ws_root}
+    Commit changes  "Changes"  ${ws_root}
+
+    # Core CI test same package  # policy 2
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdePkg  ${default_branch}  ${EMPTY}  ${ws_root}
+    Confirm same contents  ${pkgs}  MdePkg
+
+    # Core CI test another package and make sure a it doesn't need to build
+    ${pkgs}=  Stuart pr evaluation  ${core_ci_file}  MdeModulePkg  ${default_branch}  ${EMPTY}  ${ws_root}
+    Confirm same contents  ${pkgs}  MdeModulePkg
 
     [Teardown]  Delete branch  ${branch_name}  ${default_branch}  ${ws_root}
 


### PR DESCRIPTION
Policy 5 is used when a library INF has been changed. Policy 5 will parse each package's dsc (Found via `<pkg>.ci.yaml`.`PrEval`.`DscPath`) and mark a package to be built if that package has a dependency on the changed library INF.

Consuming repo's must update each package's ci.yaml file to now include a new top-level section "PrEval" with an entry "DscPath". This will be the package's DSC used to compile all components and libraries the package provides.

``` yaml
{
    "PrEval" : {
        "DscPath": "path/to/dsc"
    }
}
```