### PR TITLE
repo_resolver: add git version Check

### DIFF
--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -15,16 +15,17 @@ The intent is to keep all git functionality consolidated in this module. Current
 edk2_setup.py, and git_dependency.py use this module to perform git operations.
 """
 import os
-from logging import getLogger
+import logging
 from edk2toolext import edk2_logging
+from edk2toollib.utility_functions import version_compare
 from git import Repo, GitCommandError, InvalidGitRepositoryError, NoSuchPathError
 from git.cmd import Git
 from git.util import rmtree
 from pathlib import Path
 
 
-logger = getLogger(__name__)
-
+logger = logging.getLogger(__name__)
+MIN_GIT_VERSION = "2.36.0"
 
 def resolve(file_system_path, dependency, force=False, ignore=False, update_ok=False):
     """Resolves a particular repo.
@@ -204,10 +205,17 @@ def repo_details(abs_file_system_path):
     Returns:
         (obj): Object with data members listed above
     """
+    git_version = ".".join(map(str, Git().version_info))
+    if version_compare(git_version, MIN_GIT_VERSION) < 0:
+        logging.error("FAILED!\n")
+        e = f"Upgrade Git! Current version is {git_version}. Minimum is {MIN_GIT_VERSION}"
+        logging.error(e)
+        raise RuntimeError(e)
+
     details = {
         "Path": Path(abs_file_system_path),
         "Valid": False,
-        "GitVersion": ".".join(map(str, Git().version_info)),
+        "GitVersion": git_version,
         "Initialized": False,
         "Bare": False,
         "Dirty": False,

--- a/edk2toolext/invocables/edk2_setup.py
+++ b/edk2toolext/invocables/edk2_setup.py
@@ -126,12 +126,6 @@ class Edk2PlatformSetup(Edk2MultiPkgAwareInvocable):
         version_aggregator.GetVersionAggregator().ReportVersion("Git",
                                                                 git_version,
                                                                 version_aggregator.VersionTypes.TOOL)
-        min_git = "2.36.0"
-        # This code is highly specific to the return value of "git version"...
-        if version_compare(min_git, git_version) > 0:
-            logging.error("FAILED!\n")
-            logging.error("Please upgrade Git! Current version is %s. Minimum is %s." % (git_version, min_git))
-            return -1
 
         # Pre-setup cleaning if "--force" is specified.
         if self.force_it:


### PR DESCRIPTION
Previously, the git version only mattered to edk2_setup, so the check was appropriate there. Now that the git version matters to much of the build system due to it's use of the `-z` flag when reading git worktrees, the check needed to be moved to a more appropriate place. This commit moves it from edk2_setup to repo_resolver.py:get_details()