### PR TITLE
repo_resolver.py: `repo_details()` to use first remote if origin does not exist

### DIFF
--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -238,7 +238,7 @@ def repo_details(abs_file_system_path):
             details["Dirty"] = repo.is_dirty(untracked_files=True)
             details["Initialized"] = True
             details["Url"] = repo.remotes.origin.url or repo.remotes[0].url
-            details["Url"] = repo.remotes.origin.url
+
     except (InvalidGitRepositoryError, NoSuchPathError):
         pass
     return details

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -237,6 +237,7 @@ def repo_details(abs_file_system_path):
             details["Bare"] = repo.bare
             details["Dirty"] = repo.is_dirty(untracked_files=True)
             details["Initialized"] = True
+            details["Url"] = repo.remotes.origin.url or repo.remotes[0].url
             details["Url"] = repo.remotes.origin.url
     except (InvalidGitRepositoryError, NoSuchPathError):
         pass

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -246,7 +246,6 @@ def repo_details(abs_file_system_path):
             details["Dirty"] = repo.is_dirty(untracked_files=True)
             details["Initialized"] = True
             details["Url"] = repo.remotes.origin.url if "origin" in repo.remotes else repo.remotes[0].url
-
     except (InvalidGitRepositoryError, NoSuchPathError):
         pass
     return details

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -245,7 +245,18 @@ def repo_details(abs_file_system_path):
             details["Bare"] = repo.bare
             details["Dirty"] = repo.is_dirty(untracked_files=True)
             details["Initialized"] = True
-            details["Url"] = repo.remotes.origin.url if "origin" in repo.remotes else repo.remotes[0].url
+
+            # 1. Use the remote associated with the branch if on a branch and it exists
+            if not repo.head.is_detached and repo.branches[repo.head.ref.name].tracking_branch():
+                remote_name = repo.branches[repo.head.ref.name].tracking_branch().remote_name
+                details["Url"] = repo.remotes[remote_name].url
+            # 2. Use the origin url if it exists
+            elif "origin" in repo.remotes:
+                details["Url"] = repo.remotes.origin.url
+            # 3. Use whatever the first remote is
+            else:
+                details["Url"] = repo.remotes[0].url
+
     except (InvalidGitRepositoryError, NoSuchPathError):
         pass
     return details

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -254,7 +254,7 @@ def repo_details(abs_file_system_path):
             elif "origin" in repo.remotes:
                 details["Url"] = repo.remotes.origin.url
             # 3. Use whatever the first remote is
-            else:
+            elif len(repo.remotes) > 0:
                 details["Url"] = repo.remotes[0].url
 
     except (InvalidGitRepositoryError, NoSuchPathError):

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -237,7 +237,7 @@ def repo_details(abs_file_system_path):
             details["Bare"] = repo.bare
             details["Dirty"] = repo.is_dirty(untracked_files=True)
             details["Initialized"] = True
-            details["Url"] = repo.remotes.origin.url or repo.remotes[0].url
+            details["Url"] = repo.remotes.origin.url if "origin" in repo.remotes else repo.remotes[0].url
 
     except (InvalidGitRepositoryError, NoSuchPathError):
         pass


### PR DESCRIPTION
In some scenarios, the origin branch does not exist; due to this hardcoding the URL to be the origin URL can fail. In this scenario, we default to the first existing remote's URL.