### PR TITLE
Switch to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -85,10 +85,9 @@ setuptools.setup(
         'pefile>=2023.2.7',
         'semantic_version>=2.10.0',
         'GitPython>=3.1.30',
-        'cryptography >= 39.0.1'
     ],
     extras_require={
-        'openssl': ['pyopenssl']
+        'openssl': ['pyopenssl', 'cryptography >= 39.0.1']
     },
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Direct use of was deprecated then removed. It is necessary to transition to pyproject.toml for building edk2-pytool-extensions.