### PR TITLE
Resolve CI failures [REBASE&FF]

### DIFF
--- a/edk2toolext/tests/test_nuget_dependency.py
+++ b/edk2toolext/tests/test_nuget_dependency.py
@@ -100,8 +100,8 @@ class TestNugetDependency(unittest.TestCase):
         # delete the package file
         original = NugetDependency.GetNugetCmd()[-1]  # get last item which will be exe path
         os.remove(original)
-        path = NugetDependency.GetNugetCmd()
-        self.assertIsNone(path)  # Should not be found
+        path = NugetDependency.GetNugetCmd()[-1]
+        self.assertTrue(os.path.isfile(path))
 
     def test_nuget_env_var(self):
         if NugetDependency.NUGET_ENV_VAR_NAME in os.environ:

--- a/integration_test/Shared_Keywords.robot
+++ b/integration_test/Shared_Keywords.robot
@@ -153,7 +153,7 @@ Stuart platform build
     [Arguments]  ${setting_file}  ${arch}  ${target}  ${tool_chain}  ${ws}
     Log to console  Stuart Build
     ${result}=   Run Process    stuart_build
-    ...  -c  ${setting_file}  -a  ${arch}  TOOL_CHAIN_TAG\=${tool_chain}  TARGET\=${target}
+    ...  -c  ${setting_file}  -a  ${arch}  TOOL_CHAIN_TAG\=${tool_chain}  TARGET\=${target}  CODE_COVERAGE\=FALSE
     ...  cwd=${ws}  stdout=stdout.txt  stderr=stderr.txt
     Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
     Should Be Equal As Integers  ${result.rc}  0
@@ -171,7 +171,7 @@ Stuart CI build
     [Arguments]  ${setting_file}  ${archs}  ${targets}  ${packages}  ${tool_chain}  ${ws}
     Log to console  Stuart CI Build
     ${result}=   Run Process    stuart_ci_build
-    ...  -c  ${setting_file}  -a  ${archs}  -t  ${targets}  -p  ${packages}  TOOL_CHAIN_TAG\=${tool_chain}
+    ...  -c  ${setting_file}  -a  ${archs}  -t  ${targets}  -p  ${packages}  TOOL_CHAIN_TAG\=${tool_chain}  CODE_COVERAGE\=FALSE
     ...  cwd=${ws}  stdout=stdout.txt  stderr=stderr.txt
     Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
     Should Be Equal As Integers  ${result.rc}  0

--- a/setup.py
+++ b/setup.py
@@ -20,28 +20,18 @@ with open("readme.md", "r") as fh:
 class PostSdistCommand(sdist):
     """Post-sdist."""
     def run(self): # noqa
-        # we need to download nuget so throw the exception if we don't get it
-        DownloadNuget()
         sdist.run(self)
 
 
 class PostInstallCommand(install):
     """Post-install."""
     def run(self): # noqa
-        try:
-            DownloadNuget()
-        except Exception:
-            pass
         install.run(self)
 
 
 class PostDevCommand(develop):
     """Post-develop."""
     def run(self): # noqa
-        try:
-            DownloadNuget()
-        except Exception:
-            pass
         develop.run(self)
 
 


### PR DESCRIPTION
Resolves two CI failures in edk2-pytool-extensions:

## Commit 1
Integration tests were failing due to the addition of the command line
build variable CODE_COVERAGE being set to true by default. This adds the
flag and sets it to false in integration tests as this execution is a
build plugin and outside the scope of edk2-pytool-extensions.

## Commit 2

With recent changes to pip, using a method from the package during the
setup of the package is no longer supported. Due to this, it was decided
to move when we download NuGet to when we first attempt to use it. This
has multiple benifits as we now no longer download NuGet, even if the
user is supplying their own version of NuGet, and our download NuGet
functionality remains inside the package and easily testable, rather
then an extra function inside of setup.py

Additionally we no longer use the deprecated module pkg_resources to
identify the binary folder inside the package, instead using
importlib's resources module to do this.