### PR TITLE
edk2_logging.py: increase specificity of NuGet API key

### DIFF
--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -256,8 +256,9 @@ class Edk2LogFilter(logging.Filter):
         self._currentSection = "root"
 
         secrets_regex_strings = [
-            r"[A-Za-z0-9]{46}",  # Nuget API Key
+            r"[a-z0-9]{46}",  # Nuget API Key is generated as all lowercase
             r"gh[pousr]_[A-Za-z0-9_]+",  # Github PAT
+            r"[a-z0-9]{52}", # Azure PAT is generated as all lowercase 
         ]
 
         self.secrets_regex = re.compile(r"{}".format("|".join(secrets_regex_strings)), re.IGNORECASE)

--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -258,7 +258,7 @@ class Edk2LogFilter(logging.Filter):
         secrets_regex_strings = [
             r"[a-z0-9]{46}",  # Nuget API Key is generated as all lowercase
             r"gh[pousr]_[A-Za-z0-9_]+",  # Github PAT
-            r"[a-z0-9]{52}", # Azure PAT is generated as all lowercase 
+            r"[a-z0-9]{52}",  # Azure PAT is generated as all lowercase
         ]
 
         self.secrets_regex = re.compile(r"{}".format("|".join(secrets_regex_strings)), re.IGNORECASE)


### PR DESCRIPTION
The False positive rate of API keys being filtered out was a detriment to developer productivity per #502. This commit reduces the API key to be only lowercase a-z as NuGet API keys generated from NuGet.org are generated as all lowercase. This should reduce the amount of false positives noted, specifically false positives due to the long folder names in the build output folder.