### PR TITLE
integration_tests: Update Qemu and revert 71a2d5a [REBASE&FF]

### DIFF
--- a/integration_test/Shared_Keywords.robot
+++ b/integration_test/Shared_Keywords.robot
@@ -162,7 +162,7 @@ Stuart platform run
     [Arguments]  ${setting_file}  ${arch}  ${target}  ${tool_chain}  ${additional_flags}  ${ws}
     Log to console  Stuart Build Run
     ${result}=   Run Process    stuart_build
-    ...  -c  ${setting_file}  -a  ${arch}  TOOL_CHAIN_TAG\=${tool_chain}  TARGET\=${target}  --FlashOnly  QEMU_HEADLESS\=TRUE  QEMU_CPUHP_QUIRK\=TRUE  ${additional_flags}
+    ...  -c  ${setting_file}  -a  ${arch}  TOOL_CHAIN_TAG\=${tool_chain}  TARGET\=${target}  --FlashOnly  QEMU_HEADLESS\=TRUE  ${additional_flags}
     ...  cwd=${ws}  stdout=stdout.txt  stderr=stderr.txt
     Log Many	stdout: ${result.stdout}  stderr: ${result.stderr}
     Should Be Equal As Integers  ${result.rc}  0

--- a/integration_test/azure-pipelines/windows-robot-integration-test.yml
+++ b/integration_test/azure-pipelines/windows-robot-integration-test.yml
@@ -60,7 +60,7 @@ jobs:
   - script: pip install -e .
     displayName: 'Install from Source'
 
-  - powershell: choco install qemu --version=2020.08.14; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
+  - powershell: choco install qemu --version=2023.4.24; Write-Host "##vso[task.prependpath]c:\Program Files\qemu"
     displayName: Install QEMU and Set QEMU on path # friendly name displayed in the UI
     condition: and(contains(variables.Image, 'windows'), succeeded())
   


### PR DESCRIPTION
Updates Qemu to 2023.4.24 (which is version 8.0.0) and reverts the temporary change that allows qemu to boot until qemu 8.0.0 was released