### PR TITLE
azure-pipelines: build a wheel update

### DIFF
--- a/azure-pipelines/templates/build-publish-whl-steps.yml
+++ b/azure-pipelines/templates/build-publish-whl-steps.yml
@@ -13,7 +13,7 @@ steps:
 - script: pip install --upgrade -e .[publish]
   displayName: 'Install PyPI publishing requirements'
 
-- script: python build --wheel --sdist
+- script: python -m build --wheel --sdist
   displayName: 'Build a wheel'
 
 - task: PythonScript@0


### PR DESCRIPTION
The `Build a wheel` azure pipeline step fails as the `-m` flag specifying we are calling a python module rather than a python file was not included. This results in the building of the wheel failing. This commit adds the -m flag to the command.