### PR TITLE
pyproject.toml: update readme content-type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "edk2-pytool-extensions"
 maintainers = [{name = "EDK2 Pytool Maintainers", email = "edk2-pytools@microsoft.com"}]
 dynamic = ["version"]
 description = "Python tools supporting UEFI EDK2 firmware development"
-readme = {file = "readme.md", content-type = "markdown"}
+readme = {file = "readme.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
 dependencies = [
     "edk2-pytool-library>=0.14.0",


### PR DESCRIPTION
Updates the project's readme `content-type` from markdown to text/markdown as specified by PEP 621. Due to the incorrect content-type, the readme was not being properly displayed on PyPi releases.