### PR TITLE
uefi_build: missing env error handling

### DIFF
--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -473,7 +473,12 @@ class UefiBuilder(object):
                           os.path.normpath(os.path.join(self.ws, self.env.GetValue("OUTPUT_DIRECTORY"))),
                           "Computed in SetEnv")
 
-        target = self.env.GetValue("TARGET")
+        target = self.env.GetValue("TARGET", None)
+        if target is None:
+            logging.error("Environment variable TARGET must be set to a build target.")
+            logging.error("Review the 'CLI Env Guide' section provided when using stuart_build with the -help flag.")
+            return -1
+
         self.env.SetValue("BUILD_OUTPUT_BASE", os.path.join(self.env.GetValue(
             "BUILD_OUT_TEMP"), target + "_" + self.env.GetValue("TOOL_CHAIN_TAG")), "Computed in SetEnv")
 
@@ -638,7 +643,12 @@ class UefiBuilder(object):
             # Get the tool chain tag and then find the family
             # need to parse tools_def and find *_<TAG>_*_*_FAMILY
             # Example:  *_VS2019_*_*_FAMILY        = MSFT
-            tag = "*_" + self.env.GetValue("TOOL_CHAIN_TAG") + "_*_*_FAMILY"
+            tool_chain = self.env.GetValue("TOOL_CHAIN_TAG", None)
+            if tool_chain is None:
+                logging.error("Environment variable TOOL_CHAIN_TAG must be set to a tool chain.")
+                logging.error("Review the 'CLI Env Guide' section provided when using stuart_build with the -help flag.")
+                return -1
+            tag = "*_" + tool_chain + "_*_*_FAMILY"
             tool_chain_family = tdp.Dict.get(tag, "UNKNOWN")
             self.env.SetValue("FAMILY", tool_chain_family, "DSC Spec macro - from tools_def.txt")
 

--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -476,7 +476,8 @@ class UefiBuilder(object):
         target = self.env.GetValue("TARGET", None)
         if target is None:
             logging.error("Environment variable TARGET must be set to a build target.")
-            logging.error("Review the 'CLI Env Guide' section provided when using stuart_build with the -help flag.")
+            logging.error("Review the 'CLI Env Guide' section provided when using stuart_build "\
+                          "with the -help flag.")
             return -1
 
         self.env.SetValue("BUILD_OUTPUT_BASE", os.path.join(self.env.GetValue(
@@ -646,7 +647,8 @@ class UefiBuilder(object):
             tool_chain = self.env.GetValue("TOOL_CHAIN_TAG", None)
             if tool_chain is None:
                 logging.error("Environment variable TOOL_CHAIN_TAG must be set to a tool chain.")
-                logging.error("Review the 'CLI Env Guide' section provided when using stuart_build with the -help flag.")
+                logging.error("Review the 'CLI Env Guide' section provided when using stuart_build "\
+                              "with the -help flag.")
                 return -1
             tag = "*_" + tool_chain + "_*_*_FAMILY"
             tool_chain_family = tdp.Dict.get(tag, "UNKNOWN")

--- a/tests.unit/test_uefi_build.py
+++ b/tests.unit/test_uefi_build.py
@@ -192,7 +192,7 @@ def test_missing_TARGET(tmp_path, caplog):
         target_folder = os.path.join(tmp_path, "Conf", "target.template")
         os.remove(target_folder)
         TestUefiBuild.write_to_file(target_folder, ["ACTIVE_PLATFORM = Test.dsc\n",
-                                                  "TOOL_CHAIN_TAG = VS2022\n"])
+                                                    "TOOL_CHAIN_TAG = VS2022\n"])
 
         shell_environment.GetBuildVars().SetValue("EDK_TOOLS_PATH",
                                                   str(tmp_path),
@@ -204,7 +204,6 @@ def test_missing_TARGET(tmp_path, caplog):
         ret = builder.Go(str(tmp_path), "", helper, manager)
 
         # two error messages are logged when the environment variable is missing
-        print(caplog.records)
         assert ret == -1
         assert len(list(filter(lambda r: r.levelno == logging.ERROR, caplog.records))) == 2
         assert len(list(filter(lambda r: "TARGET" in r.message, caplog.records))) == 1

--- a/tests.unit/test_uefi_build.py
+++ b/tests.unit/test_uefi_build.py
@@ -7,6 +7,8 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 import unittest
+import logging
+import pytest
 from edk2toolext.environment import uefi_build
 from edk2toolext.environment.plugintypes import uefi_helper_plugin
 from edk2toolext.environment.plugin_manager import PluginManager
@@ -58,7 +60,7 @@ class TestUefiBuild(unittest.TestCase):
                                                   "TOOL_CHAIN_TAG = test\n",
                                                   "TARGET = DEBUG\n"])
         tools_path = os.path.join(conf_folder, "tools_def.template")
-        TestUefiBuild.write_to_file(tools_path, ["hello"])
+        TestUefiBuild.write_to_file(tools_path, ["*_VS2022_*_*_FAMILY        = MSFT"])
         build_path = os.path.join(conf_folder, "build_rule.template")
         TestUefiBuild.write_to_file(build_path, ["hello"])
         platform_path = os.path.join(root, "Test.dsc")
@@ -161,6 +163,51 @@ class TestUefiBuild(unittest.TestCase):
         self.assertTrue(os.path.isfile(test_file_path))
 
     # TODO finish unit test
+
+def test_missing_TOOL_CHAIN_TAG(tmp_path, caplog):
+    with caplog.at_level(logging.ERROR):
+        TestUefiBuild().create_min_uefi_build_tree(tmp_path)
+        target_folder = os.path.join(tmp_path, "Conf", "target.template")
+        os.remove(target_folder)
+        TestUefiBuild.write_to_file(target_folder, ["ACTIVE_PLATFORM = Test.dsc\n"])
+
+        shell_environment.GetBuildVars().SetValue("EDK_TOOLS_PATH",
+                                                  str(tmp_path),
+                                                  "Set in build wrapper test")
+
+        builder = uefi_build.UefiBuilder()
+        manager = PluginManager()
+        helper = uefi_helper_plugin.HelperFunctions()
+        ret = builder.Go(str(tmp_path), "", helper, manager)
+
+        # two error messages are logged when the environment variable is missing
+        assert ret == -1
+        assert len(list(filter(lambda r: r.levelno == logging.ERROR, caplog.records))) == 2
+        assert len(list(filter(lambda r: "TOOL_CHAIN_TAG" in r.message, caplog.records))) == 1
+
+
+def test_missing_TARGET(tmp_path, caplog):
+    with caplog.at_level(logging.ERROR):
+        TestUefiBuild().create_min_uefi_build_tree(tmp_path)
+        target_folder = os.path.join(tmp_path, "Conf", "target.template")
+        os.remove(target_folder)
+        TestUefiBuild.write_to_file(target_folder, ["ACTIVE_PLATFORM = Test.dsc\n",
+                                                  "TOOL_CHAIN_TAG = VS2022\n"])
+
+        shell_environment.GetBuildVars().SetValue("EDK_TOOLS_PATH",
+                                                  str(tmp_path),
+                                                  "Set in build wrapper test")
+
+        builder = uefi_build.UefiBuilder()
+        manager = PluginManager()
+        helper = uefi_helper_plugin.HelperFunctions()
+        ret = builder.Go(str(tmp_path), "", helper, manager)
+
+        # two error messages are logged when the environment variable is missing
+        print(caplog.records)
+        assert ret == -1
+        assert len(list(filter(lambda r: r.levelno == logging.ERROR, caplog.records))) == 2
+        assert len(list(filter(lambda r: "TARGET" in r.message, caplog.records))) == 1
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds error logging and gracefully exit when either TARGET or TOOL_CHAIN_TAG has not been set in the environment.