### PR TITLE
edk2_logging: add gcc fatal error regex

### DIFF
--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -211,7 +211,8 @@ def scan_compiler_output(output_stream):
     # Would prefer to do something like r"(?:\/[^\/: ]*)+\/?:\d+:\d+: (error):"
     # but the script is currently setup on fixed formatting assumptions rather
     # than offering per rule flexibility to parse tokens via regex
-    gcc_error_exp = re.compile(r":\d+:\d+: (error):")
+    gcc_error_exp = re.compile(r":\d+:\d+: (error):", re.IGNORECASE)
+    gcc_fatal_error_exp = re.compile(r"fatal error:")
     edk2_error_exp = re.compile(r"error F(\d+):")
     build_py_error_exp = re.compile(r"error (\d+)E:")
     linker_error_exp = re.compile(r"error LNK(\d+):")
@@ -226,6 +227,9 @@ def scan_compiler_output(output_stream):
         if match is not None:
             error = output_compiler_error(match, line, "Compiler")
             problems.append((logging.ERROR, error))
+        match = gcc_fatal_error_exp.search(line)
+        if match is not None:
+            problems.append((logging.ERROR, line))
         match = warning_exp.search(line)
         if match is not None:
             error = output_compiler_error(match, line, "Compiler")

--- a/tests.unit/test_edk2_logging.py
+++ b/tests.unit/test_edk2_logging.py
@@ -52,11 +52,13 @@ class Test_edk2_logging(unittest.TestCase):
         output_stream = io.StringIO("<source_file>error A1: error 1 details\n"
                                     "<source_file>warning B2: warning 2 details\n"
                                     "<source_file>error C3: error 3 details\n"
-                                    "<source_file>warning D4: warning 4 details\n")
+                                    "<source_file>warning D4: warning 4 details\n"
+                                    "<source_file>fatal error: details\n")
         expected_output = [(logging.ERROR, "Compiler #1 from <source_file> error 1 details"),
                            (logging.WARNING, "Compiler #2 from <source_file> warning 2 details"),
                            (logging.ERROR, "Compiler #3 from <source_file> error 3 details"),
-                           (logging.WARNING, "Compiler #4 from <source_file> warning 4 details")]
+                           (logging.WARNING, "Compiler #4 from <source_file> warning 4 details"),
+                           (logging.ERROR, "<source_file>fatal error: details")]
         self.assertEqual(edk2_logging.scan_compiler_output(output_stream), expected_output)
 
         # Input with no issue (empty string)


### PR DESCRIPTION
Adds a regex that detects `fatal error` in the compiler output and logs the line as an error.

Example:
`BrotliCompress.c:20:10: fatal error: ./brotli/c/common/constants.h: No such file or directory`