### PR TITLE
uefi_helper_plugin.py: Log plugin load exception message at error level

### DIFF
--- a/edk2toolext/environment/plugintypes/uefi_helper_plugin.py
+++ b/edk2toolext/environment/plugintypes/uefi_helper_plugin.py
@@ -101,6 +101,6 @@ class HelperFunctions(object):
             except Exception as e:
                 logging.warning(
                     "Unable to register {0}".format(Descriptor.Name))
-                logging.info(e)
+                logging.error(e)
                 error += 1
         return error


### PR DESCRIPTION
Logs the message at error level so it is more likely to be seen by the user in their console so they know what to do.

Before:

```
> stuart_update -c .\Platforms\QemuQ35Pkg\PlatformBuild.py TOOL_CHAIN_TAG=VS2022
SECTION - Init Self Describing Environment
SECTION - Loading Plugins
WARNING - Unable to register Supervisor Policy Maker
Traceback (most recent call last):
  ...
Exception: One or more helper plugins failed to load.
```

After:

```
> stuart_update -c .\Platforms\QemuQ35Pkg\PlatformBuild.py TOOL_CHAIN_TAG=VS2022
SECTION - Init Self Describing Environment
SECTION - Loading Plugins
WARNING - Unable to register Supervisor Policy Maker
ERROR - Function MakeSupervisorPolicy already registered from plugin file D:\src\mu_tiano_platforms\Features\MM_SUPV\MmSupervisorPkg\SupervisorPolicyTools\SupervisorPolicyMaker.py.  Can't register again from D:\src\mu_tiano_platforms\Features\MM_SUPV_Redundant\MmSupervisorPkg\SupervisorPolicyTools\SupervisorPolicyMaker.py
Traceback (most recent call last):
  ...
Exception: One or more helper plugins failed to load.
```