### PR TITLE
edk2_logging: Secrets filtering off by default

### DIFF
--- a/docs/user/features/logging.md
+++ b/docs/user/features/logging.md
@@ -12,7 +12,7 @@ setup_logging is a helper function that creates 1-3 of the handlers. The output_
 so they can keep track of compiler output
 
 !!! note
-    Secret / PAT filtering automaticaly automatically occur if "CI" or "TF_BUILD" is set to TRUE in the os's
+    Secret / PAT filtering will automatically occur if "CI" or "TF_BUILD" is set to TRUE in the os's
     environment.
 
 ## General Practice

--- a/docs/user/features/logging.md
+++ b/docs/user/features/logging.md
@@ -11,6 +11,10 @@ There are three different ways to create handlers.
 setup_logging is a helper function that creates 1-3 of the handlers. The output_stream is used for plugins in mu_build
 so they can keep track of compiler output
 
+!!! note
+    Secret / PAT filtering automaticaly automatically occur if "CI" or "TF_BUILD" is set to TRUE in the os's
+    environment.
+
 ## General Practice
 
 + All modules that are not PlatformBuilder or stuart_ci_build should request a named logger like this:

--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -1,12 +1,17 @@
 # @file edk2_logging.py
-# Handle basic logging config for builds;
+# Handle basic logging config for invocables;
 # splits logs into a master log and per package.
 ##
 # Copyright (c) Microsoft Corporation
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
-"""Handles basic logging config for builds.
+"""Handles basic logging config for invocables.
+
+edk2_logging will automatically filter logs for PATs / Secrets when it is
+detected that the invocable is running on a CI system. It does this via
+searching for "CI" or "TF_BUILD" in the os's environment variables. If either
+of these exists and and are set to TRUE, filtering will occur.
 
 Splits logs into a master log and per package log.
 """
@@ -120,7 +125,11 @@ def setup_txt_logger(directory, filename="log", logging_level=logging.INFO,
 # sets up a colored console logger
 def setup_console_logging(logging_level=logging.INFO, formatter=None, logging_namespace='',
                           isVerbose=False, use_azure_colors=False, use_color=True):
-    """Configures a console logger."""
+    """Configures a console logger.
+    
+    Filtering of secrets will automatically occur if "CI" or "TF_BUILD" is set to TRUE
+    in the os's environment.
+    """
     if formatter is None and isVerbose:
         formatter_msg = "%(name)s: %(levelname)s - %(message)s"
     elif formatter is None:

--- a/tests.unit/test_edk2_logging.py
+++ b/tests.unit/test_edk2_logging.py
@@ -206,6 +206,7 @@ def test_NO_secret_filter(caplog):
     caplog.clear()
 
 def test_CI_secret_filter(caplog):
+    caplog.set_level(logging.DEBUG)
     end_list = [" ", ",", ";", ":", " "]
     start_list = [" ", " ", " ", " ", ":"]
     
@@ -223,6 +224,7 @@ def test_CI_secret_filter(caplog):
     caplog.clear()
 
 def test_TF_BUILD_secret_filter(caplog):
+    caplog.set_level(logging.DEBUG)
     end_list = [" ", ",", ";", ":", " "]
     start_list = [" ", " ", " ", " ", ":"]
     

--- a/tests.unit/test_edk2_logging.py
+++ b/tests.unit/test_edk2_logging.py
@@ -211,6 +211,8 @@ def test_CI_secret_filter(caplog):
     
     os.environ["CI"] = "TRUE"
     edk2_logging.setup_console_logging(logging.DEBUG)
+    caplog.clear()
+
     # Test secret github (valid) 1
     fake_secret = "ghp_aeiou1"
     for start, end in zip(start_list, end_list):
@@ -226,6 +228,8 @@ def test_TF_BUILD_secret_filter(caplog):
     
     os.environ["TF_BUILD"] = "TRUE"
     edk2_logging.setup_console_logging(logging.DEBUG)
+    caplog.clear()
+
     # Test secret github (valid) 1
     fake_secret = "ghp_aeiou1"
     for start, end in zip(start_list, end_list):
@@ -240,6 +244,7 @@ def test_catch_secrets_filter(caplog):
     caplog.set_level(logging.DEBUG)
     os.environ["CI"] = "TRUE"
     edk2_logging.setup_console_logging(logging.DEBUG)
+    caplog.clear()
 
     end_list = [" ", ",", ";", ":", " "]
     start_list = [" ", " ", " ", " ", ":"]

--- a/tests.unit/test_edk2_logging.py
+++ b/tests.unit/test_edk2_logging.py
@@ -191,15 +191,26 @@ class Test_edk2_logging(unittest.TestCase):
                            (logging.ERROR, "EDK2 #002 from : Failed to build module")]
         self.assertEqual(edk2_logging.scan_compiler_output(output_stream), expected_output)
 
-
-# caplog is a pytest fixture that captures log messages
-def test_catch_secrets_filter(caplog):
-    caplog.set_level(logging.DEBUG)
-    edk2_logging.setup_console_logging(logging.DEBUG)
-
+def test_NO_secret_filter(caplog):
     end_list = [" ", ",", ";", ":", " "]
     start_list = [" ", " ", " ", " ", ":"]
+    
+    edk2_logging.setup_console_logging(logging.DEBUG)
+    # Test secret github (valid) 1
+    fake_secret = "ghp_aeiou1"
+    for start, end in zip(start_list, end_list):
+        logging.debug(f"This is a secret{start}{fake_secret}{end}to be caught")
 
+    for (record, start, end) in zip(caplog.records, start_list, end_list):
+        assert record.msg == f"This is a secret{start}{fake_secret}{end}to be caught"
+    caplog.clear()
+
+def test_CI_secret_filter(caplog):
+    end_list = [" ", ",", ";", ":", " "]
+    start_list = [" ", " ", " ", " ", ":"]
+    
+    os.environ["CI"] = "TRUE"
+    edk2_logging.setup_console_logging(logging.DEBUG)
     # Test secret github (valid) 1
     fake_secret = "ghp_aeiou1"
     for start, end in zip(start_list, end_list):
@@ -208,6 +219,30 @@ def test_catch_secrets_filter(caplog):
     for (record, start, end) in zip(caplog.records, start_list, end_list):
         assert record.msg == f"This is a secret{start}*******{end}to be caught"
     caplog.clear()
+
+def test_TF_BUILD_secret_filter(caplog):
+    end_list = [" ", ",", ";", ":", " "]
+    start_list = [" ", " ", " ", " ", ":"]
+    
+    os.environ["TF_BUILD"] = "TRUE"
+    edk2_logging.setup_console_logging(logging.DEBUG)
+    # Test secret github (valid) 1
+    fake_secret = "ghp_aeiou1"
+    for start, end in zip(start_list, end_list):
+        logging.debug(f"This is a secret{start}{fake_secret}{end}to be caught")
+
+    for (record, start, end) in zip(caplog.records, start_list, end_list):
+        assert record.msg == f"This is a secret{start}*******{end}to be caught"
+    caplog.clear()
+
+# caplog is a pytest fixture that captures log messages
+def test_catch_secrets_filter(caplog):
+    caplog.set_level(logging.DEBUG)
+    os.environ["CI"] = "TRUE"
+    edk2_logging.setup_console_logging(logging.DEBUG)
+
+    end_list = [" ", ",", ";", ":", " "]
+    start_list = [" ", " ", " ", " ", ":"]
 
     # Test secret github (valid) 2
     fake_secret = "gho_aeiou1"
@@ -244,3 +279,5 @@ def test_catch_secrets_filter(caplog):
     for (record, start, end) in zip(caplog.records, start_list, end_list):
         assert record.msg == f"This is a secret{start}{fake_secret}{end}to be caught"
     caplog.clear()
+
+# def test_no_filter_secrets()

--- a/tests.unit/test_edk2_logging.py
+++ b/tests.unit/test_edk2_logging.py
@@ -284,5 +284,3 @@ def test_catch_secrets_filter(caplog):
     for (record, start, end) in zip(caplog.records, start_list, end_list):
         assert record.msg == f"This is a secret{start}{fake_secret}{end}to be caught"
     caplog.clear()
-
-# def test_no_filter_secrets()


### PR DESCRIPTION
This commit turns secrets filtering off by default, and automatically turns it on when a CI build is detected. This is detected by the environment variable CI or TF_BUILD existing and being set to true, which is automatically set in a github action or azure pipeline respectively.

integration tests confirmed logging automatically enabled:

`DEBUG:root:Detected CI Build on Azure Pipelines. Secrets Filtering Enabled.`

Closes #565 