### PR TITLE
resolve deprecation warnings

### DIFF
--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -24,6 +24,7 @@ from edk2toolext.environment import shell_environment
 from edk2toollib.uefi.edk2.parsers.targettxt_parser import TargetTxtParser
 from edk2toollib.uefi.edk2.parsers.dsc_parser import DscParser
 from edk2toollib.uefi.edk2.parsers.fdf_parser import FdfParser
+from edk2toollib.uefi.edk2.path_utilities import Edk2Path
 from edk2toollib.utility_functions import RunCmd, RemoveTree
 from edk2toolext import edk2_logging
 from edk2toolext.environment.plugintypes.uefi_build_plugin import IUefiBuildPlugin
@@ -680,9 +681,7 @@ class UefiBuilder(object):
             input_vars = self.env.GetAllNonBuildKeyValues()
             # Update with special environment set build keys
             input_vars.update(self.env.GetAllBuildKeyValues())
-
-            dscp = DscParser().SetBaseAbsPath(self.ws).SetPackagePaths(
-                self.pp.split(os.pathsep)).SetInputVars(input_vars)
+            dscp = DscParser().SetEdk2Path(Edk2Path(self.ws, self.pp.split(os.pathsep))).SetInputVars(input_vars)
             dscp.ParseFile(dsc_file_path)
             for key, value in dscp.LocalVars.items():
                 # set env as overrideable
@@ -711,9 +710,7 @@ class UefiBuilder(object):
             input_vars = self.env.GetAllNonBuildKeyValues()
             # Update with special environment set build keys
             input_vars.update(self.env.GetAllBuildKeyValues())
-
-            fdf_parser = FdfParser().SetBaseAbsPath(self.ws).SetPackagePaths(
-                self.pp.split(os.pathsep)).SetInputVars(input_vars)
+            fdf_parser = FdfParser().SetEdk2Path(Edk2Path(self.ws, self.pp.split(os.pathsep))).SetInputVars(input_vars)
             pa = self.mws.join(self.ws, self.env.GetValue("FLASH_DEFINITION"))
             fdf_parser.ParseFile(pa)
             for key, value in fdf_parser.LocalVars.items():

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -287,9 +287,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
             changed_modules = [Path(m) for m in changed_modules]
 
             # now check DSC
-            dsc = DscParser()
-            dsc.SetBaseAbsPath(self.edk2_path_obj.WorkspacePath)
-            dsc.SetPackagePaths(self.edk2_path_obj.PackagePathList)
+            dsc = DscParser().SetEdk2Path(self.edk2_path_obj)
             # given that PR eval runs before dependencies are downloaded we must tolerate errors
             dsc.SetNoFailMode()
             dsc.SetInputVars(PlatformDscInfo[1])
@@ -345,8 +343,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
         # For each INF file
         for f in inf_files:
             ip = InfParser()
-            ip.SetBaseAbsPath(self.edk2_path_obj.WorkspacePath).SetPackagePaths(
-                self.edk2_path_obj.PackagePathList).ParseFile(f)
+            ip.SetEdk2Path(self.edk2_path_obj).ParseFile(f)
 
             for p in ip.PackagesUsed:
                 if p.startswith(support_package):
@@ -406,7 +403,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
 
         # parse it
         dec = DecParser()
-        dec.SetBaseAbsPath(self.edk2_path_obj.WorkspacePath).SetPackagePaths(self.edk2_path_obj.PackagePathList)
+        dec.SetEdk2Path(self.edk2_path_obj)
         dec.ParseFile(wsr_dec_path)
         return dec
 

--- a/tests.unit/test_edk2_setup.py
+++ b/tests.unit/test_edk2_setup.py
@@ -120,7 +120,7 @@ class Settings(SetupSettingsManager):
 
     def GetRequiredSubmodules(self) -> list[RequiredSubmodule]:
         return [
-            RequiredSubmodule('Common\BAD_REPO', True)
+            RequiredSubmodule('Common\\BAD_REPO', True)
         ]
 
     def GetPackagesSupported(self) -> list[str]:


### PR DESCRIPTION
Resolves deprecation warnings from edk2-pytool-library to update parsers to use SetEdk2Path() instead of SetBaseAbsPath() and SetPackagePaths()