### PR TITLE
external_dependency: add sha256 verification

### DIFF
--- a/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
+++ b/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
@@ -152,6 +152,7 @@ class AzureCliUniversalDependency(ExternalDependency):
             # We successfully found the package in the cache.
             # The published path may change now that the package has been unpacked.
             self.published_path = self.compute_published_path()
+            self.calculate_sha256()
             return
 
         #
@@ -173,6 +174,7 @@ class AzureCliUniversalDependency(ExternalDependency):
         #
         # Add a file to track the state of the dependency.
         #
+        self.calculate_sha256()
         self.update_state_file()
 
         # The published path may change now that the package has been unpacked.

--- a/edk2toolext/environment/extdeptypes/nuget_dependency.py
+++ b/edk2toolext/environment/extdeptypes/nuget_dependency.py
@@ -11,6 +11,9 @@ import os
 import logging
 import semantic_version
 import shutil
+import yaml
+import hashlib
+from pathlib import Path
 from io import StringIO
 from edk2toolext.environment.external_dependency import ExternalDependency
 from edk2toollib.utility_functions import RunCmd, RemoveTree
@@ -266,6 +269,7 @@ class NugetDependency(ExternalDependency):
             # We successfully found the package in the cache.
             # The published path may change now that the package has been unpacked.
             # Bail.
+            self.calculate_sha256()
             self.update_state_file()
             self.published_path = self.compute_published_path()
             return
@@ -297,6 +301,7 @@ class NugetDependency(ExternalDependency):
         #
         # Add a file to track the state of the dependency.
         #
+        self.calculate_sha256()
         self.update_state_file()
 
         #

--- a/edk2toolext/environment/extdeptypes/nuget_dependency.py
+++ b/edk2toolext/environment/extdeptypes/nuget_dependency.py
@@ -11,9 +11,6 @@ import os
 import logging
 import semantic_version
 import shutil
-import yaml
-import hashlib
-from pathlib import Path
 from io import StringIO
 from edk2toolext.environment.external_dependency import ExternalDependency
 from edk2toollib.utility_functions import RunCmd, RemoveTree

--- a/edk2toolext/environment/extdeptypes/web_dependency.py
+++ b/edk2toolext/environment/extdeptypes/web_dependency.py
@@ -35,7 +35,7 @@ class WebDependency(ExternalDependency):
                              compute_published_path is run.
         compression_type (str): Supports zip and tar. If the file isn't
                                 compressed, do not include this field. Optional
-        sha256 (str): Hash of downloaded file to be checked against. Optional
+        sha256 (str): Hash of downloaded dependency. Will be calculated if not provided. Optional
 
     !!! tip
         The attributes are what must be described in the ext_dep yaml file!
@@ -48,7 +48,6 @@ class WebDependency(ExternalDependency):
         super().__init__(descriptor)
         self.internal_path = os.path.normpath(descriptor['internal_path'])
         self.compression_type = descriptor.get('compression_type', None)
-        self.sha256 = descriptor.get('sha256', None)
 
         # If the internal path starts with a / that means we are downloading a directory
         self.download_is_directory = self.internal_path.startswith(os.path.sep)
@@ -169,6 +168,9 @@ class WebDependency(ExternalDependency):
             shutil.move(temp_file_path, complete_internal_path)
 
         self.copy_to_global_cache(self.contents_dir)
+
+        if not self.sha256:
+            self.calculate_sha256()
 
         # Add a file to track the state of the dependency.
         self.update_state_file()


### PR DESCRIPTION
Previously, the default implementation of external dependency only verified the version, and did not verify files within the directory had not changed. This type of functionality did exist for git dependencies and for web dependencies as long as it was a single file. This commit adds sha256 verification for all dependencies by default.

This is completed by calculating the sha256 hash for a dependency if it is not provided in the extdep file. This calculation works by finding all files in the content directory, sorting them, then hashing them chunk by chunk. This hash is stored in the state file.

Then, whenever the SDE verifies the environment, the hash is calculated again and compared.

Closes #549