### PR TITLE
external_dependency: unsupported host logging

### DIFF
--- a/edk2toolext/environment/external_dependency.py
+++ b/edk2toolext/environment/external_dependency.py
@@ -111,7 +111,11 @@ class ExternalDependency(object):
                 logging.debug("{0} does not exist".format(dirname))
 
             if new_published_path is None:
-                logging.error("Could not find appropriate folder for {0}. {1}".format(self.name, str(host)))
+                logging.error(f"{self.name} is host specific, but does not appear to have support for {str(host)}.")
+                logging.error(f"Verify support for detected host: {str(host)} and contact dependency provider to add "\
+                              "support.")
+                logging.error("Otherwise, delete the external dependency directory to reset.")
+                
                 new_published_path = self.contents_dir
 
         if self.flags and "include_separator" in self.flags:


### PR DESCRIPTION
Improve the logging done when either a downloaded external dependency is host_specific and does not support the local host, or the folder for the local host has been deleted.

Closes #549