### PR TITLE
base_abstract_invocable: force debug logging

### DIFF
--- a/docs/user/features/logging.md
+++ b/docs/user/features/logging.md
@@ -12,8 +12,10 @@ setup_logging is a helper function that creates 1-3 of the handlers. The output_
 so they can keep track of compiler output
 
 !!! note
-    Secret / PAT filtering will automatically occur if "CI" or "TF_BUILD" is set to TRUE in the os's
-    environment.
+    Secret / PAT filtering will automatically occur if "CI" or "TF_BUILD" is set to "TRUE" in the os's
+    environment. Additionally, if "DEBUG" or "RUNNER_DEBUG" is set to "TRUE" or "1" respectively, the
+    console logger logging level will be forced to DEBUG. This is to support easy CI server debugging for
+    azure pipelines and github actions.
 
 ## General Practice
 

--- a/edk2toolext/base_abstract_invocable.py
+++ b/edk2toolext/base_abstract_invocable.py
@@ -168,8 +168,10 @@ class BaseAbstractInvocable(object):
     def ConfigureLogging(self):
         """Sets up the logging.
 
-        !!! tip
-            Optional override in a subclass if new behavior is needed
+        !!! warning
+            console logging can be overwritten via the environment variables DEBUG
+            or RUNNER_DEBUG to easily enable server CI debugging. Review the logging
+            documentation for more details.
         """
         logger = logging.getLogger('')
         logger.setLevel(self.GetLoggingLevel("base"))
@@ -177,7 +179,12 @@ class BaseAbstractInvocable(object):
         # Adjust console mode depending on mode.
         edk2_logging.setup_section_level()
 
-        edk2_logging.setup_console_logging(self.GetLoggingLevel("con"))
+        if os.environ.get('RUNNER_DEBUG', "0") == "1" or os.environ.get('DEBUG', 'FALSE').upper() == 'TRUE':
+            logging.warning("Console logging forced to DEBUG due to CI environment.")
+            con_level = logging.DEBUG
+        else:
+            con_level = self.GetLoggingLevel("con")
+        edk2_logging.setup_console_logging(con_level)
 
         log_directory = os.path.join(self.GetWorkspaceRoot(), self.GetLoggingFolderRelativeToRoot())
 

--- a/edk2toolext/base_abstract_invocable.py
+++ b/edk2toolext/base_abstract_invocable.py
@@ -169,7 +169,7 @@ class BaseAbstractInvocable(object):
         """Sets up the logging.
 
         !!! warning
-            console logging can be overwritten via the environment variables DEBUG
+            console logging level can be overwritten via the environment variables DEBUG
             or RUNNER_DEBUG to easily enable server CI debugging. Review the logging
             documentation for more details.
         """


### PR DESCRIPTION
Adds the ability to force debug logging via the environment variables "DEBUG" and "RUNNER_DEBUG" to easily enable debug logging on server builds. azure pipelines allow you to update the DEBUG env variable to enable debug logging in azure pipelines while RUNNER_DEBUG env variable is set when you re-run a pipeline with debug logging.

closes #182 