### PR TITLE
dependabot.yml: Update frequency of checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,12 +13,12 @@ updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
-  - package-ecosystem: "pip"
-    directory: "/docs/user/"
-    schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "01:00"


### PR DESCRIPTION
Updates the frequency of checks to once a week, Mondays at 01:00 UTC.

It was noted that for any given release of edk2-pytool-extensions, that multiple dependencies were updated multiple times, which is a waste of maintainer time. This moves the checks to once a week at Monday, to be reviewed and merged every Monday morning.