### PR TITLE
repo_resolver: bugfix error printing

### DIFF
--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -142,9 +142,9 @@ def resolve(file_system_path, dependency, force=False, ignore=False, update_ok=F
                 return
             else:
                 logger.critical("The URL of the git Repo {2} in the folder {0} does not match {1}".format(
-                    git_path, dependency["Url"], repo_details(git_path).url))
+                    git_path, dependency["Url"], details["Url"]))
                 raise Exception("The URL of the git Repo {2} in the folder {0} does not match {1}".format(
-                    git_path, dependency["Url"], repo_details(git_path).url))
+                    git_path, dependency["Url"], details["Url"]))
 
     ##########################################################################
     # 6. The repo is normal, Perform a regular checkout.                     #


### PR DESCRIPTION
When resolving a repository dependency, if the URL of the existing repository does not match the URL of the actual dependency, an error is printed to the user stating there is a mismatch. A bug was found in the code that prints this error. The attribute trying to be accessed did not exist because there was an interface change in how that information is accessed.

This bugfix updates the logic to access the information the correct way.