### PR TITLE
Update txt logger mode to 'a'

### DIFF
--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -110,9 +110,14 @@ def setup_txt_logger(directory, filename="log", logging_level=logging.INFO,
     if not os.path.isdir(directory):
         os.makedirs(directory)
 
-    # Create file logger
     logfile_path = os.path.join(directory, filename + ".txt")
-    filelogger = file_handler.FileHandler(filename=(logfile_path), mode='w+')
+
+    # delete file before starting a new log
+    if os.path.isfile(logfile_path):
+        os.remove(logfile_path)
+
+    # Create file logger
+    filelogger = file_handler.FileHandler(filename=(logfile_path), mode='a')
     filelogger.setLevel(logging_level)
     filelogger.setFormatter(log_formatter)
     logger.addHandler(filelogger)
@@ -126,7 +131,7 @@ def setup_txt_logger(directory, filename="log", logging_level=logging.INFO,
 def setup_console_logging(logging_level=logging.INFO, formatter=None, logging_namespace='',
                           isVerbose=False, use_azure_colors=False, use_color=True):
     """Configures a console logger.
-    
+
     Filtering of secrets will automatically occur if "CI" or "TF_BUILD" is set to TRUE
     in the os's environment.
     """
@@ -268,12 +273,12 @@ class Edk2LogFilter(logging.Filter):
         self._verbose = False
         self._currentSection = "root"
         self.apply_filter = False
-        
+
         # Turn on filtering for azure pipelines
         if os.environ.get("CI", "FALSE").upper() == "TRUE":
             logging.debug("Detected CI Build on Github Actions. Secrets Filtering Enabled.")
             self.apply_filter = True
-        
+
         # Turn on filter for github actions
         elif os.environ.get("TF_BUILD", "FALSE").upper() == "TRUE":
             logging.debug("Detected CI Build on Azure Pipelines. Secrets Filtering Enabled.")


### PR DESCRIPTION
Python logging to a file with mode='w' can cause log loss when logging happens after the logger has already been cleaned up. 
See issue: https://github.com/python/cpython/issues/86544

The fix for Python was to have a special handle for files opened in mode='w'. Currently we use mode='w+', so the checked in fix does not solve our problem.

I've implemented moving the file_logger to mode='a' and an explicit deletion of the logging file before opening the FileHandler.