### PR TITLE
repo_resolver: repo_details missing information

### DIFF
--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -245,6 +245,8 @@ def repo_details(abs_file_system_path):
             details["Bare"] = repo.bare
             details["Dirty"] = repo.is_dirty(untracked_files=True)
             details["Initialized"] = True
+            details["Submodules"] = [submodule.name for submodule in repo.submodules]
+            details["Remotes"] = [remote.name for remote in repo.remotes]
 
             # 1. Use the remote associated with the branch if on a branch and it exists
             if not repo.head.is_detached and repo.branches[repo.head.ref.name].tracking_branch():


### PR DESCRIPTION
repo_details() was missing information on a repository's submodules and remotes. This information is now populated with this PR.

closes #600 