### PR TITLE
nuget_dependency: authorization failure logging

### DIFF
--- a/edk2toolext/environment/extdeptypes/nuget_dependency.py
+++ b/edk2toolext/environment/extdeptypes/nuget_dependency.py
@@ -248,7 +248,8 @@ class NugetDependency(ExternalDependency):
             if non_interactive and found_cred_provider:  # we should be interactive next time
                 self._attempt_nuget_install(install_dir, False)
             else:
-                if is_unauthorized:
+                # Only provide this error message if they are not using a credential provider, but receive a 401 error
+                if is_unauthorized and not found_cred_provider:
                     logging.warning("[Nuget] A package requires credentials, but you do not have a credential "\
                                     "provider installed.")
                     logging.warning("[Nuget] Please install a credential provider and try again or run the following "\

--- a/edk2toolext/environment/extdeptypes/nuget_dependency.py
+++ b/edk2toolext/environment/extdeptypes/nuget_dependency.py
@@ -231,12 +231,15 @@ class NugetDependency(ExternalDependency):
         output_stream.seek(0)  # return the start of the stream
         # check if we found credential providers
         found_cred_provider = False
+        is_unauthorized = False
         for out_line in output_stream:
             line = out_line.strip()
             if line.startswith("CredentialProvider") or line.startswith("[CredentialProvider"):
                 found_cred_provider = True
             if line.endswith("as a credential provider plugin."):
                 found_cred_provider = True
+            if "401 (Unauthorized)" in line:
+                is_unauthorized = True
         # if we fail, then we should retry if we have credential providers
         # we currently steal command input so if we don't have cred providers, we hang
         # this gives cred providers a chance to prompt for input since they don't use stdin
@@ -245,6 +248,12 @@ class NugetDependency(ExternalDependency):
             if non_interactive and found_cred_provider:  # we should be interactive next time
                 self._attempt_nuget_install(install_dir, False)
             else:
+                if is_unauthorized:
+                    logging.warning("[Nuget] A package requires credentials, but you do not have a credential "\
+                                    "provider installed.")
+                    logging.warning("[Nuget] Please install a credential provider and try again or run the following "\
+                                    "command in your terminal to install the package manually:")
+                    logging.warning(f"[{' '.join(cmd).replace(' -NonInteractive', '')}]")
                 raise RuntimeError(f"[Nuget] We failed to install this version {self.version} of {package_name}")
 
     def fetch(self):


### PR DESCRIPTION
When a nuget package fails to download due to an authorization error, additional logging is provided to help the user understand the problem and possible solutions. The message informs the user to either install a credential provider (because the package requires authorization) or to run the command themselves to provide the credentials manually.

The logging appears as follows, per failed NuGet Package:
![image](https://github.com/tianocore/edk2-pytool-extensions/assets/24388509/674b15eb-4352-44c1-99de-daf2e9052448)
