### PR TITLE
ci_build_plugin: remove unecessary logging

### DIFF
--- a/edk2toolext/environment/plugintypes/ci_build_plugin.py
+++ b/edk2toolext/environment/plugintypes/ci_build_plugin.py
@@ -114,7 +114,6 @@ class ICiBuildPlugin(object):
                                     ignoreIt = True
                                     break
                         if not ignoreIt:
-                            logging.debug(os.path.join(Root, File))
                             returnlist.append(os.path.join(Root, File))
 
         return returnlist


### PR DESCRIPTION
Removes an unecessary log that logs a file path before it is appended to the returned list. As this is the only logging in the function and the only way files get added to the list, a user can log the list of their own accord.

closes #581 