### PR TITLE
web_external_dependency: restore zipped file permissions

### DIFF
--- a/edk2toolext/environment/extdeptypes/web_dependency.py
+++ b/edk2toolext/environment/extdeptypes/web_dependency.py
@@ -90,6 +90,8 @@ class WebDependency(ExternalDependency):
             logging.info(f"{compressed_file_path} is a zip file, trying to unpack it.")
             _ref = zipfile.ZipFile(compressed_file_path, 'r')
             files_in_volume = _ref.namelist()
+            x = _ref.infolist()
+            print(x)
 
         elif compression_type and "tar" in compression_type:
             logging.info(f"{compressed_file_path} is a tar file, trying to unpack it.")
@@ -102,9 +104,14 @@ class WebDependency(ExternalDependency):
 
         # Filter the files inside to only the ones that are inside the important folder
         files_to_extract = [name for name in files_in_volume if linux_internal_path in name]
-
+        import pathlib
         for file in files_to_extract:
+            expected_mode = _ref.getinfo(file).external_attr >> 16
+            print(expected_mode)
             _ref.extract(member=file, path=destination)
+            pathlib.Path(destination, file).chmod(expected_mode)
+            actual_mode = pathlib.Path(destination, file).stat().st_mode
+            print(actual_mode)
         _ref.close()
 
     def fetch(self):

--- a/tests.unit/test_web_dependency.py
+++ b/tests.unit/test_web_dependency.py
@@ -7,15 +7,19 @@
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
 
-import os
-import unittest
+import json
 import logging
+import os
+import pathlib
 import shutil
 import tarfile
-import zipfile
 import tempfile
-import json
+import unittest
 import urllib.request
+import zipfile
+from sys import platform
+
+import pytest
 from edk2toolext.environment import environment_descriptor_files as EDF
 from edk2toolext.environment.extdeptypes.web_dependency import WebDependency
 
@@ -76,6 +80,19 @@ jquery_json_file = {
     "flags": [],
     "sha256": "5A93A88493AA32AAB228BF4571C01207D3B42B0002409A454D404B4D8395BD55",
     "internal_path": "jquery.js"
+}
+
+basetools_json_file = {
+  "scope": "global",
+  "type": "web",
+  "name": "Mu-Basetools",
+  "source": "https://github.com/microsoft/mu_basecore/releases/download/v2023020002.0.3/basetools-v2023020002.0.3.zip",
+  "version": "v2023020002.0.3",
+  "sha256": "6eaf5dc61690592e441c92c3150167c40315efb24a3805a05642d5b4f875b008",
+  "internal_path": "/basetools/",
+  "compression_type": "zip",
+  "flags": ["set_shell_var", "set_path", "host_specific"],
+  "var_name": "EDK_TOOLS_BIN"
 }
 
 
@@ -456,6 +473,21 @@ class TestWebDependency(unittest.TestCase):
         self.assertFalse(internal_path_win in namelist[0])
         self.assertTrue(WebDependency.linuxize_path(internal_path_win) in namelist[0])
 
+    @pytest.mark.skipif(platform == "win32", reason="Only Linux care about file attributes.")
+    def test_unpack_zip_file_attr(self):
+        """Test that unpacked zip files keep their file attributes."""
+        extdep_file = pathlib.Path(test_dir, "my_ext_dep.json")
+
+        with open(extdep_file, "w+") as f:
+            f.write(json.dumps(basetools_json_file))
+
+        extdep_descriptor = EDF.ExternDepDescriptor(extdep_file).descriptor_contents
+        extdep = WebDependency(extdep_descriptor)
+        extdep.fetch()
+
+        extdep_dir = pathlib.Path(test_dir, "Mu-Basetools_extdep")
+
+        assert extdep_dir.exists()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests.unit/test_web_dependency.py
+++ b/tests.unit/test_web_dependency.py
@@ -22,6 +22,7 @@ from sys import platform
 import pytest
 from edk2toolext.environment import environment_descriptor_files as EDF
 from edk2toolext.environment.extdeptypes.web_dependency import WebDependency
+from edk2toollib.utility_functions import RemoveTree
 
 test_dir = None
 bad_json_file = '''
@@ -103,7 +104,7 @@ def prep_workspace():
         test_dir = tempfile.mkdtemp()
         logging.debug("temp dir is: %s" % test_dir)
     else:
-        shutil.rmtree(test_dir)
+        RemoveTree(test_dir)
         test_dir = tempfile.mkdtemp()
 
 

--- a/tests.unit/test_web_dependency.py
+++ b/tests.unit/test_web_dependency.py
@@ -475,7 +475,11 @@ class TestWebDependency(unittest.TestCase):
 
     @pytest.mark.skipif(platform == "win32", reason="Only Linux care about file attributes.")
     def test_unpack_zip_file_attr(self):
-        """Test that unpacked zip files keep their file attributes."""
+        """Test that unpacked zip files keep their file attributes.
+
+        This is done by downloading the Basetools extdep where we know for a fact that each
+        file should have the owner executable bit set.
+        """
         extdep_file = pathlib.Path(test_dir, "my_ext_dep.json")
 
         with open(extdep_file, "w+") as f:
@@ -488,6 +492,10 @@ class TestWebDependency(unittest.TestCase):
         extdep_dir = pathlib.Path(test_dir, "Mu-Basetools_extdep")
 
         assert extdep_dir.exists()
+
+        OWNER_EXE = 0o100
+        for file in [path for path in extdep_dir.rglob("*") if "Linux" in str(path) and path.is_file()]:
+            assert file.stat().st_mode & OWNER_EXE
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The zipfile module does not retain the individual file permissions when extracting files, even though the file permission metadata is present - whereas the tarfile does. This change restores each file's permission to what it was zipped with. 

Confirmed mu_tiano_platforms builds when changing BaseTools to the zip extdep.

closes #579 