### PR TITLE
edk2_pr_eval: Policy 5: allow dsc parse failures

### DIFF
--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -324,6 +324,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
                     continue
 
                 dsc_parser = DscParser()
+                dsc_parser.SetNoFailMode()
                 dsc_parser.SetEdk2Path(self.edk2_path_obj).SetInputVars(defines)
                 dsc_parser.ParseFile(dsc)
 


### PR DESCRIPTION
Given that PR eval runs before dependencies are downloaded, there will be instances where files used in the dsc are not present. This can be tolerated by setting NoFailMode, which just results in the parser moving onto the next line when the parsing fails.