### PR TITLE
Deprecate mws [REBASE&FF]

### DIFF
--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -21,6 +21,7 @@ import inspect
 import logging
 import os
 import sys
+import warnings
 from random import choice
 from string import ascii_letters
 from textwrap import dedent
@@ -390,6 +391,9 @@ class Edk2Invocable(BaseAbstractInvocable):
             settingsParserObj.print_help()
             print(e)
             sys.exit(2)
+
+        # Turn on Deprecation warnings for code in the module
+        warnings.filterwarnings("default", category=DeprecationWarning, module=self.PlatformModule.__name__)
 
         # instantiate the second argparser that will get passed around
         parserObj = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,)

--- a/edk2toolext/environment/multiple_workspace.py
+++ b/edk2toolext/environment/multiple_workspace.py
@@ -17,6 +17,7 @@ File is slightly modified from Edk2 BaseTools/Source/Python/Common/MultipleWorks
 """
 
 import os
+import warnings
 
 
 class MultipleWorkspace(object):
@@ -73,6 +74,9 @@ class MultipleWorkspace(object):
         Returns:
             (str): absolute path of the specified file
         """
+        warnings.warn(
+            "MultipleWorkspace is deprecated. Use Edk2Path.GetAbsolutePathOnThisSystemFromEdk2RelativePath().",
+            DeprecationWarning, stacklevel=2)
         Path = os.path.join(Ws, *p)
         if not os.path.exists(Path):
             for Pkg in cls.PACKAGES_PATH:
@@ -94,6 +98,9 @@ class MultipleWorkspace(object):
         Returns:
             (str): the relative path of specified file
         """
+        warnings.warn(
+            "MultipleWorkspace is deprecated. use Edk2Path.GetEdk2RelativePathOnThisSystemFromAbsolutePath().",
+            DeprecationWarning, stacklevel=2)
         for Pkg in cls.PACKAGES_PATH:
             if Path.lower().startswith(Pkg.lower()):
                 Path = os.path.relpath(Path, Pkg)
@@ -135,6 +142,9 @@ class MultipleWorkspace(object):
         Returns:
             (Str): Path string including the $(WORKSPACE)
         """
+        warnings.warn("MultipleWorkspace is deprecated. Manually replace the $(WORKSPACE). If you believe "
+                      "this functionality needs a direct replacement, file an issue in edk2-pytool-extensions.",
+                      DeprecationWarning, stacklevel=2)
         TAB_WORKSPACE = '$(WORKSPACE)'
         if TAB_WORKSPACE in PathStr:
             PathList = PathStr.split()

--- a/edk2toolext/environment/plugin_manager.py
+++ b/edk2toolext/environment/plugin_manager.py
@@ -11,6 +11,7 @@ import importlib
 import logging
 import os
 import sys
+import warnings
 
 from edk2toolext.environment import shell_environment
 
@@ -100,6 +101,9 @@ class PluginManager(object):
             py_module_dir = os.path.dirname(py_module_path)
             if py_module_dir not in sys.path:
                 sys.path.append(py_module_dir)
+
+            # Turn on Deprecation warnings for code in the plugin
+            warnings.filterwarnings("default", category=DeprecationWarning, module=module.__name__)
 
             spec.loader.exec_module(module)
         except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "Python tools supporting UEFI EDK2 firmware development"
 readme = {file = "readme.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
 dependencies = [
-    "edk2-pytool-library>=0.14.0",
+    "edk2-pytool-library>=0.16.1",
     "pyyaml>=6.0.0",
     "pefile>=2023.2.7",
     "semantic_version>=2.10.0",


### PR DESCRIPTION
## Commit 1

This commit enables (forces) deprecation warnings to be displayed for external code consumed by the stuart invocable to include the Platform module (typically PlatformBuild.py, CISettings.py) and any plugin (CIBuild, Helper, UefiBuild). This is so that consumers of edk2-pytool-extensions and edk2-pytool-library are made aware of deprecations in parts of the codebase that don't have (1) tests via pytest / unittest that automatically display deprecations or (2) would not typically turn on deprecation warnings themselves.

## Commit 2

This commit deprecates `MultipleWorkspace`, consumed by `uefi_build` and used by external code, in favor of Edk2Path. `self.mws` will temporarily exist in `uefi_build`, but `self.edk2path` has been made available for consumers to easily transition and resolve the deprecation warning.

## Breaking Changes

This commit upgrades edk2-pytool-library to require >= v0.16.1, where [v0.16.0](https://github.com/tianocore/edk2-pytool-library/releases/tag/v0.16.0) contains a possibly breaking change to Edk2Path. 

As this function is heavily used by external code consumed by the `stuart` invocable, this change will be released as a part of v0.24.0 to signal changes may need to be made, even though those changes originate from edk2-pytool-library.

closes #446