### PR TITLE
edk2toolext.capsule: add __init__.py

### DIFF
--- a/edk2toolext/capsule/__init__.py
+++ b/edk2toolext/capsule/__init__.py
@@ -1,0 +1,9 @@
+##
+# Copyright (c) Microsoft Corporation
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+##
+"""This file exists to satisfy pythons packaging requirements.
+
+Read more: https://docs.python.org/3/reference/import.html#regular-packages
+"""

--- a/edk2toolext/capsule/capsule_tool.py
+++ b/edk2toolext/capsule/capsule_tool.py
@@ -16,6 +16,7 @@ import os
 import sys
 
 import yaml
+
 from edk2toolext.capsule import capsule_helper, signing_helper
 
 TOOL_DESCRIPTION = """

--- a/edk2toolext/capsule/signing_helper.py
+++ b/edk2toolext/capsule/signing_helper.py
@@ -18,8 +18,9 @@ file path to a local Python module that should be dynamically loaded.
 
 import importlib
 
-from edk2toolext.capsule import signtool_signer
 from edk2toollib.utility_functions import import_module_by_file_name
+
+from edk2toolext.capsule import signtool_signer
 
 # Valid types.
 PYOPENSSL_SIGNER = 'pyopenssl'


### PR DESCRIPTION
`__init__.py` is missing from edk2toolext/capsule, which causes the module to not be found on local edit installs of the project (i.e. `pip install -e .`). This commit adds in the expected file.