### PR TITLE
Show invocable's help even without a config file

### DIFF
--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -379,7 +379,7 @@ class Edk2Invocable(BaseAbstractInvocable):
         """
         # first argparser will only get settings manager and help will be disabled
         settingsParserObj = argparse.ArgumentParser(add_help=False)
-        
+
         settingsParserObj.add_argument('-h', '--help', dest="help", action="store_true",
                                        help='show this help message and exit')
         settingsParserObj.add_argument('-c', '--platform_module', dest='platform_module',
@@ -423,9 +423,9 @@ class Edk2Invocable(BaseAbstractInvocable):
                     print("WARNING: Some command line arguments may be missing. Provide a PLATFORM_MODULE file to "
                           "ensure all command line arguments are present.\n")
                     self.AddCommandLineOptions(settingsParserObj)
-                except:
+                except Exception:
                     pass
-            else:     
+            else:
                 # Gracefully exit if we can't find the file
                 print(f"We weren't able to find {settingsArg.platform_module}")
             settingsParserObj.print_help()

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -420,7 +420,7 @@ class Edk2Invocable(BaseAbstractInvocable):
         except (FileNotFoundError):
             if settingsArg.help:
                 try:
-                    print("WARNING: Some command line arguments may be missing. Provide a platform module file to "
+                    print("WARNING: Some command line arguments may be missing. Provide a PLATFORM_MODULE file to "
                           "ensure all command line arguments are present.\n")
                     self.AddCommandLineOptions(settingsParserObj)
                 except:

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -379,7 +379,9 @@ class Edk2Invocable(BaseAbstractInvocable):
         """
         # first argparser will only get settings manager and help will be disabled
         settingsParserObj = argparse.ArgumentParser(add_help=False)
-
+        
+        settingsParserObj.add_argument('-h', '--help', dest="help", action="store_true",
+                                       help='show this help message and exit')
         settingsParserObj.add_argument('-c', '--platform_module', dest='platform_module',
                                        default="PlatformBuild.py", type=str,
                                        help='Provide the Platform Module relative to the current working directory.'
@@ -416,8 +418,16 @@ class Edk2Invocable(BaseAbstractInvocable):
             sys.exit(1)
 
         except (FileNotFoundError):
-            # Gracefully exit if we can't find the file
-            print(f"We weren't able to find {settingsArg.platform_module}")
+            if settingsArg.help:
+                try:
+                    print("WARNING: Some command line arguments may be missing. Provide a platform module file to "
+                          "ensure all command line arguments are present.\n")
+                    self.AddCommandLineOptions(settingsParserObj)
+                except:
+                    pass
+            else:     
+                # Gracefully exit if we can't find the file
+                print(f"We weren't able to find {settingsArg.platform_module}")
             settingsParserObj.print_help()
             sys.exit(2)
 

--- a/edk2toolext/invocables/edk2_multipkg_aware_invocable.py
+++ b/edk2toolext/invocables/edk2_multipkg_aware_invocable.py
@@ -180,7 +180,7 @@ class Edk2MultiPkgAwareInvocable(Edk2Invocable):
                                'Can list multiple by doing -p <pkg1>,<pkg2> or -p <pkg3> -p <pkg4>',
                                action="append", default=[])
         parserObj.add_argument('-a', '--arch', dest="requested_arch", type=str, default=None,
-                               help="Optional - CSV of architecutres requested to update. Example: -a X64,AARCH64")
+                               help="Optional - CSV of architecture requested to update. Example: -a X64,AARCH64")
         parserObj.add_argument('-t', '--target', dest='requested_target', type=str, default=None,
                                help="Optional - CSV of targets requested to update.  Example: -t DEBUG,NOOPT")
 


### PR DESCRIPTION
Enables the invocable to display it's command line arguments if `-h` or `--help` is provided, regardless of if it has a configuration file.

## Examples

### stuart_build

``` cmd
WARNING: Some command line arguments may be missing. Provide a platform module file to ensure all command line arguments are present.

usage: stuart_build [-h] [-c PLATFORM_MODULE]

options:
  -h, --help            show this help message and exit
  -c PLATFORM_MODULE, --platform_module PLATFORM_MODULE
                        Provide the Platform Module relative to the current working directory.This should contain a BuildSettingsManager instance.
```

### stuart_ci_build

```cmd
WARNING: Some command line arguments may be missing. Provide a platform module file to ensure all command line arguments are present.

usage: stuart_ci_build [-h] [-c PLATFORM_MODULE] [-p PACKAGELIST] [-a REQUESTED_ARCH] [-t REQUESTED_TARGET]

options:
  -h, --help            show this help message and exit
  -c PLATFORM_MODULE, --platform_module PLATFORM_MODULE
                        Provide the Platform Module relative to the current working directory.This should contain a CiBuildSettingsManager instance.
  -p PACKAGELIST, --pkg PACKAGELIST, --pkg-dir PACKAGELIST
                        Optional - A package or folder you want to update (workspace relative).Can list multiple by doing -p <pkg1>,<pkg2> or -p <pkg3> -p <pkg4>
  -a REQUESTED_ARCH, --arch REQUESTED_ARCH
                        Optional - CSV of architecture requested to update. Example: -a X64,AARCH64
  -t REQUESTED_TARGET, --target REQUESTED_TARGET
                        Optional - CSV of targets requested to update. Example: -t DEBUG,NOOPT
```