### PR TITLE
Simple heuristics to try and locate platform module

### DIFF
--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -22,11 +22,11 @@ import logging
 import os
 import sys
 import warnings
+from pathlib import Path
 from random import choice
 from string import ascii_letters
 from textwrap import dedent
 from typing import Iterable, Tuple
-from pathlib import Path
 
 import pkg_resources
 from edk2toollib.utility_functions import GetHostInfo, RunCmd, import_module_by_file_name, locate_class_in_module


### PR DESCRIPTION
Currently, we only support not providing the platform module (-c) if you are in the correct directory and it is a called PlatformBuild.py

This commit slightly expands the heuristic for locating a platform module to also include CISettings.py and .pytool/CISettings.py AND it will search parent directories for those three possible locations. If one is found, it will be used. Otherwise it will print the same message it already prints.