### PR TITLE
edk2toolext/edk2_logging.py: Log rust errors

### DIFF
--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -231,6 +231,7 @@ def scan_compiler_output(output_stream):
     build_py_error_exp = re.compile(r"error (\d+)E:")
     linker_error_exp = re.compile(r"error LNK(\d+):")
     warning_exp = re.compile(r"warning [A-Z]?(\d+):")
+    rust_error_exp = re.compile(r"^(-->|\d+\s*\||error:)")
     for raw_line in output_stream.readlines():
         line = raw_line.strip("\n").strip()
         match = error_exp.search(line)
@@ -260,6 +261,9 @@ def scan_compiler_output(output_stream):
         if match is not None:
             error = output_compiler_error(match, line, "Build.py")
             problems.append((logging.ERROR, error))
+        match = rust_error_exp.search(line)
+        if match is not None:
+            problems.append((logging.ERROR, line))
     return problems
 
 

--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -231,7 +231,7 @@ def scan_compiler_output(output_stream):
     build_py_error_exp = re.compile(r"error (\d+)E:")
     linker_error_exp = re.compile(r"error LNK(\d+):")
     warning_exp = re.compile(r"warning [A-Z]?(\d+):")
-    rust_error_exp = re.compile(r"^(-->|\d+\s*\||error:)")
+    rust_error_exp = re.compile(r"^(-->|error(?:\[[A-Za-z]\d+\])?:)")
     for raw_line in output_stream.readlines():
         line = raw_line.strip("\n").strip()
         match = error_exp.search(line)


### PR DESCRIPTION
Adds the ability to detect rust build errors and print them at the end of the build when the build fails.

![image](https://github.com/tianocore/edk2-pytool-extensions/assets/24388509/46f1ca22-fb69-4211-8ef8-56a7b3a2981b)
