### PR TITLE
Update Supported Python versions to 3.10, 3.11, and 3.12

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,9 +29,9 @@ body:
       description: "Note: Bug fixes are only supported on these Python versions."
       multiple: true
       options:
-        - Python 3.9
         - Python 3.10
         - Python 3.11
+        - Python 3.12
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/VariableProducer.yml
+++ b/.github/workflows/VariableProducer.yml
@@ -14,7 +14,7 @@ on:
         value: ${{ jobs.produce.outputs.node-versions }}
 
 env:
-  pythonversions: "['3.11', '3.10', '3.9']" # Keep Python Versions in descending order
+  pythonversions: "['3.12', '3.11', '3.10']" # Keep Python Versions in descending order
   nodeversions: "['19']"
 
 jobs:

--- a/azure-pipelines/templates/basic-setup-steps.yml
+++ b/azure-pipelines/templates/basic-setup-steps.yml
@@ -15,7 +15,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.10.x'
+    versionSpec: '3.12.x'
     architecture: 'x64'
 
 - script: pip install --upgrade -e .[dev]

--- a/docs/contributor/python_release.md
+++ b/docs/contributor/python_release.md
@@ -9,17 +9,16 @@ release (3.9, 3.10, etc).
 Each individual step will be a different section below and be associated with a
 specific file that must be updated.
 
-### setup.py
+### pyproject.toml
 
 This file is responsible for the release process to pypi. We want to make sure
-we keep the required python version for our pypi releases up to date.
-Within `setuptools.setup()` locate the line `python_requires = "XXX"` and
-update it to the next version.
+we keep the required version for our pypi releases up to date. Update
+`requires-python` to the minimum required python.
 
 We typically support the last three minor versions; barring any special
 exceptions, if the newest minor version is 3.11, then overall, we will
 support 3.9, 3.10, and 3.11. Therefore you should update the line to
-`python_requires = ">=3.9.0"`.
+`python-requires = ">=3.9.0"`.
 
 Additionally, we must update the classifiers section to show the three
 supported python versions:
@@ -32,6 +31,14 @@ classifiers=[
         "Programming Language :: Python :: 3.11"
     ]
 ```
+
+### bug_report.yml
+
+Update the supported python versions in the entry with `id: py_version`
+
+### VariableProducer.yml
+
+Update `pythonversions` to the support versions
 
 ### tests.integration/azure-pipelines/windows-robot-integration-test.yml
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ classifiers = [
     "Operating System :: OS Independent",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dynamic = ["version"]
 description = "Python tools supporting UEFI EDK2 firmware development"
 readme = {file = "readme.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
+requires-python = ">=3.10"
 dependencies = [
     "edk2-pytool-library>=0.16.1",
     "pyyaml>=6.0.0",
@@ -18,6 +19,7 @@ dependencies = [
     "openpyxl>=3.1.2",
     "XlsxWriter>=3.0.9",
     "pywin32>=305; sys_platform=='win32'",
+    "setuptools>=68.2.2",
 ]
 
 classifiers = [

--- a/readme.md
+++ b/readme.md
@@ -41,18 +41,18 @@ coverage of those unit tests. We require 100% unit test success
 
 | Host Type           | Toolchain   | Project    | Integration Tests |
 | :------------------ | :---------  | :--------- | :---------------- |
-| Windows Server 2019 | Python 3.9  | Edk2       | [![ewt1]][_it]    |
-| Windows Server 2019 | Python 3.10 | Edk2       | [![ewt2]][_it]    |
-| Windows Server 2019 | Python 3.11 | Edk2       | [![ewt3]][_it]    |
-| Linux Ubuntu 20.04  | Python 3.9  | Edk2       | [![eut1]][_i359]  |
-| Linux Ubuntu 20.04  | Python 3.10 | Edk2       | [![eut2]][_it]    |
-| Linux Ubuntu 20.04  | Python 3.11 | Edk2       | [![eut3]][_it]    |
-| Windows Server 2022 | Python 3.9  | Project Mu | [![mwt1]][_it]    |
-| Windows Server 2022 | Python 3.10 | Project Mu | [![mwt2]][_it]    |
-| Windows Server 2022 | Python 3.11 | Project Mu | [![mwt3]][_it]    |
-| Linux Ubuntu 22.04  | Python 3.9  | Project Mu | [![mut1]][_i359]  |
-| Linux Ubuntu 22.04  | Python 3.10 | Project Mu | [![mut2]][_it]    |
-| Linux Ubuntu 22.04  | Python 3.11 | Project Mu | [![mut3]][_it]    |
+| Windows Server 2019 | Python 3.10 | Edk2       | [![ewt1]][_it]    |
+| Windows Server 2019 | Python 3.11 | Edk2       | [![ewt2]][_it]    |
+| Windows Server 2019 | Python 3.12 | Edk2       | [![ewt3]][_it]    |
+| Linux Ubuntu 20.04  | Python 3.10 | Edk2       | [![eut1]][_i359]  |
+| Linux Ubuntu 20.04  | Python 3.11 | Edk2       | [![eut2]][_it]    |
+| Linux Ubuntu 20.04  | Python 3.12 | Edk2       | [![eut3]][_it]    |
+| Windows Server 2022 | Python 3.10 | Project Mu | [![mwt1]][_it]    |
+| Windows Server 2022 | Python 3.11 | Project Mu | [![mwt2]][_it]    |
+| Windows Server 2022 | Python 3.12 | Project Mu | [![mwt3]][_it]    |
+| Linux Ubuntu 22.04  | Python 3.10 | Project Mu | [![mut1]][_i359]  |
+| Linux Ubuntu 22.04  | Python 3.11 | Project Mu | [![mut2]][_it]    |
+| Linux Ubuntu 22.04  | Python 3.12 | Project Mu | [![mut3]][_it]    |
 
 ### Current Release
 
@@ -173,18 +173,18 @@ contributing to the edk2-pytool-extensions repository.
 
 [_it]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_build?definitionId=52&_a=summary&repositoryFilter=2&branchFilter=14
 [_i359]: https://github.com/tianocore/edk2-pytool-extensions/issues/359
-[ewt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python39
-[ewt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python310
-[ewt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python311
+[ewt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python310
+[ewt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python311
+[ewt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python312
 
-[eut1]: https://img.shields.io/github/issues/detail/label/tianocore/edk2-pytool-extensions/359?color=orange&label=issue%20359
-[eut2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python310
-[eut3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python311
+[eut1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python310
+[eut2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python311
+[eut3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python312
 
-[mwt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python39
-[mwt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python310
-[mwt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python311
+[mwt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python310
+[mwt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python311
+[mwt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python312
 
-[mut1]: https://img.shields.io/github/issues/detail/label/tianocore/edk2-pytool-extensions/359?color=orange&label=issue%20359
-[mut2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python310
-[mut3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python311
+[mut1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python310
+[mut2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python311
+[mut3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python312

--- a/tests.integration/azure-pipelines/windows-robot-integration-test.yml
+++ b/tests.integration/azure-pipelines/windows-robot-integration-test.yml
@@ -85,10 +85,7 @@ jobs:
         output.xml
         report.html
       flattenFolders: true
-    # condition: succeededOrFailed()
-    condition: and(succeededOrFailed(), not(and(eq(variables.PythonVersion, '3.9'), contains(variables.Image, 'ubuntu'))))  
-    # Above conditional is a temp workaround for known ubuntu python 3.9 Tar file bug
-    # https://bugzilla.tianocore.org/show_bug.cgi?id=3891
+    condition: succeededOrFailed()
 
   # Publish build artifacts to Azure Artifacts/TFS or a file share
   - task: PublishBuildArtifacts@1

--- a/tests.integration/azure-pipelines/windows-robot-integration-test.yml
+++ b/tests.integration/azure-pipelines/windows-robot-integration-test.yml
@@ -73,9 +73,6 @@ jobs:
   - script: python -m robot.run -v TEST_OUTPUT_BASE:$(Build.BinariesDirectory) -v TOOL_CHAIN_TAG:$(ToolChain) -d report --xunit xunittestresults.xml --include $(Tag) -L TRACE .
     displayName: 'Run Robot Tests'
     workingDirectory: "tests.integration"
-    condition: not(and(eq(variables.PythonVersion, '3.9'), contains(variables.Image, 'ubuntu')))  
-    # Above conditional is a temp workaround for known ubuntu python 3.9 Tar file bug
-    # https://bugzilla.tianocore.org/show_bug.cgi?id=3891
 
   # Copy the build logs to the artifact staging directory
   - task: CopyFiles@2

--- a/tests.integration/azure-pipelines/windows-robot-integration-test.yml
+++ b/tests.integration/azure-pipelines/windows-robot-integration-test.yml
@@ -10,7 +10,7 @@
 parameters:
 - name: PythonVersionList
   type: object
-  default: ['3.9', '3.10', '3.11']
+  default: ['3.10', '3.11', '3.12']
 
 jobs:
 - job:


### PR DESCRIPTION
Updates all documentation and testing to use python 3.10, 3.11, and 3.12.

Additionally adds a python-requires section to the pyproject.toml, to ensure a proper error if someone tries to pip install edk2-pytool-library v0.19.0 on a python version less than 3.10