### PR TITLE
pyproject.toml: require edk2-pytool-library>=0.19.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = {file = "readme.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
 requires-python = ">=3.10"
 dependencies = [
-    "edk2-pytool-library>=0.16.1",
+    "edk2-pytool-library>=0.19.2",
     "pyyaml>=6.0.0",
     "pefile>=2023.2.7",
     "semantic_version>=2.10.0",


### PR DESCRIPTION
edk2-pytool-library has import bugfixes for ensuring expected support for gitignore parsing. This commit ensures edk2-pytool-library is at the required version.