### PR TITLE
Reports: Usage Report: Add additional data

### DIFF
--- a/edk2toolext/environment/reporttypes/templates/usage_report_template.html
+++ b/edk2toolext/environment/reporttypes/templates/usage_report_template.html
@@ -30,6 +30,12 @@
                 <button class="nav-link active" id="summary-tab" data-bs-toggle="tab" data-bs-target="#summary" type="button" role="tab" aria-controls="summary" aria-selected="true">Summary</button>
             </li>
             <li class="nav-item" role="presentation">
+                <button class="nav-link" id="inf-pie-tab" data-bs-toggle="tab" data-bs-target="#inf" type="button" role="tab" aria-controls="inf" aria-selected="false">INF Reports</button>
+            </li>
+            <li class="nav-=item" role="presentation">
+                <button class="nav-link" id="lc-pie-tab" data-bs-toggle="tab" data-bs-target="#lc" type="button" role="tab" aria-controls="lc" aria-selected="false">Line Count Reports</button>          
+            </li>
+            <li class="nav-item" role="presentation">
                 <button class="nav-link" id="env-tab" data-bs-toggle="tab" data-bs-target="#env" type="button" role="tab" aria-controls="env" aria-selected="false">Environment Variables</button>
             </li>
             <li class="nav-item" role="presentation">
@@ -39,26 +45,6 @@
         <div class="tab-content">
             <!-- Summary Tab -->
             <div id="summary" class="tab-pane fade show active" role="tabpanel" aria-labelledby="summary-tab">
-                <div class="row align-items-center">
-                    <div class="col-md-6">
-                        {{ total_pie_chart }}
-                    </div>
-                    <div class="col-md-6">
-                        {{ comp_pie_chart }}
-                    </div>
-                    <div class="col-md-6">
-                        {{ lib_pie_chart }}
-                    </div>
-                    <div class="col-md-6">
-                        {{ total_src_pie_chart }}
-                    </div>
-                    <div class="col-md-6">
-                        {{ comp_src_pie_chart }}
-                    </div>
-                    <div class="col-md-6">
-                        {{ lib_src_pie_chart }}
-                    </div>
-                </div>
                 <div class="row align-items-left">
                     <div class="col">
                         <div class="card" style="width: 30rem;">
@@ -71,6 +57,32 @@
                                 <li class="list-group-item">Commit Sha: {{ version }}</li>
                             </ul>
                         </div>
+                    </div>
+                </div>
+            </div>
+            <div id="inf" class="tab-pane fade" role="tabpanel" aria-labelledby="inf-pie-tab">
+                <div class="row align-items-center">
+                    <div class="col-md-6">
+                        {{ total_pie_chart }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ comp_pie_chart }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ lib_pie_chart }}
+                    </div>
+                </div>
+            </div>
+            <div id="lc" class="tab-pane fade" role="tabpanel" aria-labelledby="lc-pie-tab">
+                <div class="row align-items-center">
+                    <div class="col-md-6">
+                        {{ total_src_pie_chart }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ comp_src_pie_chart }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ lib_src_pie_chart }}
                     </div>
                 </div>
             </div>

--- a/edk2toolext/environment/reporttypes/templates/usage_report_template.html
+++ b/edk2toolext/environment/reporttypes/templates/usage_report_template.html
@@ -41,10 +41,22 @@
             <div id="summary" class="tab-pane fade show active" role="tabpanel" aria-labelledby="summary-tab">
                 <div class="row align-items-center">
                     <div class="col-md-6">
+                        {{ total_pie_chart }}
+                    </div>
+                    <div class="col-md-6">
                         {{ comp_pie_chart }}
                     </div>
                     <div class="col-md-6">
                         {{ lib_pie_chart }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ total_src_pie_chart }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ comp_src_pie_chart }}
+                    </div>
+                    <div class="col-md-6">
+                        {{ lib_src_pie_chart }}
                     </div>
                 </div>
                 <div class="row align-items-left">

--- a/edk2toolext/environment/reporttypes/templates/usage_report_template.html
+++ b/edk2toolext/environment/reporttypes/templates/usage_report_template.html
@@ -60,6 +60,7 @@
                     </div>
                 </div>
             </div>
+            <!-- INF Reports -->
             <div id="inf" class="tab-pane fade" role="tabpanel" aria-labelledby="inf-pie-tab">
                 <div class="row align-items-center">
                     <div class="col-md-6">
@@ -73,6 +74,7 @@
                     </div>
                 </div>
             </div>
+            <!-- Source Reports -->
             <div id="lc" class="tab-pane fade" role="tabpanel" aria-labelledby="lc-pie-tab">
                 <div class="row align-items-center">
                     <div class="col-md-6">
@@ -118,14 +120,16 @@
                                 <th>Repository</th>
                                 <th>Package</th>
                                 <th>Path</th>
+                                <th>Line Count</th>
                             </tr>
                         </thead>
                         <tbody>
-                            {% for repo, package, path in inf_list %}
+                            {% for repo, package, path, lc in inf_list %}
                             <tr>
                                 <td>{{ repo }}</td>
                                 <td>{{ package }}</td>
                                 <td>{{ path }}</td>
+                                <td>{{ lc }}</td>
                             </tr>
                             {% endfor %}
                         </tbody>

--- a/edk2toolext/environment/reporttypes/usage_report.py
+++ b/edk2toolext/environment/reporttypes/usage_report.py
@@ -168,9 +168,11 @@ class UsageReport(Report):
         comp_lines = {}
         total_lines = {}
 
-        inf_list = set()
+        inf_dict = {}
         for repo, package, inf, _src, line_count, is_component in db.connection.execute(QUERY, (env_id,)).fetchall():
-            inf_list.add((repo, package, inf))
+            key = (repo, package, inf)
+            current = inf_dict.setdefault(key, (repo, package, inf, 0))
+            inf_dict[key] = (repo, package, inf, current[3] + (line_count or 0))
 
             if is_component:
                 inf_d = comp_infs
@@ -194,7 +196,7 @@ class UsageReport(Report):
             ("lib_src_pie_chart", lib_lines, "Library Line Count Per Repository", False),
             ("comp_src_pie_chart", comp_lines, "Component Line Count Per Repository", False),
         ]
-        return (reports, inf_list)
+        return (reports, set(inf_dict.values()))
 
     def _get_env_vars(self, connection, env_id):
         env_vars = {}

--- a/edk2toolext/environment/reporttypes/usage_report.py
+++ b/edk2toolext/environment/reporttypes/usage_report.py
@@ -23,7 +23,7 @@ WITH variable AS (
     SELECT
         ? AS env -- VARIABLE: Change this to the environment parse you care about
 )
-SELECT
+SELECT DISTINCT
     package.repository AS "Repository",
     inf.package AS "Package",
     inf_list.path AS "INF Path",
@@ -74,6 +74,9 @@ DESC LIMIT 1;
 """
 
 
+COLORS = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf', '#aec7e8', '#ffbb78', '#98df8a', '#ff9896', '#c5b0d5']
+
+
 class UsageReport(Report):
     """A report that generates a INF usage report for a specific build."""
     def report_info(self):
@@ -104,54 +107,42 @@ class UsageReport(Report):
             exit(-1)
 
         env_id = args.env_id or db.connection.execute(ID_QUERY).fetchone()[0]
+        reports, inf_list = self.generate_data(env_id, db)
+
+        # Build color map for consistent colors across all reports
+        color_map = {}
+        for idx, key in enumerate({item[0] for item in inf_list}):
+            color_map[key] = COLORS[idx % len(COLORS)]
 
         # Vars for html template
         env = Environment(loader=FileSystemLoader(templates.__path__))
         template = env.get_template("usage_report_template.html")
-
-        # This is the data that gets passed to the html template
-        data = {
+        report_data = {
             "version": db.connection.execute(VERSION_QUERY, (env_id,)).fetchone()[0],
             "env": self._get_env_vars(db.connection, env_id),
-            "inf_list": set(),
+            "inf_list":  inf_list,
         }
 
-        # Split up the data from the database
-        lib_infs = {}
-        comp_infs = {}
-        for repo, package, inf, _src, _lc, is_component in db.connection.execute(QUERY, (env_id,)).fetchall():
-            data["inf_list"].add((repo, package, inf))
-            if is_component:
-                d = comp_infs
-            else:
-                d = lib_infs
-            if repo not in d:
-                d[repo] = [inf]
-            else:
-                d[repo].append(inf)
-
-        # Build the reports
-        reports = [
-            ("lib_pie_chart", lib_infs, "Library Usage Per Repository"),
-            ("comp_pie_chart", comp_infs, "Component Usage Per Repository")
-        ]
-        for key, value, title in reports:
-            # Build the figure
+        # Build the pie charts and save them in report_data
+        for key, value, title, combine in reports:
             labels = [key for key in value.keys()]
-            values = [len(set(value)) for value in value.values()]
+            if combine:
+                values = [len(set(value)) for value in value.values()]
+            else:
+                values = [value[key] for key in value.keys()]
             fig = go.Figure(go.Pie(labels=labels, values=values, hole = .3, title=title, titleposition="top center"))
-
+            fig.update_traces(marker=dict(colors=[color_map[key] for key in value.keys()]))
             # Write the html
             html = io.StringIO()
             fig.write_html(html, full_html=False, include_plotlyjs=False)
             html.seek(0)
 
             # Add the html to the data dictionary
-            data[key] = html.read()
+            report_data[key] = html.read()
 
-        # Open the template and write the html with the data
-        html_output = template.render(**data)
-        path_out = args.output or data["env"].get("PLATFORM_NAME", None) or "usage_report.html"
+        # Open the template and write the html with the report data
+        html_output = template.render(**report_data)
+        path_out = args.output or report_data["env"].get("PLATFORM_NAME", None) or "usage_report.html"
         if not path_out.endswith(".html"):
             path_out += ".html"
 
@@ -160,9 +151,66 @@ class UsageReport(Report):
             f.write(html_output)
         logging.info(f"Report written to {path_out}.")
 
+    def generate_data(self, env_id, db) -> tuple[dict, set]:
+        """Generates a list of pie chart data.
+
+        Args:
+            env_id (int): The environment id the report is generating off of.
+            db (Edk2DB): The database to pull data from.
+
+        Returns:
+            (dict, set): (pie chart data, set of all INFs)
+        """
+        lib_infs = {}
+        comp_infs = {}
+        total_infs = {}
+        lib_lines = {}
+        comp_lines = {}
+        total_lines = {}
+
+        inf_list = set()
+        for repo, package, inf, _src, line_count, is_component in db.connection.execute(QUERY, (env_id,)).fetchall():
+            inf_list.add((repo, package, inf))
+
+            if is_component:
+                inf_d = comp_infs
+                src_d = comp_lines
+            else:
+                inf_d = lib_infs
+                src_d = lib_lines
+
+            inf_d.setdefault(repo, []).append(inf)
+            src_d[repo] = src_d.get(repo, 0) + (line_count or 0)
+
+        total_infs = self._merge_dicts(lib_infs, comp_infs)
+        total_lines = self._merge_dicts(lib_lines, comp_lines)
+
+        # Build the reports
+        reports = [
+            ("total_pie_chart", total_infs, "Total INF Usage Per Repository", True),
+            ("lib_pie_chart", lib_infs, "Library Usage Per Repository", True),
+            ("comp_pie_chart", comp_infs, "Component Usage Per Repository", True),
+            ("total_src_pie_chart", total_lines, "Total Line Count Per Reporitory", False),
+            ("lib_src_pie_chart", lib_lines, "Library Line Count Per Repository", False),
+            ("comp_src_pie_chart", comp_lines, "Component Line Count Per Repository", False),
+        ]
+        return (reports, inf_list)
+
     def _get_env_vars(self, connection, env_id):
         env_vars = {}
         results = connection.execute("SELECT key, value FROM environment_values WHERE id = ?;", (env_id,)).fetchall()
         for key, value in results:
             env_vars[key] = value
         return env_vars
+
+    def _merge_dicts(self, dict1, dict2) -> dict:
+        return_dict = {}
+        for key in dict1:
+            if key in dict2:
+                return_dict[key] = dict1[key] + dict2[key]
+            else:
+                return_dict[key] = dict1[key]
+        for key in dict2:
+            if key not in return_dict:
+                return_dict[key] = dict2[key]
+        return return_dict

--- a/edk2toolext/environment/reporttypes/usage_report.py
+++ b/edk2toolext/environment/reporttypes/usage_report.py
@@ -74,7 +74,8 @@ DESC LIMIT 1;
 """
 
 
-COLORS = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2', '#7f7f7f', '#bcbd22', '#17becf', '#aec7e8', '#ffbb78', '#98df8a', '#ff9896', '#c5b0d5']
+COLORS = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e377c2', '#7f7f7f','#bcbd22', '#17becf',
+          '#aec7e8', '#ffbb78', '#98df8a', '#ff9896', '#c5b0d5',]
 
 
 class UsageReport(Report):
@@ -192,7 +193,7 @@ class UsageReport(Report):
             ("total_pie_chart", total_infs, "Total INF Usage Per Repository", True),
             ("lib_pie_chart", lib_infs, "Library Usage Per Repository", True),
             ("comp_pie_chart", comp_infs, "Component Usage Per Repository", True),
-            ("total_src_pie_chart", total_lines, "Total Line Count Per Reporitory", False),
+            ("total_src_pie_chart", total_lines, "Total Line Count Per Repository", False),
             ("lib_src_pie_chart", lib_lines, "Library Line Count Per Repository", False),
             ("comp_src_pie_chart", comp_lines, "Component Line Count Per Repository", False),
         ]


### PR DESCRIPTION
Updates usage report (`stuart_report usage`) with the following:

1. Adds a third pie chart that is the combined totals from the library and components pie charts.
2. Adds an additional three pie charts that show total line count used by a repository rather than INF count.
3. Moves the INF pie charts and source pie charts into their own respective tabs in the report, leaving the Summary tab to only provide important environment information.
4. Updates the data table tab to also include total line count of all source files used by the INF in the table.