### PR TITLE
coverage_report: Add additional functionality

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -104,6 +104,7 @@
         "prebuild",
         "prepended",
         "pygit",
+        "pygout",
         "pymodule",
         "pyopenssl",
         "pypath",

--- a/.cspell.json
+++ b/.cspell.json
@@ -104,7 +104,7 @@
         "prebuild",
         "prepended",
         "pygit",
-        "pygout",
+        "pygount",
         "pymodule",
         "pyopenssl",
         "pypath",

--- a/edk2toolext/environment/reporttypes/coverage_report.py
+++ b/edk2toolext/environment/reporttypes/coverage_report.py
@@ -14,8 +14,10 @@ import xml.dom.minidom as minidom
 import xml.etree.ElementTree as ET
 from argparse import Action, ArgumentParser, Namespace
 from pathlib import Path
+from pygount import SourceAnalysis
 
 from edk2toollib.database import Edk2DB
+from edk2toollib.uefi.edk2.path_utilities import Edk2Path
 
 from edk2toolext.environment.reporttypes.base_report import Report
 
@@ -117,31 +119,39 @@ class CoverageReport(Report):
 
     def add_cli_options(self, parserobj: ArgumentParser):
         """Configure command line arguments for this report."""
-        # Group 1
+        # Group 1 - Calculate coverage only for files in a specific package
         group = parserobj.add_argument_group("Coverage by package options")
         group.add_argument("--by-package", action="store_true", dest="by_package", default=False,
                            help="Filters test coverage to only files in the specified packages(s)")
         group.add_argument("-p", "--package", "--Package", "--PACKAGE", dest="package_list",
                            action=SplitCommaAction, default=[],
                            help="The package to include in the report. Can be specified multiple times.")
-        # Group 2
+
+        # Group 2 - Calculate coverage only on files used by a specific platform
         group = parserobj.add_argument_group("Coverage by platform options")
         group.add_argument("--by-platform", action="store_true", dest="by_platform", default=False,
                            help="Filters test coverage to all files used to build the specified platform package.")
         group.add_argument("-d", "--dsc", "--DSC", dest="dsc",
                            help="Edk2 relative path the ACTIVE_PLATFORM DSC file.")
 
+        # Group 3 - Run either by-platform or by-package with a FULL report
+        group = parserobj.add_argument_group("Full Report")
+        group.add_argument("--full", action="store_true", dest="full", default=False,
+                           help="Include all files in the report, not just those with coverage data.")
+        group.add_argument("-ws", "--workspace", "--Workspace", "--WORKSPACE", dest="workspace",
+                               help="The Workspace root associated with the xml argument.", default=".")
+
         # Other args
         parserobj.add_argument(dest="xml", action="store", help="The path to the XML file parse.")
         parserobj.add_argument("-o", "--output", "--Output", "--OUTPUT", dest="output", default="Coverage.xml",
                                help="The path to the output XML file.", action="store")
-        parserobj.add_argument("-ws", "--workspace", "--Workspace", "--WORKSPACE", dest="workspace",
-                               help="The Workspace root associated with the xml argument.", default=".")
-
         parserobj.add_argument("-e", "--exclude", "--Exclude", "--EXCLUDE", dest="exclude",
                                action=SplitCommaAction, default=[],
                                help="Package path relative paths or file (.txt). Globbing is supported. Can be "
                                "specified multiple times")
+        parserobj.add_argument("--flatten", action="store_true", dest="flatten", default=False,
+                              help="Flatten the report to only source files. This removes duplicate files that are in "
+                              "multiple INFs.")
 
     def run_report(self, db: Edk2DB, args: Namespace) -> None:
         """Generate the Coverage report."""
@@ -293,7 +303,8 @@ class CoverageReport(Report):
         specified file.
         """
         pp_list, = db.connection.execute(PACKAGE_PATH_QUERY, (env_id,)).fetchone()
-        pp_list = pp_list.split(os.pathsep)
+        pp_list = re.split(r'[:;]', pp_list)
+        edk2path = Edk2Path(self.args.workspace, pp_list)
 
         root = ET.Element("coverage")
         sources = ET.SubElement(root, "sources")
@@ -306,6 +317,8 @@ class CoverageReport(Report):
 
         packages = ET.SubElement(root, "packages")
         for path, source_list in inf_source_dict.items():
+            if fnmatch.fnmatch(path, "*Test*"):
+                continue
             if not source_list:
                 continue
             inf = ET.SubElement(packages, "package", path=path, name=Path(path).name)
@@ -325,8 +338,12 @@ class CoverageReport(Report):
                 match = next((key for key in source_coverage_dict.keys() if Path(source).is_relative_to(key)), None)
                 if match is not None:
                     classes.append(source_coverage_dict[match])
-                else:
-                    classes.append(ET.Element("class", name=Path(source).name, filename=source))
+                elif self.args.full:
+                    classes.append(self.create_file_xml(source, edk2path))
+
+        # Flaten the report to only source files, removing duplicates from INFs.
+        if self.args.flatten:
+            root = self.flatten_report(root)
 
         xml_string = ET.tostring(root, "utf-8")
         dom = minidom.parseString(xml_string)
@@ -336,7 +353,7 @@ class CoverageReport(Report):
         p = Path(self.args.output)
         p.unlink(missing_ok=True)
         with open(p, 'wb') as f:
-            f.write(dom.toxml(encoding="utf-8"))
+            f.write(dom.toprettyxml(encoding="utf-8", indent="  "))
         logging.info(f"Coverage xml data written to {p}")
 
     def update_excluded_files(self):
@@ -349,3 +366,36 @@ class CoverageReport(Report):
             else:
                 temporary_list.append(pattern)
         self.args.exclude = temporary_list
+
+    def create_file_xml(self, source_path: str, edk2path: Edk2Path) -> ET:
+        """Parses the source file and creates a coverage 'lines' xml element for it."""
+        source_path = edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(source_path)
+        code_count = SourceAnalysis.from_file(source_path, "_").code_count
+        file_xml = ET.Element("class", name=Path(source_path).name, filename=source_path)
+        lines_xml = ET.Element("lines")
+        for i in range(1, code_count + 1):
+            lines_xml.append(ET.Element("line", number=str(i), hits="0"))
+        file_xml.append(lines_xml)
+        return file_xml
+
+    def flatten_report(self, root: ET.Element) -> ET.Element:
+        """Flattens the report to only source files, removing the INF layer and duplicate source files."""
+        class_list = ET.Element("classes")
+
+        class_dict = {}
+        count = 0
+        for class_element in root.iter("class"):
+            filename = class_element.get('filename')
+            class_dict[filename] = class_element
+            count += 1
+
+        for class_element in class_dict.values():
+            class_list.append(class_element)
+
+        package_element = ET.Element("package", name = "All Source")
+        package_element.append(class_list)
+
+        packages = root.find('.//packages')
+        packages.clear()
+        packages.append(package_element)
+        return root

--- a/edk2toolext/environment/reporttypes/coverage_report.py
+++ b/edk2toolext/environment/reporttypes/coverage_report.py
@@ -386,13 +386,10 @@ class CoverageReport(Report):
         class_list = ET.Element("classes")
 
         class_dict = {}
-        count = 0
         for class_element in root.iter("class"):
             filename = class_element.get('filename')
-            filename = filename.replace("/", "\\")
             class_element.set("name", "\\".join(Path(filename).parts))
             class_dict[filename] = class_element
-            count += 1
 
         for class_element in class_dict.values():
             class_list.append(class_element)

--- a/edk2toolext/environment/reporttypes/coverage_report.py
+++ b/edk2toolext/environment/reporttypes/coverage_report.py
@@ -388,7 +388,8 @@ class CoverageReport(Report):
         class_dict = {}
         for class_element in root.iter("class"):
             filename = class_element.get('filename')
-            class_element.set("name", "\\".join(Path(filename).parts))
+            filename = "\\".join(Path(filename).parts)
+            class_element.set("name", filename)
             class_dict[filename] = class_element
 
         for class_element in class_dict.values():

--- a/edk2toolext/environment/reporttypes/coverage_report.py
+++ b/edk2toolext/environment/reporttypes/coverage_report.py
@@ -412,5 +412,5 @@ class CoverageReport(Report):
         except ImportError as e:
             print(e)
             print("WARNING: This report requires pip modules not installed with edk2-pytool-extensions:")
-            print("  Run the following command: `pip install pygout`")
+            print("  Run the following command: `pip install pygount`")
             exit(-1)

--- a/edk2toolext/environment/reporttypes/coverage_report.py
+++ b/edk2toolext/environment/reporttypes/coverage_report.py
@@ -340,7 +340,7 @@ class CoverageReport(Report):
                 if match is not None:
                     classes.append(source_coverage_dict[match])
                 elif self.args.full:
-                    classes.append(self.create_file_xml(source, edk2path))
+                    classes.append(self.create_source_xml(source, edk2path))
 
         # Flaten the report to only source files, removing duplicates from INFs.
         if self.args.flatten:
@@ -368,7 +368,7 @@ class CoverageReport(Report):
                 temporary_list.append(pattern)
         self.args.exclude = temporary_list
 
-    def create_file_xml(self, source_path: str, edk2path: Edk2Path) -> ET:
+    def create_source_xml(self, source_path: str, edk2path: Edk2Path) -> ET:
         """Parses the source file and creates a coverage 'lines' xml element for it."""
         from pygount import SourceAnalysis
         full_path = edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(source_path)


### PR DESCRIPTION
Adds the additional functionality to the coverage report:

1. Generate xml data for source files that do not have coverage data with the `--full` flag. Using this flag requires the `-ws` flag is pointing to the workspace root, so that the files can be found for code counting.
2. Adds the ability to "flatten"reports with the `--flatten` flag. This flag causes the report to place all source files together, rather than grouping them by INF. This results in different coverage data as duplicate sources files are removed (which can occur when a certain source file is used by multiple INFs). 
3. Changes the `name` attribute for a file to be the package path relative path. This is because report generator tools that consume the coverage.xml file combine coverage data for source files with the same `name` attribute, even if the `filepath` attributes are different.
4. writes the coverage xml in "pretty" format, which causes the xml to have the expected indentation instead of no newlines whatsoever. This has no effect, but makes reading the coverage.xml file easier.