### PR TITLE
coverage_report: split packagepaths by os.sep

### DIFF
--- a/edk2toolext/environment/reporttypes/coverage_report.py
+++ b/edk2toolext/environment/reporttypes/coverage_report.py
@@ -8,6 +8,7 @@
 """A report that re-organizes a cobertura.xml by INF."""
 import fnmatch
 import logging
+import os
 import re
 import xml.dom.minidom as minidom
 import xml.etree.ElementTree as ET
@@ -304,7 +305,7 @@ class CoverageReport(Report):
         specified file.
         """
         pp_list, = db.connection.execute(PACKAGE_PATH_QUERY, (env_id,)).fetchone()
-        pp_list = re.split(r'[:;]', pp_list)
+        pp_list = pp_list.split(os.pathsep)
         edk2path = Edk2Path(self.args.workspace, pp_list)
 
         root = ET.Element("coverage")


### PR DESCRIPTION
coverage_report attempted to split by both separator types (":" and ";"), however this caused a bug due to the fact that windows paths contain ":" to specify the drive letter, which resulted in invalid package paths.

This change splits by os.sep, which is the correct way to split paths.