### PR TITLE
Only restore file permissions on Linux

### DIFF
--- a/edk2toolext/environment/extdeptypes/web_dependency.py
+++ b/edk2toolext/environment/extdeptypes/web_dependency.py
@@ -11,13 +11,13 @@
 import logging
 import os
 import pathlib
+import platform
 import shutil
 import tarfile
 import tempfile
 import urllib.error
 import urllib.request
 import zipfile
-import platform
 
 from edk2toollib.utility_functions import RemoveTree
 

--- a/edk2toolext/environment/extdeptypes/web_dependency.py
+++ b/edk2toolext/environment/extdeptypes/web_dependency.py
@@ -17,6 +17,7 @@ import tempfile
 import urllib.error
 import urllib.request
 import zipfile
+import platform
 
 from edk2toollib.utility_functions import RemoveTree
 
@@ -108,8 +109,9 @@ class WebDependency(ExternalDependency):
             _ref.extract(member=file, path=destination)
 
             # unzip functionality does not preserve file permissions. Fix-up the permissions
+            # if using a non-windows machine.
             path = pathlib.Path(destination, file)
-            if path.is_file() and compression_type == "zip":
+            if path.is_file() and compression_type == "zip" and not platform.system().startswith("Win"):
                 expected_mode = _ref.getinfo(file).external_attr >> 16
                 path.chmod(expected_mode)
 


### PR DESCRIPTION
The file permissions issue that was fixed via #608 was specifically targeting Linux systems (as seen in the tests, that only test for Linux), however the permissions fix-up was applied regardless of operating system. This change ensures that the fixup is only applied on Non windows systems.