### PR TITLE
edk2_invocable: print help message when build module provided

### DIFF
--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -465,7 +465,7 @@ class Edk2Invocable(BaseAbstractInvocable):
         parserObj.epilog = self.AddParserEpilog()
 
         # setup sys.argv and argparse round 2
-        sys.argv = [sys.argv[0]] + unknown_args
+        sys.argv = [sys.argv[0]] + ["--help"] if settingsArg.help else unknown_args
         args, unknown_args = parserObj.parse_known_args()
         self.Verbose = args.verbose
 

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -465,7 +465,7 @@ class Edk2Invocable(BaseAbstractInvocable):
         parserObj.epilog = self.AddParserEpilog()
 
         # setup sys.argv and argparse round 2
-        sys.argv = [sys.argv[0]] + ["--help"] if settingsArg.help else unknown_args
+        sys.argv = [sys.argv[0]] + (["--help"] if settingsArg.help else unknown_args)
         args, unknown_args = parserObj.parse_known_args()
         self.Verbose = args.verbose
 


### PR DESCRIPTION
Changes made in #639 to ensure the invocable displayed their command line arguments when a build module was not provided failed to test the critical scenario of ensuring the help message was still displayed when a build module was provided.

The help command line argument is consumed during the first pass of the command line argument parser, so when the build module is found, registered, and the parser is re-executed, the help argument is no longer present to trigger the help message display.

This commit fixes the issue by adding the "--help" command line argument to the arguments to be parsed if it was detected in the first parse.

closes #708 