### PR TITLE
edk2-pytool-library v0.20.0 integration

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -64,6 +64,7 @@
         "iasl",
         "imxfamily",
         "infp",
+        "isnot",
         "invocable",
         "invocables",
         "isabs",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,7 @@
   "[python]": {
     "editor.defaultFormatter": null,
     "editor.codeActionsOnSave": {
-      "source.fixAll.ruff": true
+      "source.fixAll.ruff": "explicit"
     }
   }
 }

--- a/edk2toolext/edk2_report.py
+++ b/edk2toolext/edk2_report.py
@@ -88,11 +88,11 @@ def main() -> int:
     cmd = args.cmd
     del args.cmd
 
-    with Edk2DB(db_path = db_path) as db:
-        for report in REPORTS:
-            name, _ = report.report_info()
-            if name == cmd:
-                return report.run_report(db, args)
+    db = Edk2DB(db_path = db_path)
+    for report in REPORTS:
+        name, _ = report.report_info()
+        if name == cmd:
+            return report.run_report(db, args)
     return -1
 
 def merge_databases(databases: list[str]) -> str:

--- a/edk2toolext/edk2_report.py
+++ b/edk2toolext/edk2_report.py
@@ -9,9 +9,7 @@
 import glob
 import logging
 import pathlib
-import sqlite3
 import sys
-import tempfile
 from argparse import ArgumentParser, Namespace
 from datetime import datetime
 
@@ -81,8 +79,8 @@ def main() -> int:
         logging.info(f"Single Database file found at: {to_merge[0]}")
         db_path = to_merge[0]
     else:
-        logging.info("Multiple Database files found...")
-        db_path = merge_databases(to_merge).name
+        logging.error("Multiple Databases not Currently Supported.")
+        return -1
 
     del args.database
     cmd = args.cmd
@@ -94,26 +92,6 @@ def main() -> int:
         if name == cmd:
             return report.run_report(db, args)
     return -1
-
-def merge_databases(databases: list[str]) -> str:
-    """Performs an in-memory merge of databases and provides a string path to the temporary file."""
-    logging.info(f"Merging database: {databases[0]}")
-    db = pathlib.Path(databases[0])
-    temp_db = tempfile.NamedTemporaryFile(delete=False)
-    temp_db.write(db.read_bytes())
-
-    conn = sqlite3.connect(temp_db.name)
-    tables = conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
-    for database in databases[1:]:
-        logging.info(f"Merging database: {database}")
-        conn.execute(f"ATTACH DATABASE '{database}' AS temp_db")
-        for table, in tables:
-            conn.execute(f"INSERT OR REPLACE INTO main.{table} SELECT * FROM temp_db.{table};")
-        conn.commit()
-        conn.execute("DETACH DATABASE temp_db;")
-        conn.commit()
-
-    return temp_db
 
 
 def go() -> None:

--- a/edk2toolext/environment/reporttypes/usage_report.py
+++ b/edk2toolext/environment/reporttypes/usage_report.py
@@ -28,7 +28,7 @@ COLORS = ['#1f77b4', '#ff7f0e', '#2ca02c', '#d62728', '#9467bd', '#8c564b', '#e3
 
 class UsageReport(Report):
     """A report that generates a INF usage report for a specific build."""
-    def report_info(self) -> Tuple(str, str):
+    def report_info(self) -> Tuple[str, str]:
         """Returns the report standard information.
 
         Returns:
@@ -104,7 +104,7 @@ class UsageReport(Report):
             f.write(html_output)
         logging.info(f"Report written to {path_out}.")
 
-    def generate_data(self, env_id: int, session: Session) -> tuple[dict, set]:
+    def generate_data(self, env_id: int, session: Session) -> Tuple[dict, set]:
         """Generates a list of pie chart data.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = {file = "readme.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
 requires-python = ">=3.10"
 dependencies = [
-    "edk2-pytool-library>=0.19.4",
+    "edk2-pytool-library>=0.20.0",
     "pyyaml>=6.0.0",
     "pefile>=2023.2.7",
     "semantic_version>=2.10.0",


### PR DESCRIPTION
edk2-pytool-library v0.20.0 provides a re-work of Edk2DB to use an ORM (sqlalchemy) instead of sqlite3 directly to help lower the barrier of entry for using the database functionality.

This pull request updates the slight usage change to Edk2DB, but is mainly focused on updating the reports for stuart_report to use the ORM entity models for getting the needed data from the database rather than raw SQL queries.