### PR TITLE
upgrade markdownlint-cli

### DIFF
--- a/.github/workflows/CIRunner.yml
+++ b/.github/workflows/CIRunner.yml
@@ -49,7 +49,7 @@ jobs:
     
     - name: Install npm Dependencies
       run: |
-        npm install -g markdownlint-cli@0.32.2
+        npm install -g markdownlint-cli@0.39.0
         npm install -g cspell@5.20.0
     
     - name: Run ruff

--- a/azure-pipelines/templates/markdown-lint-steps.yml
+++ b/azure-pipelines/templates/markdown-lint-steps.yml
@@ -11,7 +11,7 @@ parameters:
   none: ''
 
 steps:
-- script: npm install -g markdownlint-cli
+- script: npm install -g markdownlint-cli@0.39.0
   displayName: "Install markdown linter"
 
 - script: markdownlint "**/*.md"

--- a/readme.md
+++ b/readme.md
@@ -39,20 +39,20 @@ The code coverage and CI badges represent unit test status and the code
 coverage of those unit tests. We require 100% unit test success
 (Hence the pass / fail) and that code coverage percentage does not lower.
 
-| Host Type           | Toolchain   | Project    | Integration Tests |
-| :------------------ | :---------  | :--------- | :---------------- |
-| Windows Server 2019 | Python 3.10 | Edk2       | [![ewt1]][_it]    |
-| Windows Server 2019 | Python 3.11 | Edk2       | [![ewt2]][_it]    |
-| Windows Server 2019 | Python 3.12 | Edk2       | [![ewt3]][_it]    |
-| Linux Ubuntu 20.04  | Python 3.10 | Edk2       | [![eut1]][_i359]  |
-| Linux Ubuntu 20.04  | Python 3.11 | Edk2       | [![eut2]][_it]    |
-| Linux Ubuntu 20.04  | Python 3.12 | Edk2       | [![eut3]][_it]    |
-| Windows Server 2022 | Python 3.10 | Project Mu | [![mwt1]][_it]    |
-| Windows Server 2022 | Python 3.11 | Project Mu | [![mwt2]][_it]    |
-| Windows Server 2022 | Python 3.12 | Project Mu | [![mwt3]][_it]    |
-| Linux Ubuntu 22.04  | Python 3.10 | Project Mu | [![mut1]][_i359]  |
-| Linux Ubuntu 22.04  | Python 3.11 | Project Mu | [![mut2]][_it]    |
-| Linux Ubuntu 22.04  | Python 3.12 | Project Mu | [![mut3]][_it]    |
+| Host Type           | Toolchain   | Project    | Integration Tests
+| :------------------ | :---------  | :--------- | :----------------
+| Windows Server 2019 | Python 3.10 | Edk2       | [![ewt1]][_it]
+| Windows Server 2019 | Python 3.11 | Edk2       | [![ewt2]][_it]
+| Windows Server 2019 | Python 3.12 | Edk2       | [![ewt3]][_it]
+| Linux Ubuntu 20.04  | Python 3.10 | Edk2       | [![eut1]][_i359]
+| Linux Ubuntu 20.04  | Python 3.11 | Edk2       | [![eut2]][_it]
+| Linux Ubuntu 20.04  | Python 3.12 | Edk2       | [![eut3]][_it]
+| Windows Server 2022 | Python 3.10 | Project Mu | [![mwt1]][_it]
+| Windows Server 2022 | Python 3.11 | Project Mu | [![mwt2]][_it]
+| Windows Server 2022 | Python 3.12 | Project Mu | [![mwt3]][_it]
+| Linux Ubuntu 22.04  | Python 3.10 | Project Mu | [![mut1]][_i359]
+| Linux Ubuntu 22.04  | Python 3.11 | Project Mu | [![mut2]][_it]
+| Linux Ubuntu 22.04  | Python 3.12 | Project Mu | [![mut3]][_it]
 
 ### Current Release
 


### PR DESCRIPTION
Upgrades markdownlint-cli to 0.39.0 from 0.32.2.

The release is currently failing as the release pipeline that comes from edk2-pytool-extensions does not have a locked version of markdown lint. This upgrades markdownlint-cli to 0.39.0, which will be the locked version in edk2-pytool-extensions.