### PR TITLE
coverage_report: Allow package filtering for --by-platform

### DIFF
--- a/edk2toolext/environment/reporttypes/coverage_report.py
+++ b/edk2toolext/environment/reporttypes/coverage_report.py
@@ -112,6 +112,7 @@ class CoverageReport(Report):
 
         Args:
             session (Session): The session associated with the database
+            package_list (list): The list of packages to filter the results by
 
         Returns:
             (bool): True if the report was successful, False otherwise.
@@ -167,6 +168,7 @@ class CoverageReport(Report):
 
         Args:
             session (Session): The session associated with the database
+            package_list (list): The list of packages to filter the results by
 
         Returns:
             (bool): True if the report was successful, False otherwise.


### PR DESCRIPTION
Originally, both a --by-package and --by-platform flag was created to describe the types of coverage reports able to be generated, and allow for grouping the command line arguments based on these two flags.

With the adding of the ability to filter on packages for the platform report, the --by-package flag no longer has any special arguments and can be deprecated. Due to this, this change also removes the --by-package flag, making it the default behavior, which is overridden by --py-platform.