### PR TITLE
edk2_invocable: Bugfix for bad argument handling

### DIFF
--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -493,7 +493,7 @@ class Edk2Invocable(BaseAbstractInvocable):
             if argument.count("=") == 1:
                 tokens = argument.strip().split("=")
                 env.SetValue(tokens[0].strip().upper(), tokens[1].strip(), "From CmdLine")
-            elif argument.count("=") == 0:
+            elif argument.count("=") == 0 and not argument.startswith("-"):
                 env.SetValue(argument.strip().upper(),
                              ''.join(choice(ascii_letters) for _ in range(20)),
                              "Non valued variable set From cmdLine")

--- a/tests.unit/test_edk2_setup.py
+++ b/tests.unit/test_edk2_setup.py
@@ -288,7 +288,7 @@ def test_parse_command_line_options(tree: pathlib.Path):
     assert env.GetValue("BLD_*_TEST_VAR2") == "TEST"
 
     # Test invalid command line options
-    for arg in ["BLD_*_VAR=5=10", "BLD_DEBUG_VAR2=5=5", "BLD_RELEASE_VAR3=5=5", "VAR=10=10"]:
+    for arg in ["BLD_*_VAR=5=10", "BLD_DEBUG_VAR2=5=5", "BLD_RELEASE_VAR3=5=5", "VAR=10=10", "--UnexpectdArg"]:
         sys.argv = [
             "stuart_setup",
             "-c", str(empty_build_file),


### PR DESCRIPTION
This change fixes a bug in the edk2_invocable.py script where an invalid command line argument would not cause the script to exit with an error.

This occured due to a change that enabled non-valued environment variables to be passed to the script. The result of this change was that any invalid command line argument would be added as a non-valued environment variable rather than triggering the error handling.

This commit makes it such that any non-valued environment variable cannot start with a '-' character, as that is reserved for argparse arguments.