### PR TITLE
edk2_invocable.py: catch invalid arguments

### DIFF
--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -493,12 +493,13 @@ class Edk2Invocable(BaseAbstractInvocable):
             if argument.count("=") == 1:
                 tokens = argument.strip().split("=")
                 env.SetValue(tokens[0].strip().upper(), tokens[1].strip(), "From CmdLine")
-            elif argument.count("=") == 0 and not argument.startswith("-"):
+            elif argument.count("=") == 0 and not argument.startswith(("-", "/")):
                 env.SetValue(argument.strip().upper(),
                              ''.join(choice(ascii_letters) for _ in range(20)),
                              "Non valued variable set From cmdLine")
             else:
-                raise RuntimeError(f"Unknown variable passed in via CLI: {argument}")
+                print(f"error: unexpected argument: [{argument}]. Pass --help for command information.")
+                sys.exit(-1)
 
         unknown_args.clear()  # remove the arguments we've already consumed
 

--- a/tests.unit/test_edk2_setup.py
+++ b/tests.unit/test_edk2_setup.py
@@ -5,14 +5,14 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause-Patent
 ##
-import pytest
-import git
+import logging
 import pathlib
 import sys
-import logging
 
-from edk2toolext.invocables import edk2_setup
+import git
+import pytest
 from edk2toolext.environment import shell_environment
+from edk2toolext.invocables import edk2_setup
 
 MIN_BUILD_FILE = r"""
 from edk2toolext.invocables.edk2_setup import SetupSettingsManager, RequiredSubmodule
@@ -296,8 +296,8 @@ def test_parse_command_line_options(tree: pathlib.Path):
         ]
         try:
             edk2_setup.main()
-        except RuntimeError as e:
-            assert str(e).startswith(f"Unknown variable passed in via CLI: {arg}")
+        except SystemExit as e:
+            assert e.code == -1
 
 
 def test_conf_file(tree: pathlib.Path):
@@ -341,8 +341,8 @@ def test_conf_file(tree: pathlib.Path):
         ]
         try:
             edk2_setup.main()
-        except RuntimeError as e:
-            assert str(e).startswith(f"Unknown variable passed in via CLI: {arg}")
+        except SystemExit as e:
+            assert e.code == -1
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="Linux only")


### PR DESCRIPTION
1. updates edk2_invocable.py to catch any unexpected argument that start with either a "-" or "/" rather than just "-". This is due to the fact that "/" is a common argument prefix for executables.
2. Changes the RuntimeError exception to a print statement and an exit command as this is an expected possible user error and a print of the backtrace is unnecessary.