### PR TITLE
Add the ability to run only the requested plugins

### DIFF
--- a/docs/user/using/ci.md
+++ b/docs/user/using/ci.md
@@ -55,12 +55,31 @@ stuart_update -c path/to/CISettingsFile.py
 ## stuart_ci_build
 
 Stuart_ci_build is responsible for executing all CI tasks and placing any
-artifacts in the /Build/ directory.
+artifacts in the /Build/ directory. By default, stuart_ci_build will run
+all tests on all packages as specified by the configuration file passed
+to it with the `-c` command.
 
 ```cmd
 stuart_ci_build -c path/to/CISettingsFile.py
 ```
 
+You can filter the package's you want to test with the `-p` command and the
+type of test to execute with the `-t` command. To determine available packages
+and test targets available, use the help command (note you'll only see the
+available options if you provide the configuration file):
+
+```cmd
+stuart_ci_build -c path/to/CISettingsFile.py --h`
+```
+
 ## FAQ
 
-N/A
+Q: Is there a way for me to skip a CI test?
+A: Yes! You have two ways to skip a CI tests. You can permanently skip a
+   specific CI test for a package by adding the configuration `{"skip": true}`
+   in the package's ci.yaml file. If you just need to skip a specific CI test
+   once, you can add `<TestName>=skip` to the command line.
+
+Q: Is there a way for me to only run a single test?
+A: Yes! You can turn off all tests with the `-d, --disable-all` command line
+   argument, then turn the test(s) back on with `<TestName>=run`

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -87,7 +87,7 @@ class Edk2CiBuild(Edk2MultiPkgAwareInvocable):
     def AddCommandLineOptions(self, parser: argparse.ArgumentParser) -> None:
         """Adds command line arguments to Edk2CiBuild."""
         parser.add_argument('-d', '--disable-all', dest="disable", action="store_true", default=False,
-                            help="Disable all plugins. Use <PluginName> to re-enable specific plugins")
+                            help="Disable all plugins. Use <PluginName>=run to re-enable specific plugins")
         super().AddCommandLineOptions(parser)
 
     def RetrieveCommandLineOptions(self, args: argparse.Namespace) -> None:

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -205,7 +205,7 @@ class Edk2CiBuild(Edk2MultiPkgAwareInvocable):
 
                     # Skip all plugins not marked as "run" if disable is set
                     if self.disable_plugins and env.GetValue(Descriptor.Module.upper(), "skip") != "run":
-                        edk2_logging.log_progress("--->Test Skipped due to disable-all flag!"
+                        edk2_logging.log_progress("--->Test Disabled due to disable-all flag!"
                                                   f" {Descriptor.Module} {target}")
                         edk2_logging.log_progress(f"--->Set {Descriptor.Module}=run on the command line to run anyway.")
                         continue

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -13,6 +13,7 @@ Contains a CIBuildSettingsManager that must be subclassed in a build settings
 file. This provides platform specific information to Edk2CiBuild invocable
 while allowing the invocable itself to remain platform agnostic.
 """
+import argparse
 import logging
 import os
 import sys
@@ -83,6 +84,16 @@ class CiBuildSettingsManager(MultiPkgAwareSettingsInterface):
 
 class Edk2CiBuild(Edk2MultiPkgAwareInvocable):
     """Invocable supporting an iterative multi-package build and test process leveraging CI build plugins."""
+    def AddCommandLineOptions(self, parser: argparse.ArgumentParser) -> None:
+        """Adds command line arguments to Edk2CiBuild."""
+        parser.add_argument('-d', '--disable-all', dest="disable", action="store_true", default=False,
+                            help="Disable all plugins. Use <PluginName> to re-enable specific plugins")
+        super().AddCommandLineOptions(parser)
+
+    def RetrieveCommandLineOptions(self, args: argparse.Namespace) -> None:
+        """Retrieve command line options from the argparser."""
+        self.disable_plugins = args.disable
+        super().RetrieveCommandLineOptions(args)
 
     def GetSettingsClass(self) -> type:
         """Returns the CiBuildSettingsManager class.
@@ -192,6 +203,13 @@ class Edk2CiBuild(Edk2MultiPkgAwareInvocable):
                     shell_environment.CheckpointBuildVars()
                     env = shell_environment.GetBuildVars()
 
+                    # Skip all plugins not marked as "run" if disable is set
+                    if self.disable_plugins and env.GetValue(Descriptor.Module.upper(), "skip") != "run":
+                        edk2_logging.log_progress("--->Test Skipped due to disable-all flag!"
+                                                  f" {Descriptor.Module} {target}")
+                        edk2_logging.log_progress(f"--->Set {Descriptor.Module}=run on the command line to run anyway.")
+                        continue
+
                     env.SetValue("TARGET", target, "Edk2CiBuild.py before RunBuildPlugin")
                     (testcasename, testclassname) = Descriptor.Obj.GetTestName(package_class_name, env)
                     tc = ts.create_new_testcase(testcasename, testclassname)
@@ -208,7 +226,6 @@ class Edk2CiBuild(Edk2MultiPkgAwareInvocable):
                             "skip" in pkg_plugin_configuration and pkg_plugin_configuration["skip"]:
                         tc.SetSkipped()
                         edk2_logging.log_progress("--->Test Skipped by package! %s" % Descriptor.Name)
-
                     else:
                         try:
                             #   - package is the edk2 path to package.  This means workspace/package path relative.


### PR DESCRIPTION
Functionality currently exists to skip the execution of a specific plugin with `<PluginName>=skip` in the command line.  This change adds the ability to do the opposite, by setting the `-d` (or `--disable-all`) flag and then specifying the plugins to run with `<PluginName>=run`.

example:
`stuart_ci_build -c .pytool/CISettings.py --disable-all SpellCheck=run`