### PR TITLE
Fix incorrect usage of strip method while accessing the nuget_cache_path

### DIFF
--- a/edk2toolext/environment/extdeptypes/nuget_dependency.py
+++ b/edk2toolext/environment/extdeptypes/nuget_dependency.py
@@ -169,7 +169,7 @@ class NugetDependency(ExternalDependency):
                 # Seek to the beginning of the output buffer and capture the output.
                 return_buffer.seek(0)
                 return_string = return_buffer.read()
-                self.nuget_cache_path = return_string.strip().strip("global-packages: ")
+                self.nuget_cache_path = return_string.strip().replace("global-packages: ", "")
 
         if self.nuget_cache_path is None:
             logging.info("Nuget was unable to provide global packages cache location.")


### PR DESCRIPTION
edk2toolext\environment\extdeptypes\nuget_dependency.py
line number: 172
self.nuget_cache_path = return_string.strip().strip("global-packages: ")

This is an incorrect usage of the strip method. This will cause failures if the nuget dependency path ends with "e"
For example if the NuGet cache path is: "C:\nuget_cache", the second strip method will return an invalid path.

The second strip("global-packages: ") call is intended to remove the characters in the set "global-packages: " from both ends of the string. This set includes each individual character: 'g', 'l', 'o', 'b', 'a', 'l', '-', 'p', 'a', 'c', 'k', 'a', 'g', 'e', 's', ':', and ' ' (space). It does not treat "global-packages: " as a single substring to remove.

This method then removes these characters from the beginning and the end of the string until it encounters a character not in the set. Since the string "C:\nuget_cache" does not start with any of those characters, the beginning of the string remains unchanged. However, the end of the string "C:\nuget_cache" ends with "e", which is in the set of characters to remove. Therefore, it removes "e" from the end, resulting in "C:\nuget_cach".