### PR TITLE
edk2_invocable.py: Improve documentation for SDE related functions

### DIFF
--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -108,7 +108,7 @@ class Edk2InvocableSettingsInterface():
         return []
 
     def GetActiveScopes(self) -> tuple[str]:
-        """Provides scopes that should be active for this process.
+        """Provides scopes that should be active for this process for SDE.
 
         !!! tip
             Optional Override in a subclass
@@ -157,7 +157,7 @@ class Edk2InvocableSettingsInterface():
         """
 
     def GetSkippedDirectories(self) -> tuple[str]:
-        """Returns a tuple containing workspace-relative directories to be skipped.
+        """Returns a tuple containing workspace-relative directories to be skipped by SDE.
 
         !!! tip
             Optional override in a subclass


### PR DESCRIPTION
Improve the documentation for `GetActriveScopes` and `GetSkippedDirectories` to specify that these are used by the `self_descriving_environment` (SDE) to ignore parts of the workspace and to control which custom components (`path_env`, `ext_dep`, and `plug_in` are loaded for a given execution.