### PR TITLE
coverage_report: Gracefully handle missing file

### DIFF
--- a/edk2toolext/environment/reporttypes/coverage_report.py
+++ b/edk2toolext/environment/reporttypes/coverage_report.py
@@ -302,7 +302,7 @@ class CoverageReport(Report):
                 elif self.args.full:
                     xml = self.create_source_xml(source, edk2path)
                     if xml is not None:
-                        classes.append(self.create_source_xml(source, edk2path))
+                        classes.append(xml)
 
         # Flaten the report to only source files, removing duplicates from INFs.
         if self.args.flatten:

--- a/edk2toolext/environment/reporttypes/coverage_report.py
+++ b/edk2toolext/environment/reporttypes/coverage_report.py
@@ -333,7 +333,7 @@ class CoverageReport(Report):
     def create_source_xml(self, source_path: str, edk2path: Edk2Path) -> Optional[ET.Element]:
         """Parses the source file and creates a coverage 'lines' xml element for it."""
         from pygount import SourceAnalysis
-        full_path = edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(source_path)
+        full_path = edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(source_path, log_errors=False)
         if full_path is None:
             logging.warning(f"Could not find {source_path} in the workspace. Skipping...")
             return None

--- a/edk2toolext/environment/reporttypes/coverage_report.py
+++ b/edk2toolext/environment/reporttypes/coverage_report.py
@@ -300,7 +300,9 @@ class CoverageReport(Report):
                 if match is not None:
                     classes.append(source_coverage_dict[match])
                 elif self.args.full:
-                    classes.append(self.create_source_xml(source, edk2path))
+                    xml = self.create_source_xml(source, edk2path)
+                    if xml is not None:
+                        classes.append(self.create_source_xml(source, edk2path))
 
         # Flaten the report to only source files, removing duplicates from INFs.
         if self.args.flatten:
@@ -328,15 +330,14 @@ class CoverageReport(Report):
                 temporary_list.append(pattern)
         self.args.exclude = temporary_list
 
-    def create_source_xml(self, source_path: str, edk2path: Edk2Path) -> ET:
+    def create_source_xml(self, source_path: str, edk2path: Edk2Path) -> Optional[ET.Element]:
         """Parses the source file and creates a coverage 'lines' xml element for it."""
         from pygount import SourceAnalysis
         full_path = edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(source_path)
         if full_path is None:
             logging.warning(f"Could not find {source_path} in the workspace. Skipping...")
-            code_count = 0
-        else:
-            code_count = SourceAnalysis.from_file(full_path, "_").code_count
+            return None
+        code_count = SourceAnalysis.from_file(full_path, "_").code_count
         file_xml = ET.Element("class", name="\\".join(Path(source_path).parts), filename=source_path)
         lines_xml = ET.Element("lines")
 

--- a/edk2toolext/environment/reporttypes/coverage_report.py
+++ b/edk2toolext/environment/reporttypes/coverage_report.py
@@ -332,7 +332,11 @@ class CoverageReport(Report):
         """Parses the source file and creates a coverage 'lines' xml element for it."""
         from pygount import SourceAnalysis
         full_path = edk2path.GetAbsolutePathOnThisSystemFromEdk2RelativePath(source_path)
-        code_count = SourceAnalysis.from_file(full_path, "_").code_count
+        if full_path is None:
+            logging.warning(f"Could not find {source_path} in the workspace. Skipping...")
+            code_count = 0
+        else:
+            code_count = SourceAnalysis.from_file(full_path, "_").code_count
         file_xml = ET.Element("class", name="\\".join(Path(source_path).parts), filename=source_path)
         lines_xml = ET.Element("lines")
 

--- a/tests.unit/test_repo_resolver.py
+++ b/tests.unit/test_repo_resolver.py
@@ -8,13 +8,13 @@
 ##
 import logging
 import os
+import pathlib
+import tempfile
 import unittest
+
+import pytest
 from edk2toolext.environment import repo_resolver
 from edk2toollib.utility_functions import RemoveTree
-import tempfile
-import pathlib
-import pytest
-
 
 branch_dependency = {
     "Url": "https://github.com/microsoft/mu",
@@ -326,7 +326,7 @@ class test_repo_resolver(unittest.TestCase):
                 self.recursive = recursive
 
         temp_folder = tempfile.mkdtemp()
-        submodule_path = "Common/MU_TIANO"
+        submodule_path = "Common/MU"
         deps = {"Url": "https://github.com/microsoft/mu_tiano_platforms"}
         repo_resolver.clone_repo(temp_folder, deps)
 


### PR DESCRIPTION
Check if the file exists in the workspace before passing to pygount for source code analysis. If it does not exist, skip the file.