### PR TITLE
Update how importlib is imported 

### DIFF
--- a/edk2toolext/environment/plugin_manager.py
+++ b/edk2toolext/environment/plugin_manager.py
@@ -7,11 +7,11 @@
 ##
 """This module contains code that supports Build Plugins."""
 
+import importlib.util
 import logging
 import os
 import sys
 import warnings
-from importlib import util
 
 from edk2toolext.environment import shell_environment
 
@@ -97,9 +97,9 @@ class PluginManager(object):
         logging.debug("Loading Plugin from %s", py_module_path)
 
         try:
-            spec = util.spec_from_file_location(
+            spec = importlib.util.spec_from_file_location(
                 py_module_name, py_module_path)
-            module = util.module_from_spec(spec)
+            module = importlib.util.module_from_spec(spec)
             sys.modules[py_module_name] = module
 
             py_module_dir = os.path.dirname(py_module_path)

--- a/edk2toolext/environment/plugin_manager.py
+++ b/edk2toolext/environment/plugin_manager.py
@@ -7,11 +7,11 @@
 ##
 """This module contains code that supports Build Plugins."""
 
-import importlib
 import logging
 import os
 import sys
 import warnings
+from importlib import util
 
 from edk2toolext.environment import shell_environment
 
@@ -97,9 +97,9 @@ class PluginManager(object):
         logging.debug("Loading Plugin from %s", py_module_path)
 
         try:
-            spec = importlib.util.spec_from_file_location(
+            spec = util.spec_from_file_location(
                 py_module_name, py_module_path)
-            module = importlib.util.module_from_spec(spec)
+            module = util.module_from_spec(spec)
             sys.modules[py_module_name] = module
 
             py_module_dir = os.path.dirname(py_module_path)


### PR DESCRIPTION
edk2-pytool-library is failing to update on edk2 due to an importlib issue on edk2-pytool-extensions (see: https://github.com/tianocore/edk2/actions/runs/9368163753/job/25789491929?pr=5722). From a google search, the issue is that we should be importing as `import importlib.util` not `import importlib`: https://stackoverflow.com/questions/66797668/module-importlib-has-no-attribute-util