### PR TITLE
Fix parameter handling in repo_resolver and update logging configuration.

### DIFF
--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -282,7 +282,7 @@ def scan_compiler_output(output_stream: TextIO) -> list[tuple]:
 
 class Edk2LogFilter(logging.Filter):
     """Subclass of logging.Filter."""
-    _allowedLoggers = ["root", "git.cmd"]
+    _allowedLoggers = ["root", "git.cmd", "edk2toolext.environment.repo_resolver"]
 
     def __init__(self) -> None:
         """Inits a filter."""

--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -282,7 +282,7 @@ def scan_compiler_output(output_stream: TextIO) -> list[tuple]:
 
 class Edk2LogFilter(logging.Filter):
     """Subclass of logging.Filter."""
-    _allowedLoggers = ["root"]
+    _allowedLoggers = ["root", "git.cmd"]
 
     def __init__(self) -> None:
         """Inits a filter."""

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -422,8 +422,11 @@ def checkout(
                 except GitCommandError:
                     # try to fetch it and try to checkout again
                     logger.info("We failed to checkout this branch, we'll try to fetch")
-                    repo.git.fetch(branch=branch)
-                    repo.git.checkout(branch=branch)
+                    # since the repo may have been cloned with --single-branch, add a refspec for the target branch.
+                    refspec = "refs/heads/{0}:refs/remotes/origin/{0}".format(branch)
+                    repo.remotes.origin.config_writer.set_value("fetch", refspec).release()
+                    repo.git.fetch()
+                    repo.git.checkout(branch)
                 repo.git.submodule("update", "--init", "--recursive")
             else:
                 if details["Branch"] == dep["Branch"]:

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -322,7 +322,7 @@ def clone_repo(abs_file_system_path: os.PathLike, DepObj: dict) -> tuple:
         shallow = True
         branch = DepObj["Branch"]
     if "ReferencePath" in DepObj and os.path.exists(DepObj["ReferencePath"]):
-        reference = os.path.abspath(DepObj["ReferencePath"])
+        reference = Path(DepObj["ReferencePath"])
 
     # Used to generate clone params from flags
     def _build_params_list(branch: str=None, shallow: str=None, reference: str=None) -> None:
@@ -336,9 +336,10 @@ def clone_repo(abs_file_system_path: os.PathLike, DepObj: dict) -> tuple:
             params.append('--depth=5')
         if reference:
             params.append('--reference')
-            params.append('reference')
+            params.append(reference.as_posix())
         else:
             params.append("--recurse-submodules")  # if we don't have a reference we can just recurse the submodules
+        return params
 
     # Run the command
     try:


### PR DESCRIPTION
* Fix an issue with parameter handling in repo_resolver that prevented "branch", "shallow", and "reference" parameters from being passed to git clone operations.
* Updated logging configuration to allow better tracing of repo_resolver operations for future debugging of similar issues. 