### PR TITLE
ci_build: Add fail-fast option

### DIFF
--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -262,7 +262,7 @@ class Edk2CiBuild(Edk2MultiPkgAwareInvocable):
                                 logging.error('Exiting Early due to --fail-fast flag.')
                                 JunitReport.Output(os.path.join(self.GetWorkspaceRoot(), "Build", "TestSuites.xml"))
                                 return failure_num
-                        elif (rc < 0):
+                        elif rc < 0:
                             logging.warn(f"--->Test Skipped: in plugin! {Descriptor.Name} {target}")
                         else:
                             edk2_logging.log_progress(f"--->Test Success: {Descriptor.Name} {target}")

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -255,12 +255,9 @@ class Edk2CiBuild(Edk2MultiPkgAwareInvocable):
 
                         if rc is None or rc > 0:
                             failure_num += 1
-                            if rc is None:
-                                logging.error(
-                                    f"--->Test Failed: {Descriptor.Name} {target} returned NoneType")
-                            else:
-                                logging.error(
-                                    f"--->Test Failed: {Descriptor.Name} {target} returned {rc}")
+                            logging.error(
+                                f"--->Test Failed: {Descriptor.Name} {target} returned \"{rc}\"")
+
                             if self.fail_fast:
                                 logging.error('Exiting Early due to --fail-fast flag.')
                                 JunitReport.Output(os.path.join(self.GetWorkspaceRoot(), "Build", "TestSuites.xml"))


### PR DESCRIPTION
Adds a new command line argument, `-f`, `--fail-fast` to stuart_ci_build that will cause the script to exit immediately if any ci plugin fails.

`stuart_ci_build -c .\.pytool\CISettings.py -p MdeModulePkg --disable-all  NestedPackageCheck=run `
<img width="540" alt="image" src="https://github.com/tianocore/edk2-pytool-extensions/assets/24388509/70fb338c-c771-49fd-b488-6e54b64bf568">

` stuart_ci_build -c .\.pytool\CISettings.py -p MdeModulePkg --disable-all  NestedPackageCheck=run --fail-fast`
<img width="539" alt="image" src="https://github.com/tianocore/edk2-pytool-extensions/assets/24388509/6ce37078-1b90-44e8-9425-6a4885c163c1">

