### PR TITLE
nuget_dependency: Allow path override

### DIFF
--- a/.github/workflows/VariableProducer.yml
+++ b/.github/workflows/VariableProducer.yml
@@ -14,7 +14,7 @@ on:
         value: ${{ jobs.produce.outputs.node-versions }}
 
 env:
-  pythonversions: "['3.12', '3.11', '3.10']" # Keep Python Versions in descending order
+  pythonversions: "['3.12.4', '3.11', '3.10']" # Keep Python Versions in descending order
   nodeversions: "['19']"
 
 jobs:

--- a/edk2toolext/environment/extdeptypes/nuget_dependency.py
+++ b/edk2toolext/environment/extdeptypes/nuget_dependency.py
@@ -38,6 +38,7 @@ class NugetDependency(ExternalDependency):
     def __init__(self, descriptor: dict) -> None:
         """Inits a nuget dependency based off the provided descriptor."""
         super().__init__(descriptor)
+        self.package = descriptor.get("package", self.name)
         self.nuget_cache_path = None
 
     @classmethod
@@ -187,7 +188,7 @@ class NugetDependency(ExternalDependency):
         try:
             nuget_version = NugetDependency.normalize_version(self.version)
         except ValueError:
-            logging.error(f"NuGet dependency {self.name} has an invalid "
+            logging.error(f"NuGet dependency {self.package} has an invalid "
                           f"version string: {self.version}")
 
         cache_search_path = os.path.join(
@@ -210,15 +211,15 @@ class NugetDependency(ExternalDependency):
 
     def __str__(self) -> str:
         """Return a string representation."""
-        return f"NugetDependecy: {self.name}@{self.version}"
+        return f"NugetDependecy: {self.package}@{self.version}"
 
     def _attempt_nuget_install(self, install_dir: str, non_interactive: Optional[bool]=True) -> None:
         #
         # fetch the contents of the package.
         #
-        package_name = self.name
+        package_name = self.package
         cmd = NugetDependency.GetNugetCmd()
-        cmd += ["install", self.name]
+        cmd += ["install", package_name]
         cmd += ["-Source", self.source]
         cmd += ["-ExcludeVersion"]
         if non_interactive:
@@ -260,7 +261,7 @@ class NugetDependency(ExternalDependency):
 
     def fetch(self) -> None:
         """Fetches the dependency using internal state from the init."""
-        package_name = self.name
+        package_name = self.package
 
         # First, check the global cache to see if it's present.
         if super().fetch():


### PR DESCRIPTION
As described in [external_dependency.py#L38](https://github.com/tianocore/edk2-pytool-extensions/blob/1e4ddee16145c262b96c67bd442124563400d8d6/edk2toolext/environment/external_dependency.py#L38), the `name` configuration is the name of the ext_dep, used to name the folder the ext_dep will be unpacked into. When the nuget external dependency was added, `name` also became the name of the package you are downloading, which tightly couples the name of the package and the folder path. This means there is no way to name the folder something other than the package name, which can be necessary in some situations.

This change provides a backwards compatible way to de-couple the package name from the folder name by introducing a new, optional config for nuget dependencies, `package`. `package` will be used as the package name to download while `name` will continue to be the name of the ext dep and the folder it is downloaded to. For backwards compatability, if `package` is not used in the configuration file, `name` will be used instead.