### PR TITLE
image_validation: Update documentation

### DIFF
--- a/docs/user/tools/using_image_validation_tool.md
+++ b/docs/user/tools/using_image_validation_tool.md
@@ -7,7 +7,7 @@ set, and clear the NX_COMPAT flag found in OPTIONAL_HEADER.DllCharacteristics.
 
 ## Synopsis
 
-image_validation.py [-h] -i FILE [-d] [-p PROFILE] [--set-nx-compat | --clear-nx-compat | --get-nx-compat]
+`image_validation.py [-h] -i FILE [-d] [-p PROFILE] [--set-nx-compat | --clear-nx-compat | --get-nx-compat]`
 
 ## Options
 


### PR DESCRIPTION
Updates the documentation in using_image_validation_tool.md to fix the current breakage in the documentation that is causing CI to fail.