### PR TITLE
Python support: drop 3.10, add 3.13

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,9 +29,9 @@ body:
       description: "Note: Bug fixes are only supported on these Python versions."
       multiple: true
       options:
-        - Python 3.10
         - Python 3.11
         - Python 3.12
+        - Python 3.13
     validations:
       required: true
   - type: textarea
@@ -57,7 +57,7 @@ body:
     id: env
     attributes:
       label: Execution Environment
-      description: "List the OS, python micro version (e.g. 3.10.8), system environment variables, etc."
+      description: "List the OS, python micro version (e.g. 3.11), system environment variables, etc."
     validations:
       required: false
   - type: textarea

--- a/.github/workflows/VariableProducer.yml
+++ b/.github/workflows/VariableProducer.yml
@@ -14,7 +14,7 @@ on:
         value: ${{ jobs.produce.outputs.node-versions }}
 
 env:
-  pythonversions: "['3.12.4', '3.11', '3.10']" # Keep Python Versions in descending order
+  pythonversions: "['3.13', '3.12', '3.11']" # Keep Python Versions in descending order
   nodeversions: "['19']"
 
 jobs:

--- a/docs/contributor/developing.md
+++ b/docs/contributor/developing.md
@@ -7,7 +7,7 @@ out all the different parts.
 
 ## Pre-Requisites
 
-* Make sure you have python 3.10.x or newer available on path
+* Make sure you have python 3.11.x or newer available on path
 * Make sure you have git installed and available on path
 
 1. Get the code

--- a/docs/contributor/python_release.md
+++ b/docs/contributor/python_release.md
@@ -2,7 +2,7 @@
 
 This document provides information on the necessary steps to update the
 edk2-pytool-extensions repository when a new minor version of python has been
-release (3.9, 3.10, etc).
+release (3.12, 3.13, etc).
 
 ## Steps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 description = "Python tools supporting UEFI EDK2 firmware development"
 readme = {file = "readme.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "edk2-pytool-library>=0.20.0",
     "pyyaml>=6.0.0",
@@ -28,9 +28,9 @@ classifiers = [
     "Operating System :: OS Independent",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12"
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13"
 ]
 
 [project.urls]

--- a/readme.md
+++ b/readme.md
@@ -44,13 +44,13 @@ coverage of those unit tests. We require 100% unit test success
 | Windows Server 2019 | Python 3.11 | Edk2       | [![ewt1]][_it]
 | Windows Server 2019 | Python 3.12 | Edk2       | [![ewt2]][_it]
 | Windows Server 2019 | Python 3.13 | Edk2       | [![ewt3]][_it]
-| Linux Ubuntu 20.04  | Python 3.11 | Edk2       | [![eut1]][_i359]
+| Linux Ubuntu 20.04  | Python 3.11 | Edk2       | [![eut1]][_it]
 | Linux Ubuntu 20.04  | Python 3.12 | Edk2       | [![eut2]][_it]
 | Linux Ubuntu 20.04  | Python 3.13 | Edk2       | [![eut3]][_it]
 | Windows Server 2022 | Python 3.11 | Project Mu | [![mwt1]][_it]
 | Windows Server 2022 | Python 3.12 | Project Mu | [![mwt2]][_it]
 | Windows Server 2022 | Python 3.13 | Project Mu | [![mwt3]][_it]
-| Linux Ubuntu 22.04  | Python 3.11 | Project Mu | [![mut1]][_i359]
+| Linux Ubuntu 22.04  | Python 3.11 | Project Mu | [![mut1]][_it]
 | Linux Ubuntu 22.04  | Python 3.12 | Project Mu | [![mut2]][_it]
 | Linux Ubuntu 22.04  | Python 3.13 | Project Mu | [![mut3]][_it]
 
@@ -174,7 +174,6 @@ contributing to the edk2-pytool-extensions repository.
 [_ci]: https://github.com/tianocore/edk2-pytool-extensions/actions/workflows/run-ci.yml
 
 [_it]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_build?definitionId=52&_a=summary&repositoryFilter=2&branchFilter=14
-[_i359]: https://github.com/tianocore/edk2-pytool-extensions/issues/359
 [ewt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python311
 [ewt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python312
 [ewt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python313

--- a/readme.md
+++ b/readme.md
@@ -41,18 +41,18 @@ coverage of those unit tests. We require 100% unit test success
 
 | Host Type           | Toolchain   | Project    | Integration Tests
 | :------------------ | :---------  | :--------- | :----------------
-| Windows Server 2019 | Python 3.10 | Edk2       | [![ewt1]][_it]
-| Windows Server 2019 | Python 3.11 | Edk2       | [![ewt2]][_it]
-| Windows Server 2019 | Python 3.12 | Edk2       | [![ewt3]][_it]
-| Linux Ubuntu 20.04  | Python 3.10 | Edk2       | [![eut1]][_i359]
-| Linux Ubuntu 20.04  | Python 3.11 | Edk2       | [![eut2]][_it]
-| Linux Ubuntu 20.04  | Python 3.12 | Edk2       | [![eut3]][_it]
-| Windows Server 2022 | Python 3.10 | Project Mu | [![mwt1]][_it]
-| Windows Server 2022 | Python 3.11 | Project Mu | [![mwt2]][_it]
-| Windows Server 2022 | Python 3.12 | Project Mu | [![mwt3]][_it]
-| Linux Ubuntu 22.04  | Python 3.10 | Project Mu | [![mut1]][_i359]
-| Linux Ubuntu 22.04  | Python 3.11 | Project Mu | [![mut2]][_it]
-| Linux Ubuntu 22.04  | Python 3.12 | Project Mu | [![mut3]][_it]
+| Windows Server 2019 | Python 3.11 | Edk2       | [![ewt1]][_it]
+| Windows Server 2019 | Python 3.12 | Edk2       | [![ewt2]][_it]
+| Windows Server 2019 | Python 3.13 | Edk2       | [![ewt3]][_it]
+| Linux Ubuntu 20.04  | Python 3.11 | Edk2       | [![eut1]][_i359]
+| Linux Ubuntu 20.04  | Python 3.12 | Edk2       | [![eut2]][_it]
+| Linux Ubuntu 20.04  | Python 3.13 | Edk2       | [![eut3]][_it]
+| Windows Server 2022 | Python 3.11 | Project Mu | [![mwt1]][_it]
+| Windows Server 2022 | Python 3.12 | Project Mu | [![mwt2]][_it]
+| Windows Server 2022 | Python 3.13 | Project Mu | [![mwt3]][_it]
+| Linux Ubuntu 22.04  | Python 3.11 | Project Mu | [![mut1]][_i359]
+| Linux Ubuntu 22.04  | Python 3.12 | Project Mu | [![mut2]][_it]
+| Linux Ubuntu 22.04  | Python 3.13 | Project Mu | [![mut3]][_it]
 
 ### Current Release
 
@@ -175,18 +175,18 @@ contributing to the edk2-pytool-extensions repository.
 
 [_it]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_build?definitionId=52&_a=summary&repositoryFilter=2&branchFilter=14
 [_i359]: https://github.com/tianocore/edk2-pytool-extensions/issues/359
-[ewt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python310
-[ewt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python311
-[ewt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python312
+[ewt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python311
+[ewt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python312
+[ewt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python313
 
-[eut1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python310
-[eut2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python311
-[eut3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python312
+[eut1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python311
+[eut2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python312
+[eut3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python313
 
-[mwt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python310
-[mwt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python311
-[mwt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python312
+[mwt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python311
+[mwt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python312
+[mwt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python313
 
-[mut1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python310
-[mut2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python311
-[mut3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python312
+[mut1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python311
+[mut2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python312
+[mut3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python313

--- a/tests.integration/azure-pipelines/windows-robot-integration-test.yml
+++ b/tests.integration/azure-pipelines/windows-robot-integration-test.yml
@@ -10,7 +10,7 @@
 parameters:
 - name: PythonVersionList
   type: object
-  default: ['3.10', '3.11', '3.12']
+  default: ['3.11', '3.12', '3.13']
 
 jobs:
 - job:


### PR DESCRIPTION
## Breaking Change

This commit removes support for python 3.10. Attempting to install v0.28.0 of edk2-pytool-extensions using a python version less than 3.11 will result in an error from pip along the lines of `ERROR: Could not find a version that satisfies the requirement ...`

## Integration Instructions

If your platform cannot upgrade to 3.11 or above, continue using a version of edk2-python-extensions less than v0.28.0. Otherwise upgrade your version of platform to 3.11 or greater. If edk2-pytool-library is not automatically downloaded with edk2-pytool-extensions, then you also need to ensure that edk2-pytool-library is v0.22.0 or greater