### PR TITLE
Install mono on ubuntu-latest

### DIFF
--- a/.github/workflows/UnitTestRunner.yml
+++ b/.github/workflows/UnitTestRunner.yml
@@ -37,6 +37,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade -e .[dev]
     
+    - name: Install mono
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y mono-devel
+    
     - name: Run Unit Tests
       run: coverage run -m pytest
 


### PR DESCRIPTION
ubuntu-latest, now ubuntu-24.04 no longer has mono installed in the runner image.

This commit updates the UnitTestRunner.yml to install mono before running the tests.