### PR TITLE
rust.py: Use cargo-binstall

### DIFF
--- a/edk2toolext/environment/rust.py
+++ b/edk2toolext/environment/rust.py
@@ -358,9 +358,8 @@ def run(
             install_help=(
                 "  cargo binstall cargo-make "
                 f"{('--version ' + tool_ver.get('cargo-make', '')) if 'cargo-make' in tool_ver else ''}"
-                "\nOR\n"
-                "  cargo install cargo-make "
-                f"{('--version ' + tool_ver.get('cargo-make', '')) if 'cargo-make' in tool_ver else ''}\n"
+                "\n\n"
+                "  Need to install cargo-binstall? Visit: https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file#installation\n"
             ),
             required_version=tool_ver.get("cargo-make"),
             regex=r"\d+\.\d+\.\d+",
@@ -370,9 +369,8 @@ def run(
             install_help=(
                 "  cargo binstall cargo-tarpaulin "
                 f"{('--version ' + tool_ver.get('cargo-tarpaulin', '')) if 'cargo-tarpaulin' in tool_ver else ''}"
-                "\nOR\n"
-                "  cargo install cargo-tarpaulin "
-                f"{('--version ' + tool_ver.get('cargo-tarpaulin', '')) if 'cargo-tarpaulin' in tool_ver else ''}\n"
+                "\n\n"
+                "  Need to install cargo-binstall? Visit: https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file#installation\n"
             ),
             required_version=tool_ver.get("cargo-tarpaulin"),
             regex=r"\d+\.\d+\.\d+",


### PR DESCRIPTION
There have been too many instances of issues manually installing cargo-make. These issues occur because cargo-make does not upload a Cargo.lock file for releases, and our rust repositories always being on an old rust version. This results in the latest versions of some crates being pulled in, which may have their minimum supported version of rust higher than the version we use.

To improve the user experience, lets just have the user install the binaries instead of attempting to compile.