### PR TITLE
Allow [tool] or [tools] section in Rust Env Checker

### DIFF
--- a/edk2toolext/environment/rust.py
+++ b/edk2toolext/environment/rust.py
@@ -159,7 +159,7 @@ def _get_required_tool_versions() -> Dict[str, str]:
     try:
         with open(WORKSPACE_TOOLCHAIN_FILE, "r") as toml_file:
             content = toml_file.read()
-            match = re.search(r"\[tool\]\n((?:.+\s*=\s*.+\n?)*)", content)
+            match = re.search(r"\[tool(?:s)?\]\n((?:.+\s*=\s*.+\n?)*)", content)
             if match:
                 for line in match.group(1).splitlines():
                     (tool, version) = line.split("=", maxsplit=1)

--- a/tests.unit/test_rust_environment.py
+++ b/tests.unit/test_rust_environment.py
@@ -312,18 +312,18 @@ class RustEnvironmentTests(unittest.TestCase):
         self.assertTrue(result)
 
     def test_get_required_tool_versions(self):
-        # Test when the workspace toolchain file exists and contains valid tool versions
-        with patch(
-            "builtins.open",
-            mock_open(
-                read_data='[toolchain]\nchannel = "1.76.0"\n\n[tool]\ncargo-make = "0.37.9"\ncargo-tarpaulin = "0.27.3"'
-            ),
-        ):
-            tool_versions = _get_required_tool_versions()
-            assert tool_versions == {
-                "cargo-make": "0.37.9",
-                "cargo-tarpaulin": "0.27.3",
-            }
+        test_data = [
+            '[toolchain]\nchannel = "1.76.0"\n\n[tool]\ncargo-make = "0.37.9"\ncargo-tarpaulin = "0.27.3"',
+            '[toolchain]\nchannel = "1.76.0"\n\n[tools]\ncargo-make = "0.37.9"\ncargo-tarpaulin = "0.27.3"',
+        ]
+
+        for data in test_data:
+            with patch("builtins.open", mock_open(read_data=data)):
+                tool_versions = _get_required_tool_versions()
+                assert tool_versions == {
+                    "cargo-make": "0.37.9",
+                    "cargo-tarpaulin": "0.27.3",
+                }
 
         # Test when the workspace toolchain file does not exist
         with patch("builtins.open", side_effect=FileNotFoundError):


### PR DESCRIPTION
Currently, the plugin supports locating tools in a `[tool]` section. Other scripts and flows have been built around `[tools]`. This change finds tools from either section.