### PR TITLE
az_cli_universal_dependency: Enhance error messaging

### DIFF
--- a/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
+++ b/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
@@ -84,7 +84,10 @@ class AzureCliUniversalDependency(ExternalDependency):
 
         # 2 - Check for azure-devops extension
         if "azure-devops" not in found.keys():
-            logging.critical("Missing required Azure-cli extension azure-devops")
+            logging.critical(
+                "Missing required Azure-cli extension azure-devops.\n"
+                "Installation instructions: https://learn.microsoft.com/azure/devops/cli"
+            )
             raise EnvironmentError("Missing required Azure-cli extension azure-devops")
 
         cls.VersionLogged = True
@@ -141,7 +144,11 @@ class AzureCliUniversalDependency(ExternalDependency):
             e[self.AZURE_CLI_DEVOPS_ENV_VAR] = self._pat
 
         results = StringIO()
-        RunCmd(cmd[0], " ".join(cmd[1:]), outstream=results, environ=e, raise_exception_on_nonzero=True)
+        ret = RunCmd(cmd[0], " ".join(cmd[1:]), outstream=results, environ=e)
+        if ret != 0:
+            results.seek(0)
+            raise Exception(f"\nCommand \"{' '.join(cmd)}\" failed with {ret}.\n\n" f"{results.getvalue()}")
+
         # az tool returns json data that includes the downloaded version
         # lets check it to double confirm
         result_data = json.loads(results.getvalue())


### PR DESCRIPTION
1. If the `azure-devops` extension is not installed, provide a URL with installation instructions. This link can directly be clicked in many shell environments.
2. If an error occurs running the Azure CLI then show the error message to the user. This often has helpful instructions for what needs to be done to resolve the error. Example shown below.

Before:

```
    raise Exception("{0} failed with Return Code: {1}".format(cmd, returncode_str))
	Exception: az artifacts universal download --organization https://dev.azure.com/Organization/
	  --feed FEED --name NAME --version 0.0.1 --path "PATH" failed with Return Code: 0x00000001
```

After:

```
    raise Exception(
      Exception:
        Command "az artifacts universal download --organization https://dev.azure.com/Organization/
	      --feed FEED --name NAME --version 0.0.1 --path "PATH"" failed with 1.

      ERROR: Failed to update Universal Packages tooling.
        Before you can run Azure DevOps commands, you need to run the login command(az login if using
		AAD/MSA identity else az devops login if using PAT token) to setup credentials.
		Please see https://aka.ms/azure-devops-cli-auth for more information.
```