### PR TITLE
az_cli_universal_dependency.py: Manage results output for non-Json data

### DIFF
--- a/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
+++ b/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
@@ -147,7 +147,7 @@ class AzureCliUniversalDependency(ExternalDependency):
         ret = RunCmd(cmd[0], " ".join(cmd[1:]), outstream=results, environ=e)
         if ret != 0:
             results.seek(0)
-            raise Exception(f"\nCommand \"{' '.join(cmd)}\" failed with {ret}.\n\n" f"{results.getvalue()}")
+            raise Exception(f'\nCommand "{" ".join(cmd)}" failed with {ret}.\n\n{results.getvalue()}')
 
         # az tool returns json data that includes the downloaded version
         # lets check it to double confirm
@@ -155,11 +155,11 @@ class AzureCliUniversalDependency(ExternalDependency):
             result_data = json.loads(results.getvalue())
         except Exception as e:
             logging.info("Failed to parse json data from az command output: %s", e)
-        
+
             # Search results to find the json data
             index_start = results.getvalue().find("{")
             index_end = results.getvalue().rfind("}")
-            
+
             if index_start == -1 or index_end == -1:
                 raise Exception("Failed to find valid json data in az command output")
             results.seek(index_start)

--- a/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
+++ b/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
@@ -154,14 +154,14 @@ class AzureCliUniversalDependency(ExternalDependency):
         try:
             result_data = json.loads(results.getvalue())
         except Exception as e:
-            logging.info("Failed to parse json data from az command output: %s", e)
+            logging.error(f"Failed to parse json data from az command output: {e}")
 
             # Search results to find the json data
             index_start = results.getvalue().find("{")
             index_end = results.getvalue().rfind("}")
 
             if index_start == -1 or index_end == -1:
-                raise Exception("Failed to find valid json data in az command output")
+                raise ValueError("Failed to find valid json data in az command output")
             results.seek(index_start)
             result_data = json.loads(results.read(index_end - index_start + 1))
 

--- a/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
+++ b/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
@@ -158,12 +158,12 @@ class AzureCliUniversalDependency(ExternalDependency):
         
             # Search results to find the json data
             index_start = results.getvalue().find("{")
-            index_end = results.getvalue().rfind("}") + 1
+            index_end = results.getvalue().rfind("}")
             
             if index_start == -1 or index_end == -1:
                 raise Exception("Failed to find valid json data in az command output")
             results.seek(index_start)
-            result_data = json.loads(results.read(index_end - index_start))
+            result_data = json.loads(results.read(index_end - index_start + 1))
 
         results.close()
         downloaded_version = result_data["Version"]

--- a/tests.unit/test_az_cli_universal_dependency.py
+++ b/tests.unit/test_az_cli_universal_dependency.py
@@ -260,22 +260,22 @@ class TestAzCliUniversalDependency(unittest.TestCase):
         self.assertFalse(ext_dep.verify())
 
     # good case
-    @patch(
-        "edk2toolext.environment.extdeptypes.az_cli_universal_dependency.RunCmd",
-        return_value=0,
-        outstream=StringIO('Test extra prints\n{"Version": "0.0.1"}'),
-    )
-    def test_download_bad_results(self, mock_run_cmd: MagicMock):
-        version = "0.0.1"
-        ext_dep_file_path = os.path.join(test_dir, "unit_test_ext_dep.json")
-        with open(ext_dep_file_path, "w+") as ext_dep_file:
-            ext_dep_file.write(single_file_json_template % version)
+    # @patch(
+    #     "edk2toolext.environment.extdeptypes.az_cli_universal_dependency.RunCmd",
+    #     return_value=0,
+    #     outstream=StringIO('Test extra prints\n{"Version": "0.0.1"}'),
+    # )
+    # def test_download_bad_results(self, mock_run_cmd: MagicMock):
+    #     version = "0.0.1"
+    #     ext_dep_file_path = os.path.join(test_dir, "unit_test_ext_dep.json")
+    #     with open(ext_dep_file_path, "w+") as ext_dep_file:
+    #         ext_dep_file.write(single_file_json_template % version)
 
-        ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
-        ext_dep = AzureCliUniversalDependency(ext_dep_descriptor)
-        ext_dep.fetch()
-        self.assertTrue(ext_dep.verify())
-        self.assertEqual(ext_dep.version, version)
+    #     ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
+    #     ext_dep = AzureCliUniversalDependency(ext_dep_descriptor)
+    #     ext_dep.fetch()
+    #     self.assertTrue(ext_dep.verify())
+    #     self.assertEqual(ext_dep.version, version)
 
     # bad case
     @patch(

--- a/tests.unit/test_az_cli_universal_dependency.py
+++ b/tests.unit/test_az_cli_universal_dependency.py
@@ -121,9 +121,6 @@ def clean_workspace():
 class MockRunCmd(MagicMock):
     out_string = ""
 
-    def __init__() -> None:
-        super().__init__()
-
     @staticmethod
     def mock_RunCmd_outstream(
         cmd: str,

--- a/tests.unit/test_az_cli_universal_dependency.py
+++ b/tests.unit/test_az_cli_universal_dependency.py
@@ -117,12 +117,13 @@ def clean_workspace():
         RemoveTree(test_dir)
         test_dir = None
 
+
 class MockRunCmd(MagicMock):
     out_string = ""
 
     def __init__() -> None:
         super().__init__()
-    
+
     @staticmethod
     def mock_RunCmd_outstream(
         cmd: str,
@@ -301,7 +302,7 @@ class TestAzCliUniversalDependency(unittest.TestCase):
     # bad case
     @patch("edk2toolext.environment.extdeptypes.az_cli_universal_dependency.RunCmd", MockRunCmd.mock_RunCmd_outstream)
     def test_download_bad_results_assert(self):
-        MockRunCmd.out_string = 'TEST! No json data here!'
+        MockRunCmd.out_string = "TEST! No json data here!"
 
         version = "0.0.1"
         ext_dep_file_path = os.path.join(test_dir, "unit_test_ext_dep.json")

--- a/tests.unit/test_az_cli_universal_dependency.py
+++ b/tests.unit/test_az_cli_universal_dependency.py
@@ -273,9 +273,9 @@ class TestAzCliUniversalDependency(unittest.TestCase):
 
         ext_dep_descriptor = EDF.ExternDepDescriptor(ext_dep_file_path).descriptor_contents
         ext_dep = AzureCliUniversalDependency(ext_dep_descriptor)
-        with self.assertRaises(Exception):
-            ext_dep.fetch()
-        self.assertFalse(ext_dep.verify())
+        ext_dep.fetch()
+        self.assertTrue(ext_dep.verify())
+        self.assertEqual(ext_dep.version, version)
 
     # bad case
     @patch(
@@ -283,7 +283,7 @@ class TestAzCliUniversalDependency(unittest.TestCase):
         return_value=0,
         outstream=StringIO("Test!"),
     )
-    def test_download_bad_results(self, mock_run_cmd: MagicMock):
+    def test_download_bad_results_assert(self, mock_run_cmd: MagicMock):
         version = "0.0.1"
         ext_dep_file_path = os.path.join(test_dir, "unit_test_ext_dep.json")
         with open(ext_dep_file_path, "w+") as ext_dep_file:

--- a/tests.unit/test_az_cli_universal_dependency.py
+++ b/tests.unit/test_az_cli_universal_dependency.py
@@ -305,7 +305,7 @@ class TestAzCliUniversalDependency(unittest.TestCase):
     )
     @patch("edk2toolext.environment.extdeptypes.az_cli_universal_dependency.RunCmd", MockRunCmd.mock_RunCmd_outstream)
     def test_download_bad_results(self):
-        #MockRunCmd.out_string = 'Properly handle this output!\n{"Version":"0.0.1"}'
+        MockRunCmd.out_string = 'Properly handle this output!\n{"Version":"0.0.1"}'
 
         version = "0.0.1"
         ext_dep_file_path = os.path.join(test_dir, "unit_test_ext_dep.json")

--- a/tests.unit/test_az_cli_universal_dependency.py
+++ b/tests.unit/test_az_cli_universal_dependency.py
@@ -21,7 +21,7 @@ import unittest
 from edk2toolext.environment import environment_descriptor_files as EDF
 from edk2toolext.environment import version_aggregator
 from edk2toolext.environment.extdeptypes.az_cli_universal_dependency import AzureCliUniversalDependency
-from edk2toollib.utility_functions import RemoveTree
+from edk2toollib.utility_functions import RemoveTree, RunCmd
 from unittest.mock import MagicMock, patch
 
 test_dir = None
@@ -139,8 +139,23 @@ class MockRunCmd(MagicMock):
         close_fds: bool = True,
     ) -> int:
         """Mock of RunCmd that allows testcases to simulate output in the outstream."""
+
+        ret = RunCmd(
+            cmd,
+            parameters,
+            capture=capture,
+            workingdir=workingdir,
+            outfile=outfile,
+            outstream=None,
+            environ=environ,
+            logging_level=logging_level,
+            raise_exception_on_nonzero=raise_exception_on_nonzero,
+            encodingErrors=encodingErrors,
+            close_fds=close_fds,
+        )
+
         outstream.write(MockRunCmd.out_string)
-        return 0
+        return ret
 
 
 class TestAzCliUniversalDependency(unittest.TestCase):
@@ -284,9 +299,13 @@ class TestAzCliUniversalDependency(unittest.TestCase):
         self.assertFalse(ext_dep.verify())
 
     # good case
+    @unittest.skipIf(
+        "PAT_FOR_UNIVERSAL_ORG_TIANOCORE" not in os.environ.keys(),
+        "PAT not defined therefore universal packages tests will fail",
+    )
     @patch("edk2toolext.environment.extdeptypes.az_cli_universal_dependency.RunCmd", MockRunCmd.mock_RunCmd_outstream)
     def test_download_bad_results(self):
-        MockRunCmd.out_string = 'Properly handle this output!\n{"Version":"0.0.1"}'
+        #MockRunCmd.out_string = 'Properly handle this output!\n{"Version":"0.0.1"}'
 
         version = "0.0.1"
         ext_dep_file_path = os.path.join(test_dir, "unit_test_ext_dep.json")
@@ -298,8 +317,14 @@ class TestAzCliUniversalDependency(unittest.TestCase):
         ext_dep.fetch()
         self.assertTrue(ext_dep.verify())
         self.assertEqual(ext_dep.version, version)
+        # make sure we clean up after ourselves
+        ext_dep.clean()
 
     # bad case
+    @unittest.skipIf(
+        "PAT_FOR_UNIVERSAL_ORG_TIANOCORE" not in os.environ.keys(),
+        "PAT not defined therefore universal packages tests will fail",
+    )
     @patch("edk2toolext.environment.extdeptypes.az_cli_universal_dependency.RunCmd", MockRunCmd.mock_RunCmd_outstream)
     def test_download_bad_results_assert(self):
         MockRunCmd.out_string = "TEST! No json data here!"


### PR DESCRIPTION
Search az cli universal package output for json data if the StreamIO has other output from the command. Sometimes the results output will have extra data from the az cli command. This needs to be ignored before attempting to load the results as json data.