### PR TITLE
az_cli_universal_dependency.py: Lower logging verbosity when az download command results contain non-Json data

### DIFF
--- a/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
+++ b/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
@@ -154,7 +154,7 @@ class AzureCliUniversalDependency(ExternalDependency):
         try:
             result_data = json.loads(results.getvalue())
         except Exception as e:
-            logging.error(f"Failed to parse json data from az command output: {e}")
+            logging.info(f"Failed to parse json data from az command output: {e}")
 
             # Search results to find the json data
             index_start = results.getvalue().find("{")


### PR DESCRIPTION
Minor update to reduce the verbosity of log when the results data contains non-Json information. This failure should be seen as non-critical. After attempting to parse the data and the results data is still bad, then a failure and error print is enforced.