### PR TITLE
project: Add a minimum supported version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -29,6 +29,7 @@ body:
       description: "Note: Bug fixes are only supported on these Python versions."
       multiple: true
       options:
+        - Python 3.10
         - Python 3.11
         - Python 3.12
         - Python 3.13

--- a/.github/workflows/VariableProducer.yml
+++ b/.github/workflows/VariableProducer.yml
@@ -12,8 +12,12 @@ on:
       node-versions: 
         description: 'Node Versions'
         value: ${{ jobs.produce.outputs.node-versions }}
+      python-msv:
+        description: 'Minimum Supported Python Version'
+        value: ${{ jobs.produce.outputs.python-msv }}
 
 env:
+  msv: "['3.10']"
   pythonversions: "['3.13', '3.12', '3.11']" # Keep Python Versions in descending order
   nodeversions: "['19']"
 
@@ -26,6 +30,7 @@ jobs:
     outputs:
       python-versions: ${{ steps.set-python-versions.outputs.VERSION }}
       node-versions: ${{ steps.set-node-versions.outputs.VERSION }}
+      python-msv: ${{ steps.set-python-msv.outputs.VERSION }}
 
     steps:
     - name: Produce Python Version
@@ -35,3 +40,7 @@ jobs:
     - name: Produce Node Version
       id: set-node-versions
       run: echo "VERSION=$nodeversions" >> $GITHUB_OUTPUT
+
+    - name: Produce Minimum Supported Python Version
+      id: set-python-msv
+      run: echo "VERSION=$msv" >> $GITHUB_OUTPUT

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -27,6 +27,13 @@ jobs:
       node-version: ${{ fromJson(needs.variables.outputs.node-versions)[0] }}
       package-src: edk2toolext
   
+  msv:
+    needs: [variables,ci]
+    name: MSV Validation
+    uses: ./.github/workflows/UnitTestRunner.yml
+    with:
+      python-versions: ${{ needs.variables.outputs.python-msv }}
+  
   unit-test:
     needs: [variables,ci]
     name: Unit Test

--- a/docs/contributor/python_msv.md
+++ b/docs/contributor/python_msv.md
@@ -1,0 +1,49 @@
+# Python Minimum Supported Version
+
+In addition to the N-2 versions of python being actively maintained and
+supported, this repository also has a minimum supported version (MSV) of
+python. Any version of python between the MSV and N-2 version of python is not
+actively maintained or monitored, however it is supported (e.g. the repository
+does not use any features past this version of python).
+
+The MSV for this project is subject to change at any time based on project
+needs and features introduced by python. At a minimum, this repository will
+never use a feature newer than N-2, providing a two year lookback period for
+consumers to increase their supported version of python while receiving new
+feature updates of this project.
+
+## Updating the MSV
+
+If the need arises to increase the minimum supported version of python, below
+are the necessary files and steps to update the repository.
+
+### pyproject.toml
+
+This file is responsible for the release process to pypi. We want to make sure
+we keep the required version for our pypi releases up to date. Update
+`requires-python` to the new msv.
+
+Additionally, we must update the classifiers section to remove the now
+unsupported versions of python.
+
+```python
+classifiers=[
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13"
+]
+```
+
+### bug_report.yml
+
+Remove the now unsupported version of python in the following
+section: `id: py_version`.
+
+### VariableProducer.yml
+
+Update `python-msv:` to the new msv
+
+### readme.md
+
+Update the `Toolchain` section of the `Minimum Supported Version` table.

--- a/docs/contributor/python_release.md
+++ b/docs/contributor/python_release.md
@@ -11,24 +11,15 @@ specific file that must be updated.
 
 ### pyproject.toml
 
-This file is responsible for the release process to pypi. We want to make sure
-we keep the required version for our pypi releases up to date. Update
-`requires-python` to the minimum required python.
-
-We typically support the last three minor versions; barring any special
-exceptions, if the newest minor version is 3.11, then overall, we will
-support 3.9, 3.10, and 3.11. Therefore you should update the line to
-`python-requires = ">=3.9.0"`.
-
-Additionally, we must update the classifiers section to show the three
-supported python versions:
+We must update the classifiers section to show the new supported python version:
 
 ```cmd
 classifiers=[
         ...
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11"
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14"
     ]
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dynamic = ["version"]
 description = "Python tools supporting UEFI EDK2 firmware development"
 readme = {file = "readme.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = [
     "edk2-pytool-library>=0.20.0",
     "pyyaml>=6.0.0",
@@ -28,6 +28,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13"

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,8 @@ The code coverage and CI badges represent unit test status and the code
 coverage of those unit tests. We require 100% unit test success
 (Hence the pass / fail) and that code coverage percentage does not lower.
 
+Maintained Versions
+
 | Host Type           | Toolchain   | Project    | Integration Tests
 | :------------------ | :---------  | :--------- | :----------------
 | Windows Server 2019 | Python 3.11 | Edk2       | [![ewt1]][_it]
@@ -53,6 +55,13 @@ coverage of those unit tests. We require 100% unit test success
 | Linux Ubuntu 22.04  | Python 3.11 | Project Mu | [![mut1]][_it]
 | Linux Ubuntu 22.04  | Python 3.12 | Project Mu | [![mut2]][_it]
 | Linux Ubuntu 22.04  | Python 3.13 | Project Mu | [![mut3]][_it]
+
+Minimum Supported Version
+
+|  Host Type         |  Toolchain    |  Status
+|  :---------------  |  :----------  |  :-----------
+|  [Windows-Latest]  |  Python 3.10  |  [![ci]][_ci]
+|  [Ubuntu-Latest]   |  Python 3.10  |  [![ci]][_ci]
 
 ### Current Release
 


### PR DESCRIPTION
Adds the concept of a minimum supported version (MSV) to the project. The project will continue to always maintain and support N-2 versions of Python, however the MSV will be the oldest version of python that can run the project (i.e. the project does not use any features that are newer than the MSV). This value is subject to change at any time due to the needs of the project.