### PR TITLE
Add high-level performance data

### DIFF
--- a/edk2toolext/base_abstract_invocable.py
+++ b/edk2toolext/base_abstract_invocable.py
@@ -216,7 +216,7 @@ class BaseAbstractInvocable(object):
             self.GetWorkspaceRoot(), self.GetActiveScopes(), self.GetSkippedDirectories()
         )
         end_time = timeit.default_timer()
-        logging.debug(f"Time to Bootstrap Environment: {end_time - start_time}")
+        logging.debug(f"Time to Bootstrap Environment: {(end_time - start_time):.3f} s")
 
         start_time = timeit.default_timer()
         # Make sure the environment verifies IF it is required for this invocation
@@ -228,7 +228,7 @@ class BaseAbstractInvocable(object):
                 "Consider running stuart_update to possibly resolve this issue."
             )
         end_time = timeit.default_timer()
-        logging.debug(f"Time to Verify Environment: {end_time - start_time}")
+        logging.debug(f"Time to Verify Environment: {(end_time - start_time):.3f} s")
 
         start_time = timeit.default_timer()
 
@@ -248,11 +248,11 @@ class BaseAbstractInvocable(object):
             raise Exception("One or more helper plugins failed to load.")
 
         end_time = timeit.default_timer()
-        logging.debug(f"Time to Load Plugins: {end_time - start_time}")
+        logging.debug(f"Time to Load Plugins: {(end_time - start_time):.3f} s")
 
         logging.log(edk2_logging.SECTION, "Start Invocable Tool")
         overall_end_time = timeit.default_timer()
-        logging.debug(f"Time to Start Invocable: {overall_end_time - overall_start_time}")
+        logging.debug(f"Time to Start Invocable: {(overall_end_time - overall_start_time):.3f} s")
         retcode = self.Go()
         logging.log(edk2_logging.SECTION, "Summary")
         if retcode != 0:

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -229,7 +229,7 @@ def repo_details(abs_file_system_path: os.PathLike) -> dict:
     start_time = timeit.default_timer()
     git_version = ".".join(map(str, Git().version_info))
     end_time = timeit.default_timer()
-    logging.debug(f"Time to Get Git Version: {end_time - start_time}")
+    logging.debug(f"Time to Get Git Version: {(end_time - start_time):.3f} s")
     if version_compare(git_version, MIN_GIT_VERSION) < 0:
         e = f"Upgrade Git! Current version is {git_version}. Minimum is {MIN_GIT_VERSION}"
         logging.error(e)

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -18,6 +18,7 @@ edk2_setup.py, and git_dependency.py use this module to perform git operations.
 import logging
 import os
 import time
+import timeit
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -225,7 +226,10 @@ def repo_details(abs_file_system_path: os.PathLike) -> dict:
     Returns:
         (dict): dict containing details about the repository
     """
+    start_time = timeit.default_timer()
     git_version = ".".join(map(str, Git().version_info))
+    end_time = timeit.default_timer()
+    logging.debug(f"Time to Get Git Version: {end_time - start_time}")
     if version_compare(git_version, MIN_GIT_VERSION) < 0:
         e = f"Upgrade Git! Current version is {git_version}. Minimum is {MIN_GIT_VERSION}"
         logging.error(e)
@@ -262,7 +266,9 @@ def repo_details(abs_file_system_path: os.PathLike) -> dict:
             details["Head"] = {"HexSha": str(repo.head.commit.hexsha), "HexShaShort": str(repo.head.commit.hexsha[:7])}
             details["Valid"] = True
             details["Bare"] = repo.bare
+            start_time = timeit.default_timer()
             details["Dirty"] = git_retry(5, repo.is_dirty, untracked_files=True)
+            logging.debug(f"Time to Check If Repo is Dirty: {timeit.default_timer() - start_time}")
             details["Initialized"] = True
             details["Submodules"] = [submodule.name for submodule in repo.submodules]
             details["Remotes"] = [remote.name for remote in repo.remotes]

--- a/edk2toolext/environment/self_describing_environment.py
+++ b/edk2toolext/environment/self_describing_environment.py
@@ -68,7 +68,7 @@ class self_describing_environment(object):
                 ):
                     self.skipped_dirs += (worktree_path,)
         end_time = timeit.default_timer()
-        logging.debug(f"Time to Check for Worktrees: {end_time - start_time}")
+        logging.debug(f"Time to Check for Worktrees: {(end_time - start_time):.3f} s")
 
         # Validate that all scopes are unique.
         if len(self.scopes) != len(set(self.scopes)):
@@ -111,7 +111,7 @@ class self_describing_environment(object):
         start_time = timeit.default_timer()
         env_files = self._gather_env_files(("path_env", "ext_dep", "plug_in"), self.workspace)
         end_time = timeit.default_timer()
-        logging.debug(f"Time to Gather Env Files: {end_time - start_time}")
+        logging.debug(f"Time to Gather Env Files: {(end_time - start_time):.3f} s")
 
         # Next, get a list of all our scopes
         all_scopes_lower = [x.lower() for x in self.scopes]

--- a/edk2toolext/environment/self_describing_environment.py
+++ b/edk2toolext/environment/self_describing_environment.py
@@ -15,6 +15,7 @@ and then acts upon those files.
 import logging
 import os
 import time
+import timeit
 from multiprocessing import dummy
 from pathlib import Path
 from typing import Optional
@@ -56,6 +57,7 @@ class self_describing_environment(object):
         self.skipped_dirs = tuple(map(Path, (os.path.join(self.workspace, d) for d in skipped_dirs)))
 
         # Respect git worktrees
+        start_time = timeit.default_timer()
         details = repo_resolver.repo_details(self.workspace)
         if details["Valid"]:
             for worktree_path in details["Worktrees"]:
@@ -65,6 +67,8 @@ class self_describing_environment(object):
                     and worktree_path not in skipped_dirs
                 ):
                     self.skipped_dirs += (worktree_path,)
+        end_time = timeit.default_timer()
+        logging.debug(f"Time to Check for Worktrees: {end_time - start_time}")
 
         # Validate that all scopes are unique.
         if len(self.scopes) != len(set(self.scopes)):
@@ -104,7 +108,10 @@ class self_describing_environment(object):
         logging.debug("  Including scopes: %s" % ", ".join(self.scopes))
 
         # First, we need to get all of the files that describe our environment.
+        start_time = timeit.default_timer()
         env_files = self._gather_env_files(("path_env", "ext_dep", "plug_in"), self.workspace)
+        end_time = timeit.default_timer()
+        logging.debug(f"Time to Gather Env Files: {end_time - start_time}")
 
         # Next, get a list of all our scopes
         all_scopes_lower = [x.lower() for x in self.scopes]

--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -409,7 +409,7 @@ class UefiBuilder(object):
             logging.log(level, problem)
 
         build_end_time = timeit.default_timer()
-        logging.debug(f"Time to Build: {build_end_time - build_start_time}")
+        logging.debug(f"Time to Build: {(build_end_time - build_start_time):.3f} s")
 
         if ret != 0:
             return ret
@@ -430,7 +430,9 @@ class UefiBuilder(object):
         platform_pre_build_start_time = timeit.default_timer()
         ret = self.PlatformPreBuild()
         platform_pre_build_end_time = timeit.default_timer()
-        logging.debug(f"Time to run PlatformPreBuild: {platform_pre_build_end_time - platform_pre_build_start_time}")
+        logging.debug(
+            f"Time to run PlatformPreBuild: {(platform_pre_build_end_time - platform_pre_build_start_time):.3f} s"
+        )
 
         if ret != 0:
             logging.critical("PlatformPreBuild failed %d" % ret)
@@ -442,7 +444,10 @@ class UefiBuilder(object):
             plugin_start_time = timeit.default_timer()
             rc = Descriptor.Obj.do_pre_build(self)
             plugin_end_time = timeit.default_timer()
-            logging.debug(f"Time to run do_pre_build() for {Descriptor.Name}: {plugin_end_time - plugin_start_time}")
+            logging.debug(
+                f"Time to run do_pre_build() for {Descriptor.Name}: "
+                f"{((plugin_end_time - plugin_start_time) * 1000):.3f} ms"
+            )
             if rc != 0:
                 if rc is None:
                     logging.error("Plugin Failed: %s returned NoneType" % Descriptor.Name)
@@ -455,7 +460,7 @@ class UefiBuilder(object):
                 logging.debug("Plugin Success: %s" % Descriptor.Name)
 
         prebuild_end_time = timeit.default_timer()
-        logging.debug(f"Time to PreBuild: {prebuild_end_time - prebuild_start_time}")
+        logging.debug(f"Time to PreBuild: {(prebuild_end_time - prebuild_start_time):.3f} s")
 
         return ret
 
@@ -473,7 +478,9 @@ class UefiBuilder(object):
         platform_post_build_start_time = timeit.default_timer()
         ret = self.PlatformPostBuild()
         platform_post_build_end_time = timeit.default_timer()
-        logging.debug(f"Time to run PlatformPostBuild: {platform_post_build_end_time - platform_post_build_start_time}")
+        logging.debug(
+            f"Time to run PlatformPostBuild: {(platform_post_build_end_time - platform_post_build_start_time):.3f} s"
+        )
 
         if ret != 0:
             logging.critical("PlatformPostBuild failed %d" % ret)
@@ -486,7 +493,10 @@ class UefiBuilder(object):
             plugin_start_time = timeit.default_timer()
             rc = Descriptor.Obj.do_post_build(self)
             plugin_end_time = timeit.default_timer()
-            logging.debug(f"Time to run do_post_build() for {Descriptor.Name}: {plugin_end_time - plugin_start_time}")
+            logging.debug(
+                f"Time to run do_post_build() for {Descriptor.Name}: "
+                f"{((plugin_end_time - plugin_start_time) * 1000):.3f} ms"
+            )
             if rc != 0:
                 if rc is None:
                     logging.error("Plugin Failed: %s returned NoneType" % Descriptor.Name)
@@ -499,7 +509,7 @@ class UefiBuilder(object):
                 logging.debug("Plugin Success: %s" % Descriptor.Name)
 
         postbuild_end_time = timeit.default_timer()
-        logging.debug(f"Time to PostBuild: {postbuild_end_time - postbuild_start_time}")
+        logging.debug(f"Time to PostBuild: {(postbuild_end_time - postbuild_start_time):.3f} s")
 
         return ret
 
@@ -605,7 +615,7 @@ class UefiBuilder(object):
             self.env.SetValue(env_var.name, env_var.default, "Default Critical Platform Env Value.")
 
         setenv_end_time = timeit.default_timer()
-        logging.debug(f"Time to SetEnv: {setenv_end_time - setenv_start_time}")
+        logging.debug(f"Time to SetEnv: {(setenv_end_time - setenv_start_time):.3f} s")
 
         return 0
 
@@ -740,7 +750,7 @@ class UefiBuilder(object):
             return -1
 
         parse_target_file_end_time = timeit.default_timer()
-        logging.debug(f"Time to ParseTargetFile: {parse_target_file_end_time - parse_target_file_start_time}")
+        logging.debug(f"Time to ParseTargetFile: {(parse_target_file_end_time - parse_target_file_start_time):.3f} s")
 
         return 0
 
@@ -777,7 +787,9 @@ class UefiBuilder(object):
             return -1
 
         parse_toolsdef_file_end_time = timeit.default_timer()
-        logging.debug(f"Time to ParseToolsDefFile: {parse_toolsdef_file_end_time - parse_toolsdef_file_start_time}")
+        logging.debug(
+            f"Time to ParseToolsDefFile: {(parse_toolsdef_file_end_time - parse_toolsdef_file_start_time):.3f} s"
+        )
 
         return 0
 
@@ -813,7 +825,7 @@ class UefiBuilder(object):
             return -1
 
         parse_dsc_file_end_time = timeit.default_timer()
-        logging.debug(f"Time to ParseDscFile: {parse_dsc_file_end_time - parse_dsc_file_start_time}")
+        logging.debug(f"Time to ParseDscFile: {(parse_dsc_file_end_time - parse_dsc_file_start_time):.3f} s")
 
         return 0
 
@@ -850,7 +862,7 @@ class UefiBuilder(object):
             return -2
 
         parse_fdf_file_end_time = timeit.default_timer()
-        logging.debug(f"Time to ParseFdfFile: {parse_fdf_file_end_time - parse_fdf_file_start_time}")
+        logging.debug(f"Time to ParseFdfFile: {(parse_fdf_file_end_time - parse_fdf_file_start_time):.3f} s")
 
         return 0
 

--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -427,7 +427,10 @@ class UefiBuilder(object):
         #
         # Run the platform pre-build steps.
         #
+        platform_pre_build_start_time = timeit.default_timer()
         ret = self.PlatformPreBuild()
+        platform_pre_build_end_time = timeit.default_timer()
+        logging.debug(f"Time to run PlatformPreBuild: {platform_pre_build_end_time - platform_pre_build_start_time}")
 
         if ret != 0:
             logging.critical("PlatformPreBuild failed %d" % ret)
@@ -436,7 +439,10 @@ class UefiBuilder(object):
         # run all loaded UefiBuild Plugins
         #
         for Descriptor in self.pm.GetPluginsOfClass(IUefiBuildPlugin):
+            plugin_start_time = timeit.default_timer()
             rc = Descriptor.Obj.do_pre_build(self)
+            plugin_end_time = timeit.default_timer()
+            logging.debug(f"Time to run do_pre_build() for {Descriptor.Name}: {plugin_end_time - plugin_start_time}")
             if rc != 0:
                 if rc is None:
                     logging.error("Plugin Failed: %s returned NoneType" % Descriptor.Name)
@@ -464,7 +470,10 @@ class UefiBuilder(object):
         #
         # Run the platform post-build steps.
         #
+        platform_post_build_start_time = timeit.default_timer()
         ret = self.PlatformPostBuild()
+        platform_post_build_end_time = timeit.default_timer()
+        logging.debug(f"Time to run PlatformPostBuild: {platform_post_build_end_time - platform_post_build_start_time}")
 
         if ret != 0:
             logging.critical("PlatformPostBuild failed %d" % ret)
@@ -474,7 +483,10 @@ class UefiBuilder(object):
         # run all loaded UefiBuild Plugins
         #
         for Descriptor in self.pm.GetPluginsOfClass(IUefiBuildPlugin):
+            plugin_start_time = timeit.default_timer()
             rc = Descriptor.Obj.do_post_build(self)
+            plugin_end_time = timeit.default_timer()
+            logging.debug(f"Time to run do_post_build() for {Descriptor.Name}: {plugin_end_time - plugin_start_time}")
             if rc != 0:
                 if rc is None:
                     logging.error("Plugin Failed: %s returned NoneType" % Descriptor.Name)

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -317,7 +317,7 @@ class Edk2CiBuild(Edk2MultiPkgAwareInvocable):
             edk2_logging.log_progress("Overall Build Status: Success")
 
         full_end_time = timeit.default_timer()
-        logging.debug(f"Time to Complete CI Build: {full_end_time - full_start_time}")
+        logging.debug(f"Time to Complete CI Build: {(full_end_time - full_start_time):.3f} s")
 
         return failure_num
 

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -18,6 +18,7 @@ import argparse
 import logging
 import os
 import sys
+import timeit
 import traceback
 from typing import Any, Optional
 
@@ -126,6 +127,8 @@ class Edk2CiBuild(Edk2MultiPkgAwareInvocable):
 
     def Go(self) -> int:
         """Executes the core functionality of the Edk2CiBuild invocable."""
+        full_start_time = timeit.default_timer()
+
         log_directory = os.path.join(self.GetWorkspaceRoot(), self.GetLoggingFolderRelativeToRoot())
 
         Edk2CiBuild.collect_python_pip_info()
@@ -312,6 +315,9 @@ class Edk2CiBuild(Edk2MultiPkgAwareInvocable):
             edk2_logging.log_progress(f"There were {failure_num} failures out of {total_num} attempts")
         else:
             edk2_logging.log_progress("Overall Build Status: Success")
+
+        full_end_time = timeit.default_timer()
+        logging.debug(f"Time to Complete CI Build: {full_end_time - full_start_time}")
 
         return failure_num
 

--- a/edk2toolext/invocables/edk2_ci_setup.py
+++ b/edk2toolext/invocables/edk2_ci_setup.py
@@ -16,6 +16,7 @@ while allowing the invocable itself to remain platform agnostic.
 import argparse
 import logging
 import os
+import timeit
 from typing import Iterable
 
 from edk2toolext.environment import repo_resolver
@@ -134,6 +135,8 @@ class Edk2CiBuildSetup(Edk2MultiPkgAwareInvocable):
 
     def Go(self) -> int:
         """Executes the core functionality of the Edk2CiSetup invocable."""
+        full_start_time = timeit.default_timer()
+
         setup_dependencies = self.PlatformSettings.GetDependencies()
         logging.debug(f"Dependencies list {setup_dependencies}")
         repos = repo_resolver.resolve_all(
@@ -146,6 +149,9 @@ class Edk2CiBuildSetup(Edk2MultiPkgAwareInvocable):
         )
 
         logging.info(f"Repo resolver resolved {repos}")
+
+        full_end_time = timeit.default_timer()
+        logging.info(f"Time to Complete CI Setup: {full_end_time - full_start_time}")
 
         return 0 if None not in repos else -1
 

--- a/edk2toolext/invocables/edk2_ci_setup.py
+++ b/edk2toolext/invocables/edk2_ci_setup.py
@@ -151,7 +151,7 @@ class Edk2CiBuildSetup(Edk2MultiPkgAwareInvocable):
         logging.info(f"Repo resolver resolved {repos}")
 
         full_end_time = timeit.default_timer()
-        logging.info(f"Time to Complete CI Setup: {full_end_time - full_start_time}")
+        logging.info(f"Time to Complete CI Setup: {(full_end_time - full_start_time):.3f} s")
 
         return 0 if None not in repos else -1
 

--- a/edk2toolext/invocables/edk2_parse.py
+++ b/edk2toolext/invocables/edk2_parse.py
@@ -191,7 +191,7 @@ class Edk2Parse(Edk2MultiPkgAwareInvocable):
         logging.info(f"Database generated at {db_path}.")
 
         full_end_time = timeit.default_timer()
-        logging.info(f"Time to Complete Parse: {full_end_time - full_start_time}")
+        logging.info(f"Time to Complete Parse: {(full_end_time - full_start_time):.3f} s")
 
         return 0
 

--- a/edk2toolext/invocables/edk2_parse.py
+++ b/edk2toolext/invocables/edk2_parse.py
@@ -10,6 +10,7 @@
 import argparse
 import logging
 import os
+import timeit
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
 from typing import Iterable, Optional, Sequence
@@ -154,6 +155,8 @@ class Edk2Parse(Edk2MultiPkgAwareInvocable):
 
     def Go(self) -> int:
         """Executes the invocable. Runs the subcommand specified by the user."""
+        full_start_time = timeit.default_timer()
+
         logging.warning(
             "stuart_parse is in active development. Please report any issues to the edk2-pytool-extensions repo."
         )
@@ -186,6 +189,10 @@ class Edk2Parse(Edk2MultiPkgAwareInvocable):
             self.parse_with_ci_settings(db, pathobj, env)
 
         logging.info(f"Database generated at {db_path}.")
+
+        full_end_time = timeit.default_timer()
+        logging.info(f"Time to Complete Parse: {full_end_time - full_start_time}")
+
         return 0
 
     def parse_with_builder_settings(self, db: Edk2DB, pathobj: Edk2Path, env: VarDict) -> int:

--- a/edk2toolext/invocables/edk2_platform_build.py
+++ b/edk2toolext/invocables/edk2_platform_build.py
@@ -18,6 +18,7 @@ import argparse
 import logging
 import os
 import sys
+import timeit
 from textwrap import wrap
 
 from edk2toollib.uefi.edk2.path_utilities import Edk2Path
@@ -130,6 +131,7 @@ class Edk2PlatformBuild(Edk2Invocable):
 
     def Go(self) -> int:
         """Executes the core functionality of the Edk2PlatformBuild invocable."""
+        full_start_time = timeit.default_timer()
         logging.info("Running Python version: " + str(sys.version_info))
 
         Edk2PlatformBuild.collect_python_pip_info()
@@ -172,6 +174,9 @@ class Edk2PlatformBuild(Edk2Invocable):
         #
         # Now we can actually kick off a build.
         #
+        full_end_time = timeit.default_timer()
+        logging.debug(f"Time to Kick Off Platform Build: {full_end_time - full_start_time}")
+
         logging.log(edk2_logging.SECTION, "Kicking off build")
         ret = self.PlatformBuilder.Go(pathobj.WorkspacePath, os.pathsep.join(pathobj.PackagePathList), helper, pm)
         logging.log(edk2_logging.SECTION, f"Log file is located at: {self.log_filename}")

--- a/edk2toolext/invocables/edk2_platform_build.py
+++ b/edk2toolext/invocables/edk2_platform_build.py
@@ -175,7 +175,7 @@ class Edk2PlatformBuild(Edk2Invocable):
         # Now we can actually kick off a build.
         #
         full_end_time = timeit.default_timer()
-        logging.debug(f"Time to Kick Off Platform Build: {full_end_time - full_start_time}")
+        logging.debug(f"Time to Kick Off Platform Build: {(full_end_time - full_start_time):.3f} s")
 
         logging.log(edk2_logging.SECTION, "Kicking off build")
         ret = self.PlatformBuilder.Go(pathobj.WorkspacePath, os.pathsep.join(pathobj.PackagePathList), helper, pm)

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -18,6 +18,7 @@ while allowing the invocable itself to remain platform agnostic.
 import argparse
 import logging
 import os
+import timeit
 from io import StringIO
 from pathlib import Path
 from typing import Optional
@@ -159,6 +160,8 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
 
     def Go(self) -> int:
         """Executes the core functionality of the Edk2CiBuild invocable."""
+        full_start_time = timeit.default_timer()
+
         # create path obj for resolving paths.  Since PR eval is run early to determine if a build is
         # impacted by the changes of a PR we must ignore any packages path that are not valid due to
         # not having their submodule or folder populated.
@@ -193,6 +196,9 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
         if self.output_count_format_string is not None:
             pkgcount = len(actualPackagesDict.keys())
             print(self.output_count_format_string.format(pkgcount=pkgcount))
+
+        full_end_time = timeit.default_timer()
+        self.logger.info(f"Time to Complete PR Eval: {full_end_time - full_start_time}")
 
         return 0
 

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -198,7 +198,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
             print(self.output_count_format_string.format(pkgcount=pkgcount))
 
         full_end_time = timeit.default_timer()
-        self.logger.info(f"Time to Complete PR Eval: {full_end_time - full_start_time}")
+        self.logger.info(f"Time to Complete PR Eval: {(full_end_time - full_start_time):.3f} s")
 
         return 0
 

--- a/edk2toolext/invocables/edk2_setup.py
+++ b/edk2toolext/invocables/edk2_setup.py
@@ -15,6 +15,7 @@ while allowing the invocable itself to remain platform agnostic.
 import argparse
 import logging
 import os
+import timeit
 from typing import Iterable
 
 from edk2toollib.utility_functions import GetHostInfo
@@ -120,6 +121,8 @@ class Edk2PlatformSetup(Edk2MultiPkgAwareInvocable):
 
     def Go(self) -> int:
         """Executes the core functionality of the Edk2PlatformSetup invocable."""
+        full_start_time = timeit.default_timer()
+
         required_submodules = self.PlatformSettings.GetRequiredSubmodules()
 
         # Return clear error if submodules are a windows format on a non-windows system
@@ -192,6 +195,9 @@ class Edk2PlatformSetup(Edk2MultiPkgAwareInvocable):
                 logging.error(f"Error when trying to resolve {submodule.path}")
                 logging.error(e)
                 return -1
+
+        full_end_time = timeit.default_timer()
+        logging.info(f"Time to Complete Setup: {full_end_time - full_start_time}")
 
         return 0
 

--- a/edk2toolext/invocables/edk2_setup.py
+++ b/edk2toolext/invocables/edk2_setup.py
@@ -197,7 +197,7 @@ class Edk2PlatformSetup(Edk2MultiPkgAwareInvocable):
                 return -1
 
         full_end_time = timeit.default_timer()
-        logging.info(f"Time to Complete Setup: {full_end_time - full_start_time}")
+        logging.info(f"Time to Complete Setup: {(full_end_time - full_start_time):.3f} s")
 
         return 0
 

--- a/edk2toolext/invocables/edk2_update.py
+++ b/edk2toolext/invocables/edk2_update.py
@@ -119,7 +119,7 @@ class Edk2Update(Edk2MultiPkgAwareInvocable):
             self_describing_environment.DestroyEnvironment()
 
         full_end_time = timeit.default_timer()
-        logging.info(f"Time to Complete Update: {full_end_time - full_start_time}")
+        logging.info(f"Time to Complete Update: {(full_end_time - full_start_time):.3f} s")
 
         if failure_count != 0:
             logging.error(f"We were unable to successfully update {failure_count} dependencies in environment")

--- a/edk2toolext/invocables/edk2_update.py
+++ b/edk2toolext/invocables/edk2_update.py
@@ -15,6 +15,7 @@ while allowing the invocable itself to remain platform agnostic.
 
 import argparse
 import logging
+import timeit
 
 from edk2toolext import edk2_logging
 from edk2toolext.environment import self_describing_environment
@@ -89,6 +90,8 @@ class Edk2Update(Edk2MultiPkgAwareInvocable):
 
     def Go(self) -> int:
         """Executes the core functionality of the Edk2Update invocable."""
+        full_start_time = timeit.default_timer()
+
         RetryCount = 0
         failure_count = 0
         logging.log(edk2_logging.SECTION, "Initial update of environment")
@@ -114,6 +117,9 @@ class Edk2Update(Edk2MultiPkgAwareInvocable):
 
             build_env_old = build_env
             self_describing_environment.DestroyEnvironment()
+
+        full_end_time = timeit.default_timer()
+        logging.info(f"Time to Complete Update: {full_end_time - full_start_time}")
 
         if failure_count != 0:
             logging.error(f"We were unable to successfully update {failure_count} dependencies in environment")


### PR DESCRIPTION
Adds `debug` level messages with the pattern "Time to" to log the time taken to perform important tasks. This provides greater insight into overall stuart execution time and allows results to be compared for regressions and across environments.

---

A build log can be filtered to "Time to" messages to get a condensed view of build time (from mu_tiano_platforms build):

```
Time to Get Git Version: 0.125 s
Time to Check If Repo is Dirty: 1.808 s
Time to Check for Worktrees: 2.413 s
Time to Gather Env Files: 5.288 s
Time to Bootstrap Environment: 11.939 s
Time to Verify Environment: 0.314 s
Time to Load Plugins: 1.205 s
Time to Start Invocable: 13.503 s
Time to Kick Off Platform Build: 7.243 s
Time to ParseTargetFile: 0.007 s
Time to ParseToolsDefFile: 0.036 s
Time to ParseDscFile: 0.908 s
Time to ParseFdfFile: 0.048 s
Time to SetEnv: 2.316 s
Time to run PlatformPreBuild: 0.014 s
Time to run do_pre_build() for Update Config Headers: 1145.764 ms
Time to run do_pre_build() for PECOFF Image Validation Plugin: 0.073 ms
Time to run do_pre_build() for Build Tools Report Generator: 4.783 ms
Time to run do_pre_build() for Clang Pdb Tool Chain Support: 0.162 ms
Time to run do_pre_build() for Debug Macro Check Plugin: 752.201 ms
Time to run do_pre_build() for Fd Size Report Generator: 0.003 ms
Time to run do_pre_build() for Flatten PDBs UEFI Build Plugin: 0.002 ms
Time to run do_pre_build() for Override Validation and Deprecation Warning Pre Build Plugin: 6608.771 ms
Time to run do_pre_build() for Windows RC Path Support: 1.816 ms
Time to run do_pre_build() for Windows Visual Studio Tool Chain Support: 3698.368 ms
Time to PreBuild: 12.239 s
Time to Build: 134.139 s
Time to run PlatformPostBuild: 0.000 s
Time to run do_post_build() for Update Config Headers: 0.057 ms
Time to run do_post_build() for PECOFF Image Validation Plugin: 5353.019 ms
Time to run do_post_build() for Build Tools Report Generator: 3.844 ms
Time to run do_post_build() for Clang Pdb Tool Chain Support: 0.084 ms
Time to run do_post_build() for Debug Macro Check Plugin: 0.002 ms
Time to run do_post_build() for Fd Size Report Generator: 247.504 ms
Time to run do_post_build() for Flatten PDBs UEFI Build Plugin: 875.959 ms
Time to run do_post_build() for Override Validation and Deprecation Warning Pre Build Plugin: 0.003 ms
Time to run do_post_build() for Windows RC Path Support: 0.002 ms
Time to run do_post_build() for Windows Visual Studio Tool Chain Support: 0.077 ms
Time to PostBuild: 6.494 s
```