### PR TITLE
edk2_logging: Add separate perf measurement logs

### DIFF
--- a/edk2toolext/base_abstract_invocable.py
+++ b/edk2toolext/base_abstract_invocable.py
@@ -193,9 +193,7 @@ class BaseAbstractInvocable(object):
             self.log_filename = logfile
 
         edk2_logging.setup_performance_logger(
-            self.log_perf_measurements,
-            log_directory,
-            f'{self.GetLoggingFileName("txt")}_PERF'
+            self.log_perf_measurements, log_directory, f"{self.GetLoggingFileName('txt')}_PERF"
         )
 
         logging.info("Log Started: " + datetime.strftime(datetime.now(), "%A, %B %d, %Y %I:%M%p"))

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -420,9 +420,9 @@ class Edk2Invocable(BaseAbstractInvocable):
         settingsParserObj.add_argument(
             "--log-perf",
             dest="log_perf_measurements",
-            default = False,
+            default=False,
             action="store_true",
-            help="Enable performance measurements of this command."
+            help="Enable performance measurements of this command.",
         )
 
         # get the settings manager from the provided file and load an instance

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -417,11 +417,19 @@ class Edk2Invocable(BaseAbstractInvocable):
             default=False,
             help="Overrides platform module settings and sets all loggers to to the highest verbosity, including EDKII build command if applicable.",  # noqa
         )
+        settingsParserObj.add_argument(
+            "--log-perf",
+            dest="log_perf_measurements",
+            default = False,
+            action="store_true",
+            help="Enable performance measurements of this command."
+        )
 
         # get the settings manager from the provided file and load an instance
         settingsArg, unknown_args = settingsParserObj.parse_known_args()
 
         self.Verbose = settingsArg.verbose
+        self.log_perf_measurements = settingsArg.log_perf_measurements
 
         try:
             self.PlatformModule = import_module_by_file_name(os.path.abspath(settingsArg.platform_module))

--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -284,6 +284,7 @@ def scan_compiler_output(output_stream: TextIO) -> list[tuple]:
             problems.append((logging.ERROR, line))
     return problems
 
+
 def setup_performance_logger(enabled: bool, directory: str, file: str) -> None:
     """Sets up a performance logger."""
     if not enabled:
@@ -293,9 +294,11 @@ def setup_performance_logger(enabled: bool, directory: str, file: str) -> None:
     logfile, filelogger = setup_txt_logger(directory, file, logging.DEBUG, logging_namespace="performance")
     logging.getLogger("performance").propagate = False
 
+
 def perf_measurement(task: str, time: float) -> None:
     """Logs a performance measurement."""
     logging.getLogger("performance").info(f"{task} took {time:.3f} s")
+
 
 class Edk2LogFilter(logging.Filter):
     """Subclass of logging.Filter."""

--- a/edk2toolext/edk2_logging.py
+++ b/edk2toolext/edk2_logging.py
@@ -284,11 +284,23 @@ def scan_compiler_output(output_stream: TextIO) -> list[tuple]:
             problems.append((logging.ERROR, line))
     return problems
 
+def setup_performance_logger(enabled: bool, directory: str, file: str) -> None:
+    """Sets up a performance logger."""
+    if not enabled:
+        logging.getLogger("performance").disabled = True
+        return
+
+    logfile, filelogger = setup_txt_logger(directory, file, logging.DEBUG, logging_namespace="performance")
+    logging.getLogger("performance").propagate = False
+
+def perf_measurement(task: str, time: float) -> None:
+    """Logs a performance measurement."""
+    logging.getLogger("performance").info(f"{task} took {time:.3f} s")
 
 class Edk2LogFilter(logging.Filter):
     """Subclass of logging.Filter."""
 
-    _allowedLoggers = ["root", "git.cmd", "edk2toolext.environment.repo_resolver"]
+    _allowedLoggers = ["root", "performance", "git.cmd", "edk2toolext.environment.repo_resolver"]
 
     def __init__(self) -> None:
         """Inits a filter."""

--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -228,8 +228,7 @@ def repo_details(abs_file_system_path: os.PathLike) -> dict:
     """
     start_time = timeit.default_timer()
     git_version = ".".join(map(str, Git().version_info))
-    end_time = timeit.default_timer()
-    logging.debug(f"Time to Get Git Version: {(end_time - start_time):.3f} s")
+    edk2_logging.perf_measurement("Get Git Version", timeit.default_timer() - start_time)
     if version_compare(git_version, MIN_GIT_VERSION) < 0:
         e = f"Upgrade Git! Current version is {git_version}. Minimum is {MIN_GIT_VERSION}"
         logging.error(e)
@@ -268,7 +267,7 @@ def repo_details(abs_file_system_path: os.PathLike) -> dict:
             details["Bare"] = repo.bare
             start_time = timeit.default_timer()
             details["Dirty"] = git_retry(5, repo.is_dirty, untracked_files=True)
-            logging.debug(f"Time to Check If Repo is Dirty: {timeit.default_timer() - start_time}")
+            edk2_logging.perf_measurement("Validate if Repo is Dirty", timeit.default_timer() - start_time)
             details["Initialized"] = True
             details["Submodules"] = [submodule.name for submodule in repo.submodules]
             details["Remotes"] = [remote.name for remote in repo.remotes]

--- a/edk2toolext/environment/self_describing_environment.py
+++ b/edk2toolext/environment/self_describing_environment.py
@@ -20,6 +20,7 @@ from multiprocessing import dummy
 from pathlib import Path
 from typing import Optional
 
+from edk2toolext import edk2_logging
 from edk2toolext.environment import environment_descriptor_files as EDF
 from edk2toolext.environment import external_dependency, repo_resolver, shell_environment
 
@@ -67,8 +68,7 @@ class self_describing_environment(object):
                     and worktree_path not in skipped_dirs
                 ):
                     self.skipped_dirs += (worktree_path,)
-        end_time = timeit.default_timer()
-        logging.debug(f"Time to Check for Worktrees: {(end_time - start_time):.3f} s")
+        edk2_logging.perf_measurement("Check for Worktrees", timeit.default_timer() - start_time)
 
         # Validate that all scopes are unique.
         if len(self.scopes) != len(set(self.scopes)):
@@ -110,8 +110,7 @@ class self_describing_environment(object):
         # First, we need to get all of the files that describe our environment.
         start_time = timeit.default_timer()
         env_files = self._gather_env_files(("path_env", "ext_dep", "plug_in"), self.workspace)
-        end_time = timeit.default_timer()
-        logging.debug(f"Time to Gather Env Files: {(end_time - start_time):.3f} s")
+        edk2_logging.perf_measurement("Gather Env Files", timeit.default_timer() - start_time)
 
         # Next, get a list of all our scopes
         all_scopes_lower = [x.lower() for x in self.scopes]

--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -408,8 +408,7 @@ class UefiBuilder(object):
         for level, problem in problems:
             logging.log(level, problem)
 
-        build_end_time = timeit.default_timer()
-        logging.debug(f"Time to Build: {(build_end_time - build_start_time):.3f} s")
+        edk2_logging.perf_measurement("Build", timeit.default_timer() - build_start_time)
 
         if ret != 0:
             return ret
@@ -429,9 +428,8 @@ class UefiBuilder(object):
         #
         platform_pre_build_start_time = timeit.default_timer()
         ret = self.PlatformPreBuild()
-        platform_pre_build_end_time = timeit.default_timer()
-        logging.debug(
-            f"Time to run PlatformPreBuild: {(platform_pre_build_end_time - platform_pre_build_start_time):.3f} s"
+        edk2_logging.perf_measurement(
+            "PlatformPreBuild", timeit.default_timer() - platform_pre_build_start_time
         )
 
         if ret != 0:
@@ -443,10 +441,9 @@ class UefiBuilder(object):
         for Descriptor in self.pm.GetPluginsOfClass(IUefiBuildPlugin):
             plugin_start_time = timeit.default_timer()
             rc = Descriptor.Obj.do_pre_build(self)
-            plugin_end_time = timeit.default_timer()
-            logging.debug(
-                f"Time to run do_pre_build() for {Descriptor.Name}: "
-                f"{((plugin_end_time - plugin_start_time) * 1000):.3f} ms"
+            edk2_logging.perf_measurement(
+                f"do_pre_build()[{Descriptor.Name}]",
+                timeit.default_timer() - plugin_start_time
             )
             if rc != 0:
                 if rc is None:
@@ -459,8 +456,7 @@ class UefiBuilder(object):
             else:
                 logging.debug("Plugin Success: %s" % Descriptor.Name)
 
-        prebuild_end_time = timeit.default_timer()
-        logging.debug(f"Time to PreBuild: {(prebuild_end_time - prebuild_start_time):.3f} s")
+        edk2_logging.perf_measurement("PreBuild", timeit.default_timer() - prebuild_start_time)
 
         return ret
 
@@ -477,9 +473,8 @@ class UefiBuilder(object):
         #
         platform_post_build_start_time = timeit.default_timer()
         ret = self.PlatformPostBuild()
-        platform_post_build_end_time = timeit.default_timer()
-        logging.debug(
-            f"Time to run PlatformPostBuild: {(platform_post_build_end_time - platform_post_build_start_time):.3f} s"
+        edk2_logging.perf_measurement(
+            "PlatformPostBuild", timeit.default_timer() - platform_post_build_start_time
         )
 
         if ret != 0:
@@ -492,10 +487,9 @@ class UefiBuilder(object):
         for Descriptor in self.pm.GetPluginsOfClass(IUefiBuildPlugin):
             plugin_start_time = timeit.default_timer()
             rc = Descriptor.Obj.do_post_build(self)
-            plugin_end_time = timeit.default_timer()
-            logging.debug(
-                f"Time to run do_post_build() for {Descriptor.Name}: "
-                f"{((plugin_end_time - plugin_start_time) * 1000):.3f} ms"
+            edk2_logging.perf_measurement(
+                f"do_post_build()[{Descriptor.Name}]",
+                timeit.default_timer() - plugin_start_time
             )
             if rc != 0:
                 if rc is None:
@@ -508,8 +502,7 @@ class UefiBuilder(object):
             else:
                 logging.debug("Plugin Success: %s" % Descriptor.Name)
 
-        postbuild_end_time = timeit.default_timer()
-        logging.debug(f"Time to PostBuild: {(postbuild_end_time - postbuild_start_time):.3f} s")
+        edk2_logging.perf_measurement("PostBuild", timeit.default_timer() - postbuild_start_time)
 
         return ret
 
@@ -614,8 +607,7 @@ class UefiBuilder(object):
         for env_var in self.SetPlatformDefaultEnv():
             self.env.SetValue(env_var.name, env_var.default, "Default Critical Platform Env Value.")
 
-        setenv_end_time = timeit.default_timer()
-        logging.debug(f"Time to SetEnv: {(setenv_end_time - setenv_start_time):.3f} s")
+        edk2_logging.perf_measurement("SetEnv", timeit.default_timer() - setenv_start_time)
 
         return 0
 
@@ -749,8 +741,7 @@ class UefiBuilder(object):
             logging.error("Failed to find target.txt file")
             return -1
 
-        parse_target_file_end_time = timeit.default_timer()
-        logging.debug(f"Time to ParseTargetFile: {(parse_target_file_end_time - parse_target_file_start_time):.3f} s")
+        edk2_logging.perf_measurement("ParseTargetFile", timeit.default_timer() - parse_target_file_start_time)
 
         return 0
 
@@ -786,9 +777,8 @@ class UefiBuilder(object):
             logging.error("Failed to find tools_def.txt file")
             return -1
 
-        parse_toolsdef_file_end_time = timeit.default_timer()
-        logging.debug(
-            f"Time to ParseToolsDefFile: {(parse_toolsdef_file_end_time - parse_toolsdef_file_start_time):.3f} s"
+        edk2_logging.perf_measurement(
+            "ParseToolsDefFile", timeit.default_timer() - parse_toolsdef_file_start_time
         )
 
         return 0
@@ -824,8 +814,7 @@ class UefiBuilder(object):
             logging.error("Failed to find DSC file")
             return -1
 
-        parse_dsc_file_end_time = timeit.default_timer()
-        logging.debug(f"Time to ParseDscFile: {(parse_dsc_file_end_time - parse_dsc_file_start_time):.3f} s")
+        edk2_logging.perf_measurement("ParseDscFile", timeit.default_timer() - parse_dsc_file_start_time)
 
         return 0
 
@@ -861,8 +850,7 @@ class UefiBuilder(object):
             logging.error("Failed to find FDF file")
             return -2
 
-        parse_fdf_file_end_time = timeit.default_timer()
-        logging.debug(f"Time to ParseFdfFile: {(parse_fdf_file_end_time - parse_fdf_file_start_time):.3f} s")
+        edk2_logging.perf_measurement("ParseFdfFile", timeit.default_timer() - parse_fdf_file_start_time)
 
         return 0
 

--- a/edk2toolext/environment/uefi_build.py
+++ b/edk2toolext/environment/uefi_build.py
@@ -428,9 +428,7 @@ class UefiBuilder(object):
         #
         platform_pre_build_start_time = timeit.default_timer()
         ret = self.PlatformPreBuild()
-        edk2_logging.perf_measurement(
-            "PlatformPreBuild", timeit.default_timer() - platform_pre_build_start_time
-        )
+        edk2_logging.perf_measurement("PlatformPreBuild", timeit.default_timer() - platform_pre_build_start_time)
 
         if ret != 0:
             logging.critical("PlatformPreBuild failed %d" % ret)
@@ -442,8 +440,7 @@ class UefiBuilder(object):
             plugin_start_time = timeit.default_timer()
             rc = Descriptor.Obj.do_pre_build(self)
             edk2_logging.perf_measurement(
-                f"do_pre_build()[{Descriptor.Name}]",
-                timeit.default_timer() - plugin_start_time
+                f"do_pre_build()[{Descriptor.Name}]", timeit.default_timer() - plugin_start_time
             )
             if rc != 0:
                 if rc is None:
@@ -473,9 +470,7 @@ class UefiBuilder(object):
         #
         platform_post_build_start_time = timeit.default_timer()
         ret = self.PlatformPostBuild()
-        edk2_logging.perf_measurement(
-            "PlatformPostBuild", timeit.default_timer() - platform_post_build_start_time
-        )
+        edk2_logging.perf_measurement("PlatformPostBuild", timeit.default_timer() - platform_post_build_start_time)
 
         if ret != 0:
             logging.critical("PlatformPostBuild failed %d" % ret)
@@ -488,8 +483,7 @@ class UefiBuilder(object):
             plugin_start_time = timeit.default_timer()
             rc = Descriptor.Obj.do_post_build(self)
             edk2_logging.perf_measurement(
-                f"do_post_build()[{Descriptor.Name}]",
-                timeit.default_timer() - plugin_start_time
+                f"do_post_build()[{Descriptor.Name}]", timeit.default_timer() - plugin_start_time
             )
             if rc != 0:
                 if rc is None:
@@ -777,9 +771,7 @@ class UefiBuilder(object):
             logging.error("Failed to find tools_def.txt file")
             return -1
 
-        edk2_logging.perf_measurement(
-            "ParseToolsDefFile", timeit.default_timer() - parse_toolsdef_file_start_time
-        )
+        edk2_logging.perf_measurement("ParseToolsDefFile", timeit.default_timer() - parse_toolsdef_file_start_time)
 
         return 0
 

--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -316,8 +316,7 @@ class Edk2CiBuild(Edk2MultiPkgAwareInvocable):
         else:
             edk2_logging.log_progress("Overall Build Status: Success")
 
-        full_end_time = timeit.default_timer()
-        logging.debug(f"Time to Complete CI Build: {(full_end_time - full_start_time):.3f} s")
+        edk2_logging.perf_measurement("Complete CI Build", timeit.default_timer() - full_start_time)
 
         return failure_num
 

--- a/edk2toolext/invocables/edk2_ci_setup.py
+++ b/edk2toolext/invocables/edk2_ci_setup.py
@@ -19,6 +19,7 @@ import os
 import timeit
 from typing import Iterable
 
+from edk2toolext import edk2_logging
 from edk2toolext.environment import repo_resolver
 from edk2toolext.invocables.edk2_multipkg_aware_invocable import (
     Edk2MultiPkgAwareInvocable,
@@ -150,8 +151,7 @@ class Edk2CiBuildSetup(Edk2MultiPkgAwareInvocable):
 
         logging.info(f"Repo resolver resolved {repos}")
 
-        full_end_time = timeit.default_timer()
-        logging.info(f"Time to Complete CI Setup: {(full_end_time - full_start_time):.3f} s")
+        edk2_logging.perf_measurement("Complete CI Setup", timeit.default_timer() - full_start_time)
 
         return 0 if None not in repos else -1
 

--- a/edk2toolext/invocables/edk2_parse.py
+++ b/edk2toolext/invocables/edk2_parse.py
@@ -29,6 +29,7 @@ from edk2toollib.database.tables import (
 from edk2toollib.uefi.edk2.path_utilities import Edk2Path
 from edk2toollib.utility_functions import import_module_by_file_name, locate_class_in_module
 
+from edk2toolext import edk2_logging
 from edk2toolext.environment import shell_environment
 from edk2toolext.environment.uefi_build import UefiBuilder
 from edk2toolext.environment.var_dict import VarDict
@@ -190,8 +191,7 @@ class Edk2Parse(Edk2MultiPkgAwareInvocable):
 
         logging.info(f"Database generated at {db_path}.")
 
-        full_end_time = timeit.default_timer()
-        logging.info(f"Time to Complete Parse: {(full_end_time - full_start_time):.3f} s")
+        edk2_logging.perf_measurement("Complete Parse", timeit.default_timer() - full_start_time)
 
         return 0
 

--- a/edk2toolext/invocables/edk2_platform_build.py
+++ b/edk2toolext/invocables/edk2_platform_build.py
@@ -174,8 +174,7 @@ class Edk2PlatformBuild(Edk2Invocable):
         #
         # Now we can actually kick off a build.
         #
-        full_end_time = timeit.default_timer()
-        logging.debug(f"Time to Kick Off Platform Build: {(full_end_time - full_start_time):.3f} s")
+        edk2_logging.perf_measurement("Kick Off Platform Build", timeit.default_timer() - full_start_time)
 
         logging.log(edk2_logging.SECTION, "Kicking off build")
         ret = self.PlatformBuilder.Go(pathobj.WorkspacePath, os.pathsep.join(pathobj.PackagePathList), helper, pm)

--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -197,8 +197,7 @@ class Edk2PrEval(Edk2MultiPkgAwareInvocable):
             pkgcount = len(actualPackagesDict.keys())
             print(self.output_count_format_string.format(pkgcount=pkgcount))
 
-        full_end_time = timeit.default_timer()
-        self.logger.info(f"Time to Complete PR Eval: {(full_end_time - full_start_time):.3f} s")
+        edk2_logging.perf_measurement("Complete PR Eval", timeit.default_timer() - full_start_time)
 
         return 0
 

--- a/edk2toolext/invocables/edk2_setup.py
+++ b/edk2toolext/invocables/edk2_setup.py
@@ -196,8 +196,7 @@ class Edk2PlatformSetup(Edk2MultiPkgAwareInvocable):
                 logging.error(e)
                 return -1
 
-        full_end_time = timeit.default_timer()
-        logging.info(f"Time to Complete Setup: {(full_end_time - full_start_time):.3f} s")
+        edk2_logging.perf_measurement("Complete Setup", timeit.default_timer() - full_start_time)
 
         return 0
 

--- a/edk2toolext/invocables/edk2_update.py
+++ b/edk2toolext/invocables/edk2_update.py
@@ -118,8 +118,7 @@ class Edk2Update(Edk2MultiPkgAwareInvocable):
             build_env_old = build_env
             self_describing_environment.DestroyEnvironment()
 
-        full_end_time = timeit.default_timer()
-        logging.info(f"Time to Complete Update: {(full_end_time - full_start_time):.3f} s")
+        edk2_logging.perf_measurement("Complete Update", timeit.default_timer() - full_start_time)
 
         if failure_count != 0:
             logging.error(f"We were unable to successfully update {failure_count} dependencies in environment")


### PR DESCRIPTION
Adds a separate logger for logging stuart performance measurements.

Developers (both of core stuart, and of plugins) can use `edk2_logging.performance_measurement()` to record performance measurements when the feature is enabled with the `--log-perf` flag, which is disabled by default.