### PR TITLE
repo_resolver: fix case of reference and recurse being mutually exclusive.

### DIFF
--- a/edk2toolext/environment/repo_resolver.py
+++ b/edk2toolext/environment/repo_resolver.py
@@ -390,8 +390,10 @@ def clone_repo(abs_file_system_path: os.PathLike, DepObj: dict) -> tuple:
         if reference:
             params.append("--reference")
             params.append(reference.as_posix())
-        if reference and recurse:
-            params.append("--recurse-submodules")  # if we don't have a reference we can just recurse the submodules
+        elif recurse:
+            params.append("--recurse-submodules")
+
+        return params
 
         return params
 


### PR DESCRIPTION
--reference and --recurse-submodules cannot be used at the same time.

Resolve issue introduced in #966 that allowed the parameter to be used at the same time during git clone with omnicache. 