### PR TITLE
pyproject.toml: Fix deprecations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ maintainers = [{name = "EDK2 Pytool Maintainers", email = "edk2-pytools@microsof
 dynamic = ["version"]
 description = "Python tools supporting UEFI EDK2 firmware development"
 readme = {file = "readme.md", content-type = "text/markdown"}
-license = {file = "LICENSE"}
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
     "edk2-pytool-library>=0.20.0",
@@ -24,7 +24,6 @@ dependencies = [
 
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -88,6 +87,9 @@ edk2_capsule_tool = "edk2toolext.capsule.capsule_tool:main"
 versioninfo_tool = "edk2toolext.versioninfo.versioninfo_tool:main"
 validate_image_tool = "edk2toolext.image_validation:main"
 secureboot_audit = "edk2toolext.windows.secureboot.secureboot_audit:main"
+
+[tool.setuptools]
+packages = ["edk2toolext"]
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
- Fix this deprecation warning:

  > Please use a simple string containing a SPDX expression for
    `project.license`.

  By following guidance at:

  https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-files

- Fix this deprecation warning:

  > Please consider removing the following classifiers in favor of a SPDX license expression:
    License :: OSI Approved :: BSD License

  By removing the license classifier.

- Prevent pyproject from failing if documentation is built in the workspace with this error:

  > error: Multiple top-level packages discovered in a flat-layout: ['site', 'edk2toolext'].

  By explicitly setting `py-modules` to `edk2toolext`.