### PR TITLE
Adding limited cloning capabilities to stuart_setup

### DIFF
--- a/edk2toolext/invocables/edk2_setup.py
+++ b/edk2toolext/invocables/edk2_setup.py
@@ -39,16 +39,18 @@ from edk2toolext.invocables.edk2_multipkg_aware_invocable import (
 class RequiredSubmodule:
     """A class containing information about a git submodule."""
 
-    def __init__(self, path: str, recursive: bool = True) -> None:
+    def __init__(self, path: str, recursive: bool = True, configuration_file: str = None) -> None:
         """Object to hold necessary information for resolving submodules.
 
         Args:
             path (str): workspace relative path to submodule that must be
                 synchronized and updated
             recursive (bool): if recursion should be used in this submodule
+            configuration_file: path to file containing CiSettingsManager instance
         """
         self.path = path
         self.recursive = recursive
+        self.configuration_file = configuration_file
 
 
 class SetupSettingsManager(MultiPkgAwareSettingsInterface):

--- a/tests.unit/test_repo_resolver.py
+++ b/tests.unit/test_repo_resolver.py
@@ -378,9 +378,13 @@ class test_repo_resolver(unittest.TestCase):
 
         class Submodule:
             def __init__(self, path: str, recursive: bool) -> None:
-                """Inits Submodule."""
+                """Inits Submodule.
+
+                Mimics RequiredSubmodule from edk2_setup.py.
+                """
                 self.path = path
                 self.recursive = recursive
+                self.configuration_file = None
 
         temp_folder = tempfile.mkdtemp()
         submodule_path = "Common/MU"


### PR DESCRIPTION
Use case:

In a PlatformBuild.py file, GetRequiredSubmodules() is implemented to list
the required submodules that need to be downloaded for the platform build.

These submodules, today, will only have the True/False configuration option, which will 
recurse all submodules, including the submodules submodules.
(Example: mu_tiano_plus includes LibSpdm, which includes submodule openssl, which includes submodule pyca/cryptography)
But, repo dependent, the submodules of a submodule are not required to build/use the functionality.

Add an optional configuration option that will allow specifying a CISettings file and only the submodules in the settings file will be downloaded.


Test Environment:
Modify mu_tiano_platform's PlatformBuild.py:

`RequiredSubmodule("MU_BASECORE", True,),
RequiredSubmodule("Common/MU", True,),
RequiredSubmodule("Common/MU_TIANO", True, ".pytool/CISettings.py"),
RequiredSubmodule("Common/MU_OEM_SAMPLE", True,),
RequiredSubmodule("Features/DEBUGGER", True,),
RequiredSubmodule("Features/DFCI", True,),
RequiredSubmodule("Features/CONFIG", True,),
RequiredSubmodule("Features/MM_SUPV", False),`

run stuart_setup and then verify that submodules of mu_tiano_plus were not recursively downloaded. 