### PR TITLE
nuget_dependency: allow source override

### DIFF
--- a/docs/user/features/extdep.md
+++ b/docs/user/features/extdep.md
@@ -73,6 +73,10 @@ This package has a version of the NuGet.exe binary or a user can configure their
 environment to use a defined version by setting `NUGET_PATH` to the folder containing
 the NuGet.exe that should be used.
 
+For enviroments with restricted network access it's possible to override
+dependencies' sources with a single local mirror by setting the value of
+the `NUGET_PKG_SOURCE` env variable to the mirror's location.
+
 ### Web Dependency
 
 Web dependency is used to describe a dependency on an asset that can be

--- a/edk2toolext/environment/extdeptypes/nuget_dependency.py
+++ b/edk2toolext/environment/extdeptypes/nuget_dependency.py
@@ -36,6 +36,8 @@ class NugetDependency(ExternalDependency):
 
     # Env variable name for path to folder containing NuGet.exe
     NUGET_ENV_VAR_NAME = "NUGET_PATH"
+    # Env variable name for path to NuGet packages (e.g. local mirror)
+    NUGET_SOURCE_VAR_NAME = "NUGET_PKG_SOURCE"
 
     def __init__(self, descriptor: dict) -> None:
         """Inits a nuget dependency based off the provided descriptor."""
@@ -217,9 +219,14 @@ class NugetDependency(ExternalDependency):
         # fetch the contents of the package.
         #
         package_name = self.package
+        source = self.source
+        # Check if the package's source is overriden by an env variable
+        source = os.getenv(self.NUGET_SOURCE_VAR_NAME)
+        if source is None:
+          source = self.source
         cmd = NugetDependency.GetNugetCmd()
         cmd += ["install", package_name]
-        cmd += ["-Source", self.source]
+        cmd += ["-Source", source]
         cmd += ["-ExcludeVersion"]
         if non_interactive:
             cmd += ["-NonInteractive"]


### PR DESCRIPTION
Introduce an env variable NUGET_PKG_SOURCE that if set would override source for NuGet packages. This allows to install NuGet dependencies in restricted environments without global network access by pre-caching them in local directory or network share.