### PR TITLE
edk2_invocable: Register one version per pip package

### DIFF
--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -209,13 +209,14 @@ class Edk2Invocable(BaseAbstractInvocable):
             pip_packages = []
         # go through all installed pip versions
         for package in pip_packages:
-            try:
-                version = package.version
-                name = package.metadata["Name"] if "Name" in package.metadata else package.metadata.get("name", None)
-                if not name:
-                    name = package.metadata.get("Summary", "unknown")
-            except Exception:
+            name = package.metadata.get("Name", None) or package.metadata.get("Summary", None)
+            if name is None:
                 continue
+
+            # Always grab the version of the first instance of the package on the PATH. pipenv inserts its
+            # path first, so we can assume that the first instance is the one actually used.
+            version = importlib.metadata.version(name)
+
             logging.info("{0} version: {1}".format(name, version))
             ver_agg.ReportVersion(name, version, version_aggregator.VersionTypes.PIP)
 

--- a/edk2toolext/edk2_invocable.py
+++ b/edk2toolext/edk2_invocable.py
@@ -208,11 +208,13 @@ class Edk2Invocable(BaseAbstractInvocable):
         except Exception:
             pip_packages = []
         # go through all installed pip versions
+        filtered = set()
         for package in pip_packages:
             name = package.metadata.get("Name", None) or package.metadata.get("Summary", None)
-            if name is None:
-                continue
+            if name:
+                filtered.add(name)
 
+        for name in filtered:
             # Always grab the version of the first instance of the package on the PATH. pipenv inserts its
             # path first, so we can assume that the first instance is the one actually used.
             version = importlib.metadata.version(name)


### PR DESCRIPTION
This commit results in only the first version of a pip package found on the path being used as the version, even if multiple versions exist in the distribution list because it exists in multiple path locations. If using a venv environment, the path to those pip modules is prepended, so it should theoretically always be correct.