### PR TITLE
Update CoverageReport exclude statement to target folders 

### DIFF
--- a/edk2toolext/environment/reporttypes/coverage_report.py
+++ b/edk2toolext/environment/reporttypes/coverage_report.py
@@ -329,7 +329,8 @@ class CoverageReport(Report):
 
         packages = ET.SubElement(root, "packages")
         for path, source_list in inf_source_dict.items():
-            if fnmatch.fnmatch(path, "*Test*"):
+            # Exclude sources file that exists under a Test or UnitTest folder
+            if fnmatch.fnmatch(path, "*/Test/*") or fnmatch.fnmatch(path, "*/UnitTest/*"):
                 continue
             if not source_list:
                 continue


### PR DESCRIPTION
Original statement would exclude anything with Test in the path name, which ended up targeting a source file with DramTest in the name.

Updated the statement to exclude /Test/ and /UnitTest/ in the path name, would should exclude items from under the common unit test folders.

Tested on Package which was previously missing some test results. After updating missing test results were correctly reorganized.