### PR TITLE
edk2_pr_eval: Consider build variables in Policy 4 [Rebase & FF]

### DIFF
--- a/edk2toolext/invocables/edk2_pr_eval.py
+++ b/edk2toolext/invocables/edk2_pr_eval.py
@@ -83,16 +83,22 @@ class PrEvalSettingsManager(MultiPkgAwareSettingsInterface):
         return potentialPackagesList
 
     def GetPlatformDscAndConfig(self) -> tuple:
-        """Provide a platform dsc and config.
+        """Provide a platform DSC and build variable configuration.
 
-        If a platform desires to provide its DSC then Policy 4 will evaluate if
-        any of the changes will be built in the dsc.
+        If a platform provides the workspace relative path for its DSC file to this function, then
+        Policy 4 will be evaluated. This is used to determine if a change occurred in a module that
+        is used in the DSC file.
+
+        Returning the dictionary of build key value pairs is optional but allows those variables to
+        be considered when evaluating the DSC file. These variable values will override any values
+        set directly in build files such as the DSC files. These variable values will be overridden
+        by any values set on the command line for the current target.
 
         !!! tip
-            Optional Override in a subclass
+            Optional override in a subclass
 
         Returns:
-            (tuple): (workspace relative path to dsc file, input dictionary of dsc key value pairs)
+            (tuple): (workspace relative path to DSC file, input dictionary of build variable key value pairs)
         """
         return None
 


### PR DESCRIPTION
Process build variables as policy in Policy 4:

- First, consider variables in build files such as those in the [Defines] section of the DSC.
- Second, consider variables defined in the `GetPlatformDscAndConfig()` implementation. This is analogous to `SetPlatformEnv()` for PR Eval.
- Third, update the list of variables based on the dictionary returned from `GetAllBuildKeyValues()` which contains the build variables resolved against the current target.

The *second* and *third* steps above are now used as the "input" variables to the DSC parser.

---

Also describes the `PrEvalSettingsManager.GetPlatformDscAndConfig` API in more detail to clarify how it is used.

---

Note: Will use the updated edk2-pytool-library commit from https://github.com/tianocore/edk2-pytool-library/pull/750 after that PR is merged.