### PR TITLE
stuart_ci_build: Add support for listing plugins

### DIFF
--- a/edk2toolext/invocables/edk2_ci_build.py
+++ b/edk2toolext/invocables/edk2_ci_build.py
@@ -119,7 +119,7 @@ class Edk2CiBuild(Edk2MultiPkgAwareInvocable):
         """Retrieve command line options from the argparser."""
         self.disable_plugins = args.disable
         self.fail_fast = args.fail_fast
-        self.list_plugins = args.list
+        self.list_plugins = args.plugin_list
         super().RetrieveCommandLineOptions(args)
 
     def GetSettingsClass(self) -> type:


### PR DESCRIPTION
This commit adds a new cli argument, `--list` to stuart_ci_build that will list all available CI plugins and the path to their source / documentation directory.

example of the output of `stuart_ci_build -c .pytool/CISetting.py`

![image](https://github.com/user-attachments/assets/3b01bca5-1e29-45ba-8d27-43ef4f7781a0)