### PR TITLE
Format output xml and align GUID format for fpdt_parser

### DIFF
--- a/edk2toolext/perf/fpdt_parser.py
+++ b/edk2toolext/perf/fpdt_parser.py
@@ -1648,11 +1648,11 @@ class ParserApp:
             self.xml_tree.append(self.fbpt_tree)
 
             # Format XML properly with indentation
-            rough_string = ET.tostring(self.xml_tree, encoding='unicode')
+            rough_string = ET.tostring(self.xml_tree, encoding="unicode")
             reparsed = minidom.parseString(rough_string)
             formatted_xml = reparsed.toprettyxml(indent="    ")
 
-            with open(self.options.output_xml_file, "w", encoding='utf-8') as xml_file:
+            with open(self.options.output_xml_file, "w", encoding="utf-8") as xml_file:
                 xml_file.write(formatted_xml)
 
         if self.options.output_text_file:

--- a/edk2toolext/perf/fpdt_parser.py
+++ b/edk2toolext/perf/fpdt_parser.py
@@ -1643,7 +1643,7 @@ class ParserApp:
             # Add all records to the FBPT container element
             for record in fbpt_records_list:
                 self.fbpt_tree.append(record.to_xml())
-            
+
             # Now append the complete FBPT container to the main XML tree
             self.xml_tree.append(self.fbpt_tree)
 
@@ -1651,7 +1651,7 @@ class ParserApp:
             rough_string = ET.tostring(self.xml_tree, encoding='unicode')
             reparsed = minidom.parseString(rough_string)
             formatted_xml = reparsed.toprettyxml(indent="    ")
-            
+
             with open(self.options.output_xml_file, "w", encoding='utf-8') as xml_file:
                 xml_file.write(formatted_xml)
 

--- a/edk2toolext/perf/fpdt_parser.py
+++ b/edk2toolext/perf/fpdt_parser.py
@@ -77,6 +77,7 @@ from ctypes import (
 )
 from io import TextIOWrapper
 from typing import BinaryIO
+from xml.dom import minidom
 
 FPDT_PARSER_VER = "3.00"
 
@@ -873,7 +874,7 @@ class DualGuidStringEventRecord(object):
         guid1_xml.set(
             "Value",
             f"{self.guid1_uint32:08X}-{self.guid1_uint16_0:04X}-{self.guid1_uint16_1:04X}-"
-            f"{self.guid1_uint8_0:02X}{self.guid1_uint8_1:02X}{self.guid1_uint8_2:02X}{self.guid1_uint8_3:02X}"
+            f"{self.guid1_uint8_0:02X}{self.guid1_uint8_1:02X}-{self.guid1_uint8_2:02X}{self.guid1_uint8_3:02X}"
             f"{self.guid1_uint8_4:02X}{self.guid1_uint8_5:02X}{self.guid1_uint8_6:02X}{self.guid1_uint8_7:02X}",
         )
 
@@ -881,7 +882,7 @@ class DualGuidStringEventRecord(object):
         guid2_xml.set(
             "Value",
             f"{self.guid2_uint32:08X}-{self.guid2_uint16_0:04X}-{self.guid2_uint16_1:04X}-"
-            f"{self.guid2_uint8_0:02X}{self.guid2_uint8_1:02X}{self.guid2_uint8_2:02X}{self.guid2_uint8_3:02X}"
+            f"{self.guid2_uint8_0:02X}{self.guid2_uint8_1:02X}-{self.guid2_uint8_2:02X}{self.guid2_uint8_3:02X}"
             f"{self.guid2_uint8_4:02X}{self.guid2_uint8_5:02X}{self.guid2_uint8_6:02X}{self.guid2_uint8_7:02X}",
         )
 
@@ -957,7 +958,7 @@ class GuidQwordEventRecord(object):
   Apic ID     : 0x{self.apic_id:08X}
   Timestamp   : 0x{self.timestamp:016X}
   GUID        : {self.guid_uint32:08X}-{self.guid_uint16_0:04X}-{self.guid_uint16_1:04X}-"""
-            f"""{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"""
+            f"""{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}-{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"""
             f"""{self.guid_uint8_4:02X}{self.guid_uint8_5:02X}{self.guid_uint8_6:02X}{self.guid_uint8_7:02X}
   Qword       : 0x{self.qword:016X}
 """
@@ -985,7 +986,7 @@ class GuidQwordEventRecord(object):
         guid_xml.set(
             "Value",
             f"{self.guid_uint32:08X}-{self.guid_uint16_0:04X}-{self.guid_uint16_1:04X}-"
-            f"{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"
+            f"{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}-{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"
             f"{self.guid_uint8_4:02X}{self.guid_uint8_5:02X}{self.guid_uint8_6:02X}{self.guid_uint8_7:02X}",
         )
 
@@ -1082,7 +1083,7 @@ class GuidQwordStringEventRecord(object):
   Apic ID     : 0x{self.apic_id:08X}
   Timestamp   : 0x{self.timestamp:016X}
   GUID        : {self.guid_uint32:08X}-{self.guid_uint16_0:04X}-{self.guid_uint16_1:04X}-"""
-            f"""{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"""
+            f"""{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}-{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"""
             f"""{self.guid_uint8_4:02X}{self.guid_uint8_5:02X}{self.guid_uint8_6:02X}{self.guid_uint8_7:02X}
   Qword       : 0x{self.qword:016X}
   String      : {string}
@@ -1111,7 +1112,7 @@ class GuidQwordStringEventRecord(object):
         guid_xml.set(
             "Value",
             f"{self.guid_uint32:08X}-{self.guid_uint16_0:04X}-{self.guid_uint16_1:04X}-"
-            f"{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"
+            f"{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}-{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"
             f"{self.guid_uint8_4:02X}{self.guid_uint8_5:02X}{self.guid_uint8_6:02X}{self.guid_uint8_7:02X}",
         )
 
@@ -1473,6 +1474,7 @@ class ParserApp:
         self.text_log = self.handle_output_file()
         self.handle_input_file()
         self.uefi_version, self.model = self.get_uefi_version_model()
+        self.fbpt_tree = None  # Initialize FBPT container element
 
         self.write_text_header()
         self.xml_tree = self.write_xml_header()
@@ -1612,9 +1614,9 @@ class ParserApp:
         if self.options.output_text_file:
             self.text_log.write(str(fbpt_header))
         if self.options.output_xml_file:
-            # Store FBPT header and records under a separate element under FPDT
-            fbpt_tree = fbpt_header.to_xml()
-            self.xml_tree.append(fbpt_tree)
+            # Store FBPT header as a container element that will hold all records
+            self.fbpt_tree = fbpt_header.to_xml()
+            # Don't append to xml_tree yet - we'll do that after adding all records
 
     def gather_fbpt_records(self, fbpt_file: BinaryIO) -> list:
         """Collects FBPT records from an input file."""
@@ -1638,11 +1640,20 @@ class ParserApp:
     def write_records(self, fbpt_records_list: list) -> int:
         """Writes FBPT records to an output file."""
         if self.options.output_xml_file:
+            # Add all records to the FBPT container element
             for record in fbpt_records_list:
-                self.xml_tree.append(record.to_xml())
+                self.fbpt_tree.append(record.to_xml())
+            
+            # Now append the complete FBPT container to the main XML tree
+            self.xml_tree.append(self.fbpt_tree)
 
-            with open(self.options.output_xml_file, "wb") as xml_file:
-                xml_file.write(ET.tostring(self.xml_tree))
+            # Format XML properly with indentation
+            rough_string = ET.tostring(self.xml_tree, encoding='unicode')
+            reparsed = minidom.parseString(rough_string)
+            formatted_xml = reparsed.toprettyxml(indent="    ")
+            
+            with open(self.options.output_xml_file, "w", encoding='utf-8') as xml_file:
+                xml_file.write(formatted_xml)
 
         if self.options.output_text_file:
             for record in fbpt_records_list:

--- a/edk2toolext/perf/fpdt_parser.py
+++ b/edk2toolext/perf/fpdt_parser.py
@@ -577,7 +577,7 @@ class GuidEventRecord(object):
         guid_xml = ET.SubElement(xml_repr, "GUID")
         guid_xml.set(
             "Value",
-            "%08X-%04X-%04X-%02X%02X-%02X%02X-%02X%02X-%02X%02X"
+            "%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X"
             % (
                 self.guid_uint32,
                 self.guid_uint16_0,
@@ -706,7 +706,7 @@ class DynamicStringEventRecord(object):
         guid_xml = ET.SubElement(xml_repr, "GUID")
         guid_xml.set(
             "Value",
-            "%08X-%04X-%04X-%02X%02X-%02X%02X-%02X%02X-%02X%02X"
+            "%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X"
             % (
                 self.guid_uint32,
                 self.guid_uint16_0,
@@ -958,7 +958,7 @@ class GuidQwordEventRecord(object):
   Apic ID     : 0x{self.apic_id:08X}
   Timestamp   : 0x{self.timestamp:016X}
   GUID        : {self.guid_uint32:08X}-{self.guid_uint16_0:04X}-{self.guid_uint16_1:04X}-"""
-            f"""{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}-{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"""
+            f"""{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"""
             f"""{self.guid_uint8_4:02X}{self.guid_uint8_5:02X}{self.guid_uint8_6:02X}{self.guid_uint8_7:02X}
   Qword       : 0x{self.qword:016X}
 """
@@ -986,7 +986,7 @@ class GuidQwordEventRecord(object):
         guid_xml.set(
             "Value",
             f"{self.guid_uint32:08X}-{self.guid_uint16_0:04X}-{self.guid_uint16_1:04X}-"
-            f"{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}-{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"
+            f"{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"
             f"{self.guid_uint8_4:02X}{self.guid_uint8_5:02X}{self.guid_uint8_6:02X}{self.guid_uint8_7:02X}",
         )
 
@@ -1083,7 +1083,7 @@ class GuidQwordStringEventRecord(object):
   Apic ID     : 0x{self.apic_id:08X}
   Timestamp   : 0x{self.timestamp:016X}
   GUID        : {self.guid_uint32:08X}-{self.guid_uint16_0:04X}-{self.guid_uint16_1:04X}-"""
-            f"""{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}-{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"""
+            f"""{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"""
             f"""{self.guid_uint8_4:02X}{self.guid_uint8_5:02X}{self.guid_uint8_6:02X}{self.guid_uint8_7:02X}
   Qword       : 0x{self.qword:016X}
   String      : {string}
@@ -1112,7 +1112,7 @@ class GuidQwordStringEventRecord(object):
         guid_xml.set(
             "Value",
             f"{self.guid_uint32:08X}-{self.guid_uint16_0:04X}-{self.guid_uint16_1:04X}-"
-            f"{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}-{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"
+            f"{self.guid_uint8_0:02X}{self.guid_uint8_1:02X}{self.guid_uint8_2:02X}{self.guid_uint8_3:02X}"
             f"{self.guid_uint8_4:02X}{self.guid_uint8_5:02X}{self.guid_uint8_6:02X}{self.guid_uint8_7:02X}",
         )
 


### PR DESCRIPTION
Format output xml and align GUID format for fpdt_parser.
Apply `minidom` to format the output xml of the `fpdt_parser.py` to improve readability.
The script was not adding entries to FBDT table so the output is not a proper tree structure.
Before it was:
```
|- fbpt_header
|- fbpt_record
|- fbpt_record
```
Now it is:
```
|- fbpt_header
|   |- fbpt_record
|   |- fbpt_record
```
it can be properly consumed by `perf_report_generator.py` to generate perf report. Before this change there will be 0 entries in the report because the input structure doesn't match what the script needs.

Update the GUID format for different entries to make sure the output GUID format stay the same and can be recognized by the perf_report_generator.py.
Add xml formatter to make sure the output xml more readable.

Examples for GUID format change:
```
Before this fix:
For DynamicStringEvent: 
            `<GUID Value="23C9322F-2AF2-476A-BC4C-26BC-8826-6C71"/>`
For DualGuidStringEvent: 
            `<GUID1 Value="6D33944A-EC75-4855-A54D-809C75241F6C"/>`
            `<GUID2 Value="7B94C75C-36A4-4AA4-A1DF-14BC9A049AE4"/>`

After this fix:
All event guids will be in the same format of 
            `<GUID1 Value="6D33944A-EC75-4855-A54D-809C75241F6C"/>`
```
With this change the `perf_report_generator.py` can successfully parse these GUIDs and map to the right module name.

- [x] Breaking change?
Detail of the changes can be seen above. The structure and content of the output xml for `fpdt_parser.py` changed.

- [x] Integration instruction:
Use `fpdt_parser.py` first and use the output xml file as the input for the `perf_report_generator.py` to get perf report.