### PR TITLE
Replace az --version call with az version

### DIFF
--- a/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
+++ b/edk2toolext/environment/extdeptypes/az_cli_universal_dependency.py
@@ -58,7 +58,7 @@ class AzureCliUniversalDependency(ExternalDependency):
         if cls.VersionLogged:
             return
         results = StringIO()
-        RunCmd("az", "--version", outstream=results, raise_exception_on_nonzero=True)
+        RunCmd("az", "version", outstream=results, raise_exception_on_nonzero=True)
         results.seek(0)
 
         to_find = ["azure-cli", "azure-devops"]  # find these keys in the version output
@@ -80,7 +80,7 @@ class AzureCliUniversalDependency(ExternalDependency):
 
         # Check requirements
 
-        # 1 - az cli tool missing will raise exception on call to az --version earlier in function
+        # 1 - az cli tool missing will raise exception on call to az version earlier in function
 
         # 2 - Check for azure-devops extension
         if "azure-devops" not in found.keys():


### PR DESCRIPTION
## Description
az --version finds the latest version information from GitHub (https://github.com/Azure/azure-cli/issues/27437). It can be slow if you have a bad network connection. You may use az version as an alternative as this command doesn't make any network request.

```
>>az --version
azure-cli                         2.75.0

core                              2.75.0
telemetry                          1.1.0

Extensions:
azure-devops                       1.0.1

Dependencies:
msal                            1.33.0b1
azure-mgmt-resource               23.3.0

>az version
{
  "azure-cli": "2.75.0",
  "azure-cli-core": "2.75.0",
  "azure-cli-telemetry": "1.1.0",
  "extensions": {
    "azure-devops": "1.0.1"
  }
}
```

## How This Was Tested
UEFI builds succeed and the az version check passes