### PR TITLE
capsule_helper: Allow INF Target OS Version to be specified

### DIFF
--- a/edk2toolext/capsule/capsule_helper.py
+++ b/edk2toolext/capsule/capsule_helper.py
@@ -68,7 +68,8 @@ class Capsule:
         name (str): the name of the capsule package
         provider_name (str): the name of the capsule provider
         arch (str): the architecture targeted by the capsule
-        os (str): the OS targeted by the capsule.
+        os (str): the OS string targeted by the capsule.
+        target_os_ver: the target OS version for the capsule, if applicable.
         manufacturer_name (str): name of the capsule manufacturer. optional, defaults to provider_name if None.
         date (datetime.date): when the capsule was built. optional, defaults to datetime.date.today().
         payloads (List[CapsulePayload]): a list of capsule payloads. optional, defaults to empty list
@@ -79,6 +80,7 @@ class Capsule:
     provider_name: str
     arch: str = None
     os: str = None
+    target_os_ver: str = None
     manufacturer_name: str = None
     date: datetime.date = datetime.date.today()
     payloads: List[CapsulePayload] = field(default_factory=list)
@@ -252,6 +254,7 @@ def create_inf_file(capsule_options: dict, save_path: str) -> str:
         capsule_options["provider_name"],
         capsule_options["mfg_name"],
         capsule_options["arch"],
+        TargetOsVersion=capsule_options.get("target_os_ver", None),
     )
 
     inf_file.AddFirmware(
@@ -299,6 +302,7 @@ def create_multinode_inf_file(capsule: Capsule, save_path: str) -> str:
         capsule.provider_name,
         capsule.manufacturer_name,
         capsule.arch,
+        TargetOsVersion=capsule.target_os_ver,
     )
 
     idx = 0

--- a/tests.unit/capsule/test_capsule_helper.py
+++ b/tests.unit/capsule/test_capsule_helper.py
@@ -272,6 +272,20 @@ class MultiNodeFileGenerationTest(unittest.TestCase):
         inf_file_path = capsule_helper.create_multinode_inf_file(self.capsule, self.temp_output_dir)
         self.assertTrue(os.path.isfile(inf_file_path))
 
+    def test_default_and_custom_target_os_version_str(self) -> None:
+        """Test that the target OS version string is set correctly."""
+        # Default case
+        self.assertIsNone(self.capsule.target_os_ver)
+
+        DUMMY_OPTIONS["capsule"]["target_os_ver"] = "10.0.22222"
+        inf_file_path = capsule_helper.create_inf_file(DUMMY_OPTIONS["capsule"], self.temp_dir)
+
+        self.assertTrue(os.path.isfile(inf_file_path))
+        with open(inf_file_path, "r") as inf_file:
+            content = inf_file.read()
+            self.assertIn("[Manufacturer]\n%MfgName% = Firmware,NTamd64.10.0.22222\n", content)
+            self.assertIn("[Firmware.NTamd64.10.0.22222]\n", content)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds a `target_os_ver` key to the `capsule_options` dictionary that is used to customize INF file creation so that the TargetOSVersion string used in the INF file can be customized.