### PR TITLE
pyproject.toml: Update minimum setuptools to 78.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "openpyxl>=3.1.2",
     "XlsxWriter>=3.0.9",
     "pywin32>=305; sys_platform=='win32'",
-    "setuptools>=68.2.2",
+    "setuptools>=78.1.1",
 ]
 
 classifiers = [
@@ -49,7 +49,7 @@ dev = [
     "pre-commit == 4.1.0",
 ]
 publish = [
-    "setuptools == 75.8.2",
+    "setuptools == 80.9.0",
     "build == 1.2.2.post1",
     "twine == 6.1.0",
 ]


### PR DESCRIPTION
Update the minimum setuptools version to 78.1.1 to ensure PYSEC-2025-49 is mitigated.

Publish is updated to use the latest version (80.9.0).

https://osv.dev/vulnerability/PYSEC-2025-49