### PR TITLE
edk2_parse: bugfix unknown arguments for platform

### DIFF
--- a/edk2toolext/invocables/edk2_parse.py
+++ b/edk2toolext/invocables/edk2_parse.py
@@ -202,7 +202,16 @@ class Edk2Parse(Edk2MultiPkgAwareInvocable):
         try:
             platform_module = locate_class_in_module(self.PlatformModule, UefiBuilder)
             build_settings = platform_module()
-            build_settings.RetrieveCommandLineOptions(self.args)
+
+            # Setup a simple parser so we can parse the build options expected by the UefiBuilder.
+            # We then merge the args we already have with the newly parsed args to ensure all
+            # options are preserved. Then pass that to the UefiBuilder to retrieve the options.
+            temp_parser = argparse.ArgumentParser()
+            build_settings.AddCommandLineOptions(temp_parser)
+            args, _ = temp_parser.parse_known_args()
+            combined_args = Namespace(**{**vars(self.args), **vars(args)})
+            build_settings.RetrieveCommandLineOptions(combined_args)
+
             build_settings.Clean = False
             build_settings.SkipPreBuild = True
             build_settings.SkipBuild = True


### PR DESCRIPTION
For edk2_parse to accurately parse the workspace, it must set up it's environment (the environment variables - e.g. the variables that can be accessed via `self.env.GetValue(...)`). One way it supports doing this is associating itself with a platform build script and calling it's pre-build setup.

This includes calling the platform build's `RetrieveCommandLineOptions` function. However there was a bug in that logic in which we do not also call the platform's `AddCommandLineOptions` function. Due to this, if the platform has a custom build argument, it won't be available when `RetrieveCommandLineOptions` is called, ending in an error `'Namespace' object has no attribute '<arg_name>'`.

This commit fixes this bug by first calling `AddCommandLineOptions` on a new parser, re-parsing the args, and passing all known and parsed args to `RetrieveCommandLineOptions`.

resolves https://github.com/microsoft/mu_tiano_platforms/pull/1243 