### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,6 +33,7 @@ body:
         - Python 3.11
         - Python 3.12
         - Python 3.13
+        - Python 3.14
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/VariableProducer.yml
+++ b/.github/workflows/VariableProducer.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   msv: "['3.10']"
-  pythonversions: "['3.13', '3.12', '3.11']" # Keep Python Versions in descending order
+  pythonversions: "['3.14', '3.13', '3.12']" # Keep Python Versions in descending order
   nodeversions: "['19']"
 
 jobs:

--- a/azure-pipelines/templates/basic-setup-steps.yml
+++ b/azure-pipelines/templates/basic-setup-steps.yml
@@ -15,7 +15,7 @@ steps:
 
 - task: UsePythonVersion@0
   inputs:
-    versionSpec: '3.12.x'
+    versionSpec: '3.14.x'
     architecture: 'x64'
 
 - script: pip install --upgrade -e .[dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = {file = "readme.md", content-type = "text/markdown"}
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 dependencies = [
-    "edk2-pytool-library>=0.23.7",
+    "edk2-pytool-library>=0.23.10",
     "pyyaml>=6.0.0",
     "pefile>=2023.2.7",
     "semantic_version>=2.10.0",
@@ -30,7 +30,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13"
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14"
 ]
 
 [project.urls]

--- a/readme.md
+++ b/readme.md
@@ -43,18 +43,18 @@ Maintained Versions
 
 | Host Type           | Toolchain   | Project    | Integration Tests
 | :------------------ | :---------  | :--------- | :----------------
-| Windows Server 2019 | Python 3.11 | Edk2       | [![ewt1]][_it]
-| Windows Server 2019 | Python 3.12 | Edk2       | [![ewt2]][_it]
-| Windows Server 2019 | Python 3.13 | Edk2       | [![ewt3]][_it]
-| Linux Ubuntu 20.04  | Python 3.11 | Edk2       | [![eut1]][_it]
-| Linux Ubuntu 20.04  | Python 3.12 | Edk2       | [![eut2]][_it]
-| Linux Ubuntu 20.04  | Python 3.13 | Edk2       | [![eut3]][_it]
-| Windows Server 2022 | Python 3.11 | Project Mu | [![mwt1]][_it]
-| Windows Server 2022 | Python 3.12 | Project Mu | [![mwt2]][_it]
-| Windows Server 2022 | Python 3.13 | Project Mu | [![mwt3]][_it]
-| Linux Ubuntu 22.04  | Python 3.11 | Project Mu | [![mut1]][_it]
-| Linux Ubuntu 22.04  | Python 3.12 | Project Mu | [![mut2]][_it]
-| Linux Ubuntu 22.04  | Python 3.13 | Project Mu | [![mut3]][_it]
+| Windows Server 2019 | Python 3.12 | Edk2       | [![ewt1]][_it]
+| Windows Server 2019 | Python 3.13 | Edk2       | [![ewt2]][_it]
+| Windows Server 2019 | Python 3.14 | Edk2       | [![ewt3]][_it]
+| Linux Ubuntu 20.04  | Python 3.12 | Edk2       | [![eut1]][_it]
+| Linux Ubuntu 20.04  | Python 3.13 | Edk2       | [![eut2]][_it]
+| Linux Ubuntu 20.04  | Python 3.14 | Edk2       | [![eut3]][_it]
+| Windows Server 2022 | Python 3.12 | Project Mu | [![mwt1]][_it]
+| Windows Server 2022 | Python 3.13 | Project Mu | [![mwt2]][_it]
+| Windows Server 2022 | Python 3.14 | Project Mu | [![mwt3]][_it]
+| Linux Ubuntu 22.04  | Python 3.12 | Project Mu | [![mut1]][_it]
+| Linux Ubuntu 22.04  | Python 3.13 | Project Mu | [![mut2]][_it]
+| Linux Ubuntu 22.04  | Python 3.14 | Project Mu | [![mut3]][_it]
 
 Minimum Supported Version
 
@@ -183,18 +183,18 @@ contributing to the edk2-pytool-extensions repository.
 [_ci]: https://github.com/tianocore/edk2-pytool-extensions/actions/workflows/run-ci.yml
 
 [_it]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_build?definitionId=52&_a=summary&repositoryFilter=2&branchFilter=14
-[ewt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python311
-[ewt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python312
-[ewt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python313
+[ewt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python312
+[ewt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python313
+[ewt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Windows_Python314
 
-[eut1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python311
-[eut2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python312
-[eut3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python313
+[eut1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python312
+[eut2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python313
+[eut3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=Edk2_Ubuntu_Python314
 
-[mwt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python311
-[mwt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python312
-[mwt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python313
+[mwt1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python312
+[mwt2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python313
+[mwt3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Windows_Python314
 
-[mut1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python311
-[mut2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python312
-[mut3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python313
+[mut1]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python312
+[mut2]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python313
+[mut3]: https://dev.azure.com/tianocore/edk2-pytool-extensions/_apis/build/status/Integration%20Tests?branchName=master&configuration=ProjectMu_Ubuntu_Python314

--- a/tests.integration/azure-pipelines/windows-robot-integration-test.yml
+++ b/tests.integration/azure-pipelines/windows-robot-integration-test.yml
@@ -10,7 +10,7 @@
 parameters:
 - name: PythonVersionList
   type: object
-  default: ['3.11', '3.12', '3.13']
+  default: ['3.12', '3.13', '3.14']
 
 jobs:
 - job:


### PR DESCRIPTION
Follow python upgrade steps specified in docs/contributor/python_realease.md. edk2-pytool-extensions appears to fully support 3.14 with no changes necessary.