### PR TITLE
Update CI Runner versions

### DIFF
--- a/tests.integration/azure-pipelines/windows-robot-integration-test.yml
+++ b/tests.integration/azure-pipelines/windows-robot-integration-test.yml
@@ -60,7 +60,7 @@ jobs:
 
   - script: |
       sudo apt-get update
-      sudo apt-get install gcc g++ make uuid-dev qemu-utils qemu-system-x86 qemu-system-aarch64 mono-complete libx11-dev -y
+      sudo apt-get install gcc g++ make uuid-dev qemu-utils qemu-system-x86 qemu-system-aarch64 mono-complete libx11-dev libxext-dev -y
     displayName: Install packages for ubuntu
     condition: and(contains(variables.Image, 'ubuntu'), succeeded())
 


### PR DESCRIPTION
1. Updates runners to latest versions (ubuntu-24.04, windows-2025)
2. Updates ubuntu package installation as necessary
3. Uses `GCC` instead of `GCC5`